### PR TITLE
feat: respect log level flag and allow per logger levels

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,13 @@ func main() {
 				Name:    "log-level",
 				EnvVars: []string{"GOLOG_LOG_LEVEL"},
 				Value:   "debug",
+				Usage:   "Set the default log level for all loggers to `LEVEL`",
+			},
+			&cli.StringFlag{
+				Name:    "log-level-named",
+				EnvVars: []string{"VISOR_LOG_LEVEL_NAMED"},
+				Value:   "",
+				Usage:   "A comma delimited list of named loggers and log levels formatted as name:level, for example 'logger1:debug,logger2:info'",
 			},
 			&cli.BoolFlag{
 				Name:    "tracing",

--- a/services/processor/processor.go
+++ b/services/processor/processor.go
@@ -57,10 +57,6 @@ type Processor struct {
 }
 
 func (p *Processor) InitHandler(ctx context.Context, batchSize int) error {
-	if err := logging.SetLogLevel("*", "debug"); err != nil {
-		return err
-	}
-
 	p.publisher.Start(ctx)
 	p.scheduler.Start()
 

--- a/services/processor/tasks/common/actor.go
+++ b/services/processor/tasks/common/actor.go
@@ -33,7 +33,6 @@ func Setup(concurrency uint, taskName, poolName string, redisPool *redis.Pool, n
 		mt.log = logging.Logger("commonactortask")
 		return next()
 	})
-	logging.SetLogLevel("commonactortask", "info")
 	// log all task
 	pool.Middleware((*ProcessActorTask).Log)
 

--- a/services/processor/tasks/genesis/genesis.go
+++ b/services/processor/tasks/genesis/genesis.go
@@ -39,7 +39,6 @@ func Setup(concurrency uint, taskName, poolName string, redisPool *redis.Pool, n
 		mt.log = logging.Logger("genesistask")
 		return next()
 	})
-	logging.SetLogLevel("genesistask", "info")
 	// log all task
 	pool.Middleware((*ProcessGenesisSingletonTask).Log)
 

--- a/services/processor/tasks/init/init_actor.go
+++ b/services/processor/tasks/init/init_actor.go
@@ -29,7 +29,6 @@ func Setup(concurrency uint, taskName, poolName string, redisPool *redis.Pool, n
 		mt.log = logging.Logger("markettask")
 		return next()
 	})
-	logging.SetLogLevel("markettask", "info")
 	// log all task
 	pool.Middleware((*ProcessInitActorTask).Log)
 

--- a/services/processor/tasks/market/market.go
+++ b/services/processor/tasks/market/market.go
@@ -30,7 +30,6 @@ func Setup(concurrency uint, taskName, poolName string, redisPool *redis.Pool, n
 		mt.log = logging.Logger("markettask")
 		return next()
 	})
-	logging.SetLogLevel("markettask", "info")
 	// log all task
 	pool.Middleware((*ProcessMarketTask).Log)
 

--- a/services/processor/tasks/message/message.go
+++ b/services/processor/tasks/message/message.go
@@ -28,7 +28,6 @@ func Setup(concurrency uint, taskName, poolName string, redisPool *redis.Pool, n
 		mt.log = logging.Logger("messagetask")
 		return next()
 	})
-	logging.SetLogLevel("messagetask", "info")
 	// log all task
 	pool.Middleware((*ProcessMessageTask).Log)
 

--- a/services/processor/tasks/miner/miner.go
+++ b/services/processor/tasks/miner/miner.go
@@ -36,7 +36,6 @@ func Setup(concurrency uint, taskName, poolName string, redisPool *redis.Pool, n
 		mt.log = logging.Logger("minertask")
 		return next()
 	})
-	logging.SetLogLevel("minertask", "info")
 	// log all task
 	pool.Middleware((*ProcessMinerTask).Log)
 

--- a/services/processor/tasks/power/power.go
+++ b/services/processor/tasks/power/power.go
@@ -32,7 +32,6 @@ func Setup(concurrency uint, taskName, poolName string, redisPool *redis.Pool, n
 		mt.log = logging.Logger("minertask")
 		return next()
 	})
-	logging.SetLogLevel("minertask", "info")
 	// log all task
 	pool.Middleware((*ProcessPowerTask).Log)
 

--- a/services/processor/tasks/reward/reward.go
+++ b/services/processor/tasks/reward/reward.go
@@ -30,7 +30,6 @@ func Setup(concurrency uint, taskName, poolName string, redisPool *redis.Pool, n
 		mt.log = logging.Logger("rewardtask")
 		return next()
 	})
-	logging.SetLogLevel("rewardtask", "debug")
 	// log all task
 	pool.Middleware((*ProcessRewardTask).Log)
 


### PR DESCRIPTION
Removes hard coded log levels so the log-level flag now properly controls the default log level.

Adds a log-level-named flag which takes a comma delimited list of logger:level pairs that specify the log levels for specific loggers. Can also be set via the VISOR_LOG_LEVEL_NAMED environment variable.

Fixes #32