### PR TITLE
feat: read blocks directly from chainstore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/filecoin-project/sentinel-visor
 go 1.14
 
 require (
+	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/filecoin-project/go-address v0.0.3
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-jsonrpc v0.1.2-0.20200822201400-474f4fdccc52
@@ -15,6 +16,8 @@ require (
 	github.com/gomodule/redigo v1.8.2
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-cid v0.0.7
+	github.com/ipfs/go-ds-badger2 v0.1.1-0.20200708190120-187fc06f714e
+	github.com/ipfs/go-ipfs-blockstore v1.0.1
 	github.com/ipfs/go-log/v2 v2.1.2-0.20200626104915-0016c0b4b3e4
 	github.com/lib/pq v1.8.0
 	github.com/multiformats/go-multiaddr v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -151,7 +151,6 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -1341,7 +1340,6 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0 h1:G9tHG9lebljV9mfp9SNPDL36nCDxmo3zTlAf1YgvzmI=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -1449,7 +1447,6 @@ github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=

--- a/lens/lotus/blockstore.go
+++ b/lens/lotus/blockstore.go
@@ -1,0 +1,64 @@
+package lotus
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+
+	"golang.org/x/xerrors"
+
+	dgbadger "github.com/dgraph-io/badger/v2"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/lib/blockstore"
+	cid "github.com/ipfs/go-cid"
+	badger "github.com/ipfs/go-ds-badger2"
+)
+
+// BlockstoreBackedAPI is a wrapper around a full node api that bypasses the api for reading block data and
+// gets it directly from the blockstore
+type BlockstoreBackedAPI struct {
+	api.FullNode
+	bs blockstore.Blockstore
+}
+
+type closer func() error
+
+func (c closer) Close() error { return c() }
+
+func NewBlockstoreBackedAPI(path string, api api.FullNode) (*BlockstoreBackedAPI, io.Closer, error) {
+
+	chainPath := filepath.Join(path, "datastore", "chain")
+	ds, err := openChainDs(chainPath)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("open chain datastore: %w", err)
+	}
+
+	bs := blockstore.NewBlockstore(ds)
+
+	return &BlockstoreBackedAPI{
+		FullNode: api,
+		bs:       bs,
+	}, closer(ds.Close), nil
+
+}
+
+func openChainDs(path string) (*badger.Datastore, error) {
+	opts := badger.DefaultOptions
+	opts.GcInterval = 0 // disable GC for chain datastore
+
+	opts.Options = dgbadger.DefaultOptions("").
+		WithTruncate(true).
+		WithValueThreshold(1 << 10).
+		WithReadOnly(true)
+
+	return badger.NewDatastore(path, &opts)
+}
+
+func (s *BlockstoreBackedAPI) ChainReadObj(ctx context.Context, obj cid.Cid) ([]byte, error) {
+	blk, err := s.bs.Get(obj)
+	if err != nil {
+		return nil, xerrors.Errorf("blockstore get: %w", err)
+	}
+
+	return blk.RawData(), nil
+}


### PR DESCRIPTION
DO NOT MERGE

This is an untested experiment to build an API facade that bypasses the lotus API to read block data directly from disk