### PR TITLE
chore: tighten up error propagation

### DIFF
--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -7,10 +7,11 @@ import (
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	cid "github.com/ipfs/go-cid"
 	"go.opentelemetry.io/otel/api/global"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
 )
 
 func NewAPIWrapper(node api.FullNode, store adt.Store) *APIWrapper {

--- a/services/indexer/indexer_test.go
+++ b/services/indexer/indexer_test.go
@@ -51,7 +51,7 @@ func TestIndex(t *testing.T) {
 		t.Skip("short testing specified but this test requires external dependencies")
 	}
 
-	db, err := storage.NewDatabase(context.Background(), "postgres://postgres:password@localhost:5432/postgres?sslmode=disable")
+	db, err := storage.NewDatabase(context.Background(), "postgres://postgres:password@localhost:5432/postgres?sslmode=disable", 10)
 	require.NoError(t, err, "connecting to database")
 
 	t.Logf("truncating database tables")

--- a/services/indexer/types.go
+++ b/services/indexer/types.go
@@ -2,12 +2,12 @@ package indexer
 
 import (
 	"context"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/go-pg/pg/v10"
-	"go.opentelemetry.io/otel/api/global"
-
 	"github.com/ipfs/go-cid"
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -78,45 +78,45 @@ func (u *UnindexedBlockData) Persist(ctx context.Context, db *pg.DB) error {
 
 		grp.Go(func() error {
 			if err := u.blks.PersistWithTx(ctx, tx); err != nil {
-				return err
+				return xerrors.Errorf("persist block headers: %w", err)
 			}
 			return nil
 		})
 
 		grp.Go(func() error {
 			if err := u.synced.PersistWithTx(ctx, tx); err != nil {
-				return err
+				return xerrors.Errorf("persist blocks synced: %w", err)
 			}
 			return nil
 		})
 
 		grp.Go(func() error {
 			if err := u.parents.PersistWithTx(ctx, tx); err != nil {
-				return err
+				return xerrors.Errorf("persist block parents: %w", err)
 			}
 			return nil
 		})
 
 		grp.Go(func() error {
 			if err := u.drandEntries.PersistWithTx(ctx, tx); err != nil {
-				return err
+				return xerrors.Errorf("persist drand entries: %w", err)
 			}
 			return nil
 		})
 
 		grp.Go(func() error {
 			if err := u.drandBlockEntries.PersistWithTx(ctx, tx); err != nil {
-				return err
+				return xerrors.Errorf("persist drand block entries: %w", err)
 			}
 			return nil
 		})
 
 		if err := grp.Wait(); err != nil {
-			log.Info("Rollback unindexed block data", "error", err)
+			log.Info("Rolling back unindexed block data", "error", err)
 			return err
 		}
 
-		log.Info("Commit unindexed block data")
+		log.Info("Committing unindexed block data")
 		return nil
 	})
 }

--- a/storage/sql_test.go
+++ b/storage/sql_test.go
@@ -382,7 +382,7 @@ func TestCreateSchema(t *testing.T) {
 		t.Skip("short testing specified")
 	}
 
-	db, err := NewDatabase(context.Background(), "postgres://postgres:password@localhost:5432/postgres?sslmode=disable")
+	db, err := NewDatabase(context.Background(), "postgres://postgres:password@localhost:5432/postgres?sslmode=disable", 10)
 	if !assert.NoError(t, err, "connecting to database") {
 		return
 	}


### PR DESCRIPTION
Move goroutine management out of processor start into the caller so we can return an
error instead of panicing. Also make NewCacheCtxStore return an error instead of
panicing.

Add informative context to errors throughout core logic of indexer, processor and storage.