### PR TITLE
feat: add VISOR_TEST_DB environment variable to specify test database

### DIFF
--- a/services/indexer/indexer_test.go
+++ b/services/indexer/indexer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/sentinel-visor/model/blocks"
 	"github.com/filecoin-project/sentinel-visor/storage"
+	"github.com/filecoin-project/sentinel-visor/testutil"
 )
 
 func init() {
@@ -47,11 +48,11 @@ func (nodeWrapper) Store() adt.Store {
 }
 
 func TestIndex(t *testing.T) {
-	if testing.Short() {
-		t.Skip("short testing specified but this test requires external dependencies")
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
 	}
 
-	db, err := storage.NewDatabase(context.Background(), "postgres://postgres:password@localhost:5432/postgres?sslmode=disable", 10)
+	db, err := storage.NewDatabase(context.Background(), testutil.Database(), 10)
 	require.NoError(t, err, "connecting to database")
 
 	t.Logf("truncating database tables")

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -50,10 +50,10 @@ var models = []interface{}{
 
 func NewDatabase(ctx context.Context, url string, poolSize int) (*Database, error) {
 	opt, err := pg.ParseURL(url)
-	opt.PoolSize = poolSize
 	if err != nil {
 		return nil, xerrors.Errorf("parse database URL: %w", err)
 	}
+	opt.PoolSize = poolSize
 
 	db := pg.Connect(opt)
 	db = db.WithContext(ctx)

--- a/storage/sql_test.go
+++ b/storage/sql_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/go-pg/pg/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/sentinel-visor/testutil"
 )
 
 // may want to change this to use a named schema such as lotus
@@ -378,11 +380,11 @@ var expectedTables = []struct {
 }
 
 func TestCreateSchema(t *testing.T) {
-	if testing.Short() {
-		t.Skip("short testing specified")
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
 	}
 
-	db, err := NewDatabase(context.Background(), "postgres://postgres:password@localhost:5432/postgres?sslmode=disable", 10)
+	db, err := NewDatabase(context.Background(), testutil.Database(), 10)
 	if !assert.NoError(t, err, "connecting to database") {
 		return
 	}

--- a/testutil/db.go
+++ b/testutil/db.go
@@ -1,0 +1,17 @@
+package testutil
+
+import (
+	"os"
+)
+
+var testDatabase = os.Getenv("VISOR_TEST_DB")
+
+// DatabaseAvailable reports whether a database is available for testing
+func DatabaseAvailable() bool {
+	return testDatabase != ""
+}
+
+// Database returns the connection string for connecting to the test database
+func Database() string {
+	return testDatabase
+}


### PR DESCRIPTION
Helps avoid accidental wiping of data in local database. 