### PR TITLE
chore: add circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,6 @@ executors:
   golang:
     docker:
       - image: cimg/go:1.15.2
-    working_directory: '/go/src/github.com/filecoin-project/sentinel-visor'
-  dockerizer:
-    docker:
-      - image: cimg/go:1.15.2
-    environment:
-      IMAGE_NAME: filecoin/sentinel-visor
 
 jobs:
   test:
@@ -31,7 +25,7 @@ jobs:
       - run: make build
 
   docker-build:
-    executor: dockerizer
+    executor: golang
     steps:
       - checkout
       - setup_remote_docker:
@@ -39,7 +33,7 @@ jobs:
       - run:
           name: Build Docker image
           command: |
-            docker build -t $IMAGE_NAME .
+            docker build -t filecoin/sentinel-visor .
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,16 +13,8 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install -y pkg-config jq mesa-opencl-icd ocl-icd-opencl-dev
       - run: make deps
-      - restore_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
-      - run: go mod download
-      - save_cache:
-          name: 'go module cache'
-          key: go-mod-v1-{{ checksum "go.sum" }}
-          paths:
-            - '/go/pkg/mod'
-      - run: make testshort
       - run: make build
+      - run: make testshort
 
   docker-build:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
     executor: golang
     steps:
       - checkout
-      - run: apt-get update
-      - run: apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev
       - run: make deps
       - restore_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get update
-      - run: sudo apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev
+      - run: sudo apt-get install -y pkg-config jq mesa-opencl-icd ocl-icd-opencl-dev
       - run: make deps
       - restore_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,49 @@
+version: 2.1
+
+executors:
+  golang:
+    docker:
+      - image: cimg/go:1.15.2
+    working_directory: '/go/src/github.com/filecoin-project/sentinel-visor'
+  dockerizer:
+    docker:
+      - image: cimg/go:1.15.2
+    environment:
+      IMAGE_NAME: filecoin/sentinel-visor
+
+jobs:
+  test:
+    executor: golang
+    steps:
+      - checkout
+      - run: apt-get update
+      - run: apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev
+      - run: make deps
+      - restore_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}
+      - run: go mod download
+      - save_cache:
+          name: 'go module cache'
+          key: go-mod-v1-{{ checksum "go.sum" }}
+          paths:
+            - '/go/pkg/mod'
+      - run: make testshort
+      - run: make build
+
+  docker-build:
+    executor: dockerizer
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: "18.09.3"
+      - run:
+          name: Build Docker image
+          command: |
+            docker build -t $IMAGE_NAME .
+
+workflows:
+  version: 2
+  check:
+    jobs:
+      - test
+      - docker-build


### PR DESCRIPTION
adds jobs for running tests and for building in docker. We can make this stricter by adding go vet and friends if wanted. The next step with this is to get the tests running with the docker compose config, but I want to land the simple version first.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>