### PR TITLE
feat(genesis): Add task for processing genesis state

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 			&cli.StringFlag{
 				Name:    "log-level",
 				EnvVars: []string{"GOLOG_LOG_LEVEL"},
-				Value:   "info",
+				Value:   "debug",
 			},
 		},
 		Commands: []*cli.Command{

--- a/model/actors/miner/sectordeals.go
+++ b/model/actors/miner/sectordeals.go
@@ -1,0 +1,34 @@
+package miner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-pg/pg/v10"
+)
+
+type MinerDealSector struct {
+	MinerID  string `pg:",pk,notnull"`
+	SectorID uint64 `pg:",pk,use_zero"`
+	DealID   uint64 `pg:",use_zero"`
+}
+
+func (ds *MinerDealSector) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	if _, err := tx.ModelContext(ctx, ds).
+		OnConflict("do nothing").
+		Insert(); err != nil {
+		return fmt.Errorf("persisting marker deal sector: %v", err)
+	}
+	return nil
+}
+
+type MinerDealSectors []*MinerDealSector
+
+func (dss MinerDealSectors) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	for _, ds := range dss {
+		if err := ds.PersistWithTx(ctx, tx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/model/actors/miner/state.go
+++ b/model/actors/miner/state.go
@@ -37,7 +37,7 @@ func (ms *MinerState) Persist(ctx context.Context, db *pg.DB) error {
 
 }
 
-func (ms *MinerState) PersistWitTx(ctx context.Context, tx *pg.Tx) error {
+func (ms *MinerState) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
 	if _, err := tx.ModelContext(ctx, ms).
 		OnConflict("do nothing").
 		Insert(); err != nil {

--- a/model/actors/miner/task.go
+++ b/model/actors/miner/task.go
@@ -38,7 +38,7 @@ type MinerTaskResult struct {
 
 func (mtr *MinerTaskResult) Persist(ctx context.Context, db *pg.DB) error {
 	return db.RunInTransaction(ctx, func(tx *pg.Tx) error {
-		if err := NewMinerStateModel(mtr).PersistWitTx(ctx, tx); err != nil {
+		if err := NewMinerStateModel(mtr).PersistWithTx(ctx, tx); err != nil {
 			return err
 		}
 		if err := NewMinerPowerModel(mtr).PersistWithTx(ctx, tx); err != nil {

--- a/model/genesis/task.go
+++ b/model/genesis/task.go
@@ -1,0 +1,43 @@
+package genesis
+
+import (
+	"context"
+	"github.com/filecoin-project/sentinel-visor/model/actors/miner"
+	"github.com/go-pg/pg/v10"
+)
+
+type ProcessGenesisSingletonResult struct {
+	minerResults []*GenesisMinerTaskResult
+}
+
+func (r *ProcessGenesisSingletonResult) Persist(ctx context.Context, db *pg.DB) error {
+	return db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		for _, res := range r.minerResults {
+			if err := res.StateModel.PersistWithTx(ctx, tx); err != nil {
+				return err
+			}
+			if err := res.PowerModel.PersistWithTx(ctx, tx); err != nil {
+				return err
+			}
+			if err := res.SectorModels.PersistWithTx(ctx, tx); err != nil {
+				return err
+			}
+			if err := res.DealModels.PersistWithTx(ctx, tx); err != nil {
+				return err
+			}
+
+		}
+		return nil
+	})
+}
+
+func (r *ProcessGenesisSingletonResult) AddMiner(m *GenesisMinerTaskResult) {
+	r.minerResults = append(r.minerResults, m)
+}
+
+type GenesisMinerTaskResult struct {
+	StateModel   *miner.MinerState
+	PowerModel   *miner.MinerPower
+	SectorModels miner.MinerSectorInfos
+	DealModels   miner.MinerDealSectors
+}

--- a/run.go
+++ b/run.go
@@ -32,7 +32,7 @@ var processorCmd = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.IntFlag{
 			Name:  "max-batch",
-			Value: 500,
+			Value: 50,
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/services/processor/processor.go
+++ b/services/processor/processor.go
@@ -57,6 +57,9 @@ func (p *Processor) InitHandler(ctx context.Context, batchSize int) error {
 		return err
 	}
 
+	p.publisher.Start(ctx)
+	p.scheduler.Start()
+
 	gen, err := p.node.ChainGetGenesis(ctx)
 	if err != nil {
 		return err
@@ -65,8 +68,9 @@ func (p *Processor) InitHandler(ctx context.Context, batchSize int) error {
 	p.genesis = gen
 	p.batchSize = batchSize
 
-	p.publisher.Start(ctx)
-	p.scheduler.Start()
+	if _, err := p.scheduler.queueGenesisTask(gen.Key(), gen.ParentState()); err != nil {
+		return err
+	}
 
 	p.log.Infow("initialized processor", "genesis", gen.String())
 	return nil

--- a/services/processor/tasks/genesis/genesis.go
+++ b/services/processor/tasks/genesis/genesis.go
@@ -1,0 +1,209 @@
+package genesis
+
+import (
+	"bytes"
+	"context"
+	"github.com/gocraft/work"
+	"github.com/gomodule/redigo/redis"
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/filecoin-project/go-address"
+	lapi "github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+
+	api "github.com/filecoin-project/sentinel-visor/lens/lotus"
+	"github.com/filecoin-project/sentinel-visor/model"
+	minermodel "github.com/filecoin-project/sentinel-visor/model/actors/miner"
+	genesismodel "github.com/filecoin-project/sentinel-visor/model/genesis"
+)
+
+func Setup(concurrency uint, taskName, poolName string, redisPool *redis.Pool, node api.API, pubCh chan<- model.Persistable) (*work.WorkerPool, *work.Enqueuer) {
+	pool := work.NewWorkerPool(ProcessGenesisSingletonTask{}, concurrency, poolName, redisPool)
+	queue := work.NewEnqueuer(poolName, redisPool)
+
+	// https://github.com/gocraft/work/issues/10#issuecomment-237580604
+	// adding fields via a closure gives the workers access to the lotus api, a global could also be used here
+	pool.Middleware(func(mt *ProcessGenesisSingletonTask, job *work.Job, next work.NextMiddlewareFunc) error {
+		mt.node = node
+		mt.pubCh = pubCh
+		mt.log = logging.Logger("genesistask")
+		return next()
+	})
+	logging.SetLogLevel("genesistask", "info")
+	// log all task
+	pool.Middleware((*ProcessGenesisSingletonTask).Log)
+
+	// register task method and don't allow retying
+	pool.JobWithOptions(taskName, work.JobOptions{
+		MaxFails: 1,
+	}, (*ProcessGenesisSingletonTask).Task)
+
+	return pool, queue
+}
+
+type ProcessGenesisSingletonTask struct {
+	node lapi.FullNode
+	log  *logging.ZapEventLogger
+
+	pubCh chan<- model.Persistable
+
+	genesis   types.TipSetKey
+	stateroot cid.Cid
+}
+
+func (p *ProcessGenesisSingletonTask) Log(job *work.Job, next work.NextMiddlewareFunc) error {
+	p.log.Infow("Starting Job", "name", job.Name, "Args", job.Args)
+	return next()
+}
+
+func (p *ProcessGenesisSingletonTask) ParseArgs(job *work.Job) error {
+	srStr := job.ArgString("stateroot")
+	if err := job.ArgError(); err != nil {
+		return err
+	}
+
+	tsStr := job.ArgString("ts")
+	if err := job.ArgError(); err != nil {
+		return err
+	}
+
+	sr, err := cid.Decode(srStr)
+	if err != nil {
+		return err
+	}
+
+	var tsKey types.TipSetKey
+	if err := tsKey.UnmarshalJSON([]byte(tsStr)); err != nil {
+		return err
+	}
+	p.genesis = tsKey
+	p.stateroot = sr
+	return nil
+}
+
+func (p *ProcessGenesisSingletonTask) Task(job *work.Job) error {
+	if err := p.ParseArgs(job); err != nil {
+		return err
+	}
+	ctx := context.TODO()
+
+	genesisAddrs, err := p.node.StateListActors(ctx, p.genesis)
+	if err != nil {
+		return err
+	}
+
+	result := &genesismodel.ProcessGenesisSingletonResult{}
+	for _, addr := range genesisAddrs {
+		genesisAct, err := p.node.StateGetActor(ctx, addr, p.genesis)
+		if err != nil {
+			return err
+		}
+		switch genesisAct.Code {
+		case builtin.SystemActorCodeID:
+			// TODO
+		case builtin.InitActorCodeID:
+			// TODO
+		case builtin.CronActorCodeID:
+			// TODO
+		case builtin.AccountActorCodeID:
+			// TODO
+		case builtin.StoragePowerActorCodeID:
+			// TODO
+		case builtin.StorageMarketActorCodeID:
+		case builtin.StorageMinerActorCodeID:
+			res, err := p.storageMinerState(ctx, addr, genesisAct)
+			if err != nil {
+				return err
+			}
+			result.AddMiner(res)
+		case builtin.PaymentChannelActorCodeID:
+			// TODO
+		case builtin.MultisigActorCodeID:
+			// TODO
+		case builtin.RewardActorCodeID:
+			// TODO
+		case builtin.VerifiedRegistryActorCodeID:
+			// TODO
+		default:
+			p.log.Warnf("unknown actor in genesis state. address: %s code: %s head: %s", addr, genesisAct.Code, genesisAct.Head)
+		}
+	}
+	p.pubCh <- result
+	return nil
+}
+
+func (p *ProcessGenesisSingletonTask) storageMinerState(ctx context.Context, addr address.Address, act *types.Actor) (*genesismodel.GenesisMinerTaskResult, error) {
+	store := api.NewAPIIpldStore(ctx, p.node)
+
+	// actual miner actor state and miner info
+	var mstate miner.State
+	astb, err := p.node.ChainReadObj(ctx, act.Head)
+	if err != nil {
+		return nil, err
+	}
+	if err := mstate.UnmarshalCBOR(bytes.NewReader(astb)); err != nil {
+		return nil, err
+	}
+	minfo, err := mstate.GetInfo(store)
+	if err != nil {
+		return nil, err
+	}
+
+	// miner raw and qual power
+	// TODO this needs caching so we don't re-fetch the power actors claim table for every tipset.
+	mpower, err := p.node.StateMinerPower(ctx, addr, p.genesis)
+	if err != nil {
+		return nil, err
+	}
+
+	msectors, err := p.node.StateMinerSectors(ctx, addr, nil, true, p.genesis)
+
+	powerModel := &minermodel.MinerPower{
+		MinerID:              addr.String(),
+		StateRoot:            p.stateroot.String(),
+		RawBytePower:         mpower.MinerPower.RawBytePower.String(),
+		QualityAdjustedPower: mpower.MinerPower.QualityAdjPower.String(),
+	}
+
+	stateModel := &minermodel.MinerState{
+		MinerID:    addr.String(),
+		OwnerID:    minfo.Owner.String(),
+		WorkerID:   minfo.Worker.String(),
+		PeerID:     minfo.PeerId,
+		SectorSize: minfo.SectorSize.ShortString(),
+	}
+
+	sectorsModel := make(minermodel.MinerSectorInfos, len(msectors))
+	dealsModel := minermodel.MinerDealSectors{}
+	for idx, sector := range msectors {
+		sectorsModel[idx] = &minermodel.MinerSectorInfo{
+			MinerID:               addr.String(),
+			SectorID:              uint64(sector.ID),
+			StateRoot:             p.stateroot.String(),
+			SealedCID:             sector.Info.SealedCID.String(),
+			ActivationEpoch:       int64(sector.Info.Activation),
+			ExpirationEpoch:       int64(sector.Info.Expiration),
+			DealWeight:            sector.Info.DealWeight.String(),
+			VerifiedDealWeight:    sector.Info.VerifiedDealWeight.String(),
+			InitialPledge:         sector.Info.InitialPledge.String(),
+			ExpectedDayReward:     sector.Info.ExpectedDayReward.String(),
+			ExpectedStoragePledge: sector.Info.ExpectedStoragePledge.String(),
+		}
+		for _, dealID := range sector.Info.DealIDs {
+			dealsModel = append(dealsModel, &minermodel.MinerDealSector{
+				MinerID:  addr.String(),
+				SectorID: uint64(sector.ID),
+				DealID:   uint64(dealID),
+			})
+		}
+	}
+	return &genesismodel.GenesisMinerTaskResult{
+		StateModel:   stateModel,
+		PowerModel:   powerModel,
+		SectorModels: sectorsModel,
+		DealModels:   dealsModel,
+	}, nil
+}

--- a/services/processor/tasks/interface.go
+++ b/services/processor/tasks/interface.go
@@ -1,0 +1,9 @@
+package tasks
+
+import "github.com/gocraft/work"
+
+type ProcessTask interface {
+	Log(job *work.Job, next work.NextMiddlewareFunc) error
+	ParseArgs(job *work.Job) error
+	Task(job *work.Job) error
+}

--- a/services/processor/tasks/miner/miner.go
+++ b/services/processor/tasks/miner/miner.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/filecoin-project/sentinel-visor/model"
-	"github.com/gomodule/redigo/redis"
 
 	"github.com/gocraft/work"
+	"github.com/gomodule/redigo/redis"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"golang.org/x/xerrors"
@@ -17,10 +16,11 @@ import (
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/events/state"
 	"github.com/filecoin-project/lotus/chain/types"
-	api "github.com/filecoin-project/sentinel-visor/lens/lotus"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
+	api "github.com/filecoin-project/sentinel-visor/lens/lotus"
+	"github.com/filecoin-project/sentinel-visor/model"
 	minermodel "github.com/filecoin-project/sentinel-visor/model/actors/miner"
 )
 

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -20,6 +20,7 @@ var models = []interface{}{
 	(*blocks.DrandBlockEntrie)(nil),
 	(*miner.MinerPower)(nil),
 	(*miner.MinerState)(nil),
+	(*miner.MinerDealSector)(nil),
 	(*miner.MinerSectorInfo)(nil),
 	(*miner.MinerPreCommitInfo)(nil),
 }


### PR DESCRIPTION
only handles miner state, as more models are added the genesis task
processing logic will need to be extended to include new models in the
genesis state.

special handling is required here since *most* task processing works by
comparing the state of actors across two tipsets, since there isn't a
tipset before the genesis block we need special handling.

to follow #7 