### PR TITLE
chore: fix docker hub submodule error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sentinel Visor
-[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/filecoin-project/sentinel-visor)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/filecoin-project/sentinel-visor) [![docker build status](https://img.shields.io/docker/cloud/build/filecoin/sentinel-visor?style=flat-square)](https://hub.docker.com/repository/docker/filecoin/sentinel-visor) [![CI build](https://img.shields.io/circleci/build/gh/filecoin-project/sentinel-visor?label=ci%20build&style=flat-square)](https://app.circleci.com/pipelines/github/filecoin-project/sentinel-visor)
 
 A component of [**Sentinel**](https://github.com/filecoin-project/sentinel), a collection of services which monitor the health and function of the Filecoin network. 
 

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Docker hub does a recursive clone, then checks the branch out,
+# so when a PR adds a submodule (or updates it), it fails.
+# See: https://stackoverflow.com/questions/58690455/how-to-correctly-initialize-git-submodules-in-dockerfile-for-docker-cloud
+git submodule update --init


### PR DESCRIPTION
Our autobuilds on dockerhub are failing when it tries to fetch the submodule.

The internet suggests the fix is to use dockerhub hooks to init the submodule post checkout.

see: https://stackoverflow.com/questions/58690455/how-to-correctly-initialize-git-submodules-in-dockerfile-for-docker-cloud

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>