### PR TITLE
feat: refactor task scheduler implementation

### DIFF
--- a/commands/index.go
+++ b/commands/index.go
@@ -7,6 +7,7 @@ import (
 	indexer2 "github.com/filecoin-project/sentinel-visor/services/indexer"
 )
 
+// TODO: rework to use new scheduler with just indexing tasks
 var Index = &cli.Command{
 	Name:  "index",
 	Usage: "Index the lotus blockchain",

--- a/commands/process.go
+++ b/commands/process.go
@@ -7,6 +7,7 @@ import (
 	processor2 "github.com/filecoin-project/sentinel-visor/services/processor"
 )
 
+// TODO: rework to use new scheduler with just actor state and message tasks
 var Process = &cli.Command{
 	Name:  "process",
 	Usage: "Process indexed blocks of the lotus blockchain",

--- a/commands/run.go
+++ b/commands/run.go
@@ -86,7 +86,7 @@ var Run = &cli.Command{
 		// TODO: get these from CLI flags
 		defaultStateProcessors := 15
 
-		// By default we proces all supported actor types but we could limit here
+		// By default we process all supported actor types but we could limit here
 		defaultActorCodesToProcess := actorstate.SupportedActorCodes()
 		defaultActorCodesMaxHeight := int64(math.MaxInt64)
 

--- a/commands/run.go
+++ b/commands/run.go
@@ -40,6 +40,12 @@ var Run = &cli.Command{
 			Value:   true,
 			EnvVars: []string{"VISOR_INDEXHEAD"},
 		},
+		&cli.IntFlag{
+			Name:    "indexhead-confidence",
+			Usage:   "Sets the size of the cache used to hold tipsets for possible reversion before being committed to the database",
+			Value:   25,
+			EnvVars: []string{"VISOR_INDEXHEAD_CONFIDENCE"},
+		},
 		&cli.BoolFlag{
 			Name:    "indexhistory",
 			Value:   true,
@@ -161,7 +167,7 @@ var Run = &cli.Command{
 		if cctx.Bool("indexhead") {
 			scheduler.Add(schedule.TaskConfig{
 				Name:                "ChainHeadIndexer",
-				Task:                indexer.NewChainHeadIndexer(rctx.db, rctx.api),
+				Task:                indexer.NewChainHeadIndexer(rctx.db, rctx.api, cctx.Int("indexhead-confidence")),
 				Locker:              NewGlobalSingleton(ChainHeadIndexerLockID, rctx.db), // only want one forward indexer anywhere to be running
 				RestartOnFailure:    true,
 				RestartOnCompletion: true, // we always want the indexer to be running

--- a/commands/run.go
+++ b/commands/run.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -212,7 +214,11 @@ var Run = &cli.Command{
 		}
 
 		// Start the scheduler and wait for it to complete or to be cancelled.
-		return scheduler.Run(ctx)
+		err = scheduler.Run(ctx)
+		if !errors.Is(err, context.Canceled) {
+			return err
+		}
+		return nil
 	},
 }
 

--- a/commands/run.go
+++ b/commands/run.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/schedule"
+	"github.com/filecoin-project/sentinel-visor/tasks/actorstate"
+	"github.com/filecoin-project/sentinel-visor/tasks/indexer"
+	"github.com/filecoin-project/sentinel-visor/tasks/message"
+)
+
+var Run = &cli.Command{
+	Name:  "run",
+	Usage: "Index and process blocks from the filecoin blockchain",
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:  "max-batch",
+			Value: 10,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if err := setupLogging(cctx); err != nil {
+			return xerrors.Errorf("setup logging: %w", err)
+		}
+
+		tcloser, err := setupTracing(cctx)
+		if err != nil {
+			return xerrors.Errorf("setup tracing: %w", err)
+		}
+		defer tcloser()
+
+		ctx, rctx, err := setupStorageAndAPI(cctx)
+		if err != nil {
+			return xerrors.Errorf("setup storage and api: %w", err)
+		}
+		defer func() {
+			rctx.closer()
+			if err := rctx.db.Close(ctx); err != nil {
+				log.Errorw("close database", "error", err)
+			}
+		}()
+
+		scheduler := schedule.NewScheduler()
+
+		// Add one indexing task to follow the chain head
+		// TODO: enable/disable this with CLI flag
+		scheduler.Add(schedule.TaskConfig{
+			Name:                "ChainHeadIndexer",
+			Task:                indexer.NewChainHeadIndexer(rctx.db, rctx.api),
+			Locker:              NewGlobalSingleton(ChainHeadIndexerLockID, rctx.db), // only want one forward indexer anywhere to be running
+			RestartOnFailure:    true,
+			RestartOnCompletion: true, // we always want the indexer to be running
+		})
+
+		// Add one indexing task to walk the chain history
+		// TODO: enable/disable this with CLI flag
+		scheduler.Add(schedule.TaskConfig{
+			Name:                "ChainHistoryIndexer",
+			Task:                indexer.NewChainHistoryIndexer(rctx.db, rctx.api),
+			Locker:              NewGlobalSingleton(ChainHistoryIndexerLockID, rctx.db), // only want one history indexer anywhere to be running
+			RestartOnFailure:    true,
+			RestartOnCompletion: false, // run once only
+		})
+
+		// TODO: get these from CLI flags
+		defaultLeaseTime := time.Minute * 15
+		defaultBatchSize := 10
+		defaultStateChangeProcessors := 5
+		defaultStateChangeMaxHeight := int64(math.MaxInt64)
+
+		// Add several state change tasks to read which actors changed state in each indexed tipset
+		for i := 0; i < defaultStateChangeProcessors; i++ {
+			scheduler.Add(schedule.TaskConfig{
+				Name:                fmt.Sprintf("ActorStateChangeProcessor%03d", i),
+				Task:                actorstate.NewActorStateChangeProcessor(rctx.db, rctx.api, defaultLeaseTime, defaultBatchSize, defaultStateChangeMaxHeight),
+				RestartOnFailure:    true,
+				RestartOnCompletion: true,
+			})
+		}
+
+		// TODO: get these from CLI flags
+		defaultStateProcessors := 15
+
+		// By default we proces all supported actor types but we could limit here
+		defaultActorCodesToProcess := actorstate.SupportedActorCodes()
+		defaultActorCodesMaxHeight := int64(math.MaxInt64)
+
+		// Add several state tasks to read actor state from each indexed block
+		for i := 0; i < defaultStateProcessors; i++ {
+			p, err := actorstate.NewActorStateProcessor(rctx.db, rctx.api, defaultLeaseTime, defaultBatchSize, defaultActorCodesMaxHeight, defaultActorCodesToProcess)
+			if err != nil {
+				return err
+			}
+			scheduler.Add(schedule.TaskConfig{
+				Name:                fmt.Sprintf("ActorStateProcessor%03d", i),
+				Task:                p,
+				RestartOnFailure:    true,
+				RestartOnCompletion: true,
+			})
+		}
+
+		// TODO: get these from CLI flags
+		defaultMessageProcessors := 5
+		defaultMessageMaxHeight := int64(math.MaxInt64)
+
+		// Add several message tasks to read messages from indexed tipsets
+		for i := 0; i < defaultMessageProcessors; i++ {
+			scheduler.Add(schedule.TaskConfig{
+				Name:                fmt.Sprintf("MessageProcessor%03d", i),
+				Task:                message.NewMessageProcessor(rctx.db, rctx.api, defaultLeaseTime, defaultBatchSize, defaultMessageMaxHeight),
+				RestartOnFailure:    true,
+				RestartOnCompletion: true,
+			})
+		}
+
+		// Start the scheduler and wait for it to complete or to be cancelled.
+		return scheduler.Run(ctx)
+	},
+}

--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ func main() {
 			commands.Process,
 			commands.Index,
 			commands.Migrate,
+			commands.Run,
 		},
 	}
 

--- a/model/actors/market/dealproposal.go
+++ b/model/actors/market/dealproposal.go
@@ -2,7 +2,6 @@ package market
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-pg/pg/v10"
 	"go.opentelemetry.io/otel/api/global"
@@ -27,7 +26,7 @@ type MarketDealProposal struct {
 	StoragePricePerEpoch string `pg:",notnull"`
 	PieceCID             string `pg:",notnull"`
 
-	IsVerified bool
+	IsVerified bool `pg:",notnull"`
 	Label      string
 }
 
@@ -35,7 +34,7 @@ func (dp *MarketDealProposal) PersistWithTx(ctx context.Context, tx *pg.Tx) erro
 	if _, err := tx.ModelContext(ctx, dp).
 		OnConflict("do nothing").
 		Insert(); err != nil {
-		return fmt.Errorf("persisting market deal proposal %v: %v", dp, err)
+		return err
 	}
 	return nil
 }

--- a/model/actors/market/dealproposal.go
+++ b/model/actors/market/dealproposal.go
@@ -26,7 +26,7 @@ type MarketDealProposal struct {
 	StoragePricePerEpoch string `pg:",notnull"`
 	PieceCID             string `pg:",notnull"`
 
-	IsVerified bool `pg:",notnull"`
+	IsVerified bool `pg:",notnull,use_zero"`
 	Label      string
 }
 

--- a/model/actors/market/dealstate.go
+++ b/model/actors/market/dealstate.go
@@ -2,7 +2,6 @@ package market
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-pg/pg/v10"
 	"go.opentelemetry.io/otel/api/global"
@@ -23,7 +22,7 @@ func (ds *MarketDealState) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
 	if _, err := tx.ModelContext(ctx, ds).
 		OnConflict("do nothing").
 		Insert(); err != nil {
-		return fmt.Errorf("persisting marker deal state: %v", err)
+		return err
 	}
 	return nil
 }

--- a/model/actors/market/task.go
+++ b/model/actors/market/task.go
@@ -2,6 +2,7 @@ package market
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-pg/pg/v10"
 	"go.opentelemetry.io/otel/api/global"
@@ -17,10 +18,10 @@ func (mtr *MarketTaskResult) Persist(ctx context.Context, db *pg.DB) error {
 	defer span.End()
 	return db.RunInTransaction(ctx, func(tx *pg.Tx) error {
 		if err := mtr.Proposals.PersistWithTx(ctx, tx); err != nil {
-			return err
+			return fmt.Errorf("persisting market deal proposal: %w", err)
 		}
 		if err := mtr.States.PersistWithTx(ctx, tx); err != nil {
-			return err
+			return fmt.Errorf("persisting market deal state: %w", err)
 		}
 		return nil
 	})

--- a/model/actors/miner/state.go
+++ b/model/actors/miner/state.go
@@ -9,13 +9,18 @@ import (
 )
 
 func NewMinerStateModel(res *MinerTaskResult) *MinerState {
-	return &MinerState{
+	ms := &MinerState{
 		MinerID:    res.Addr.String(),
 		OwnerID:    res.Info.Owner.String(),
 		WorkerID:   res.Info.Worker.String(),
-		PeerID:     res.Info.PeerId.String(),
 		SectorSize: res.Info.SectorSize.ShortString(),
 	}
+
+	if res.Info.PeerId != nil {
+		ms.PeerID = res.Info.PeerId.String()
+	}
+
+	return ms
 }
 
 type MinerState struct {

--- a/model/genesis/task.go
+++ b/model/genesis/task.go
@@ -39,7 +39,7 @@ func (r *ProcessGenesisSingletonResult) Persist(ctx context.Context, db *pg.DB) 
 			if err := r.marketResult.DealModels.PersistWithTx(ctx, tx); err != nil {
 				return err
 			}
-			if err := r.marketResult.ProposalModesl.PersistWithTx(ctx, tx); err != nil {
+			if err := r.marketResult.ProposalModels.PersistWithTx(ctx, tx); err != nil {
 				return err
 			}
 		}
@@ -79,7 +79,7 @@ type GenesisMinerTaskResult struct {
 
 type GenesisMarketTaskResult struct {
 	DealModels     market.MarketDealStates
-	ProposalModesl market.MarketDealProposals
+	ProposalModels market.MarketDealProposals
 }
 
 type GenesisInitActorTaskResult struct {

--- a/model/visor/processing.go
+++ b/model/visor/processing.go
@@ -1,0 +1,201 @@
+package visor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/ipfs/go-cid"
+	"golang.org/x/xerrors"
+
+	"github.com/go-pg/pg/v10"
+	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/label"
+)
+
+func NewProcessingStateChange(ts *types.TipSet) *ProcessingStateChange {
+	return &ProcessingStateChange{
+		TipSet:  ts.Key().String(),
+		Height:  int64(ts.Height()),
+		AddedAt: time.Now(),
+	}
+}
+
+type ProcessingStateChange struct {
+	tableName struct{} `pg:"visor_processing_statechanges"`
+
+	TipSet string `pg:",pk,notnull"`
+
+	Height int64 `pg:",use_zero"`
+
+	// AddedAt is the time the block was discovered and written to the table
+	AddedAt time.Time `pg:",notnull"`
+
+	// ClaimedUntil marks the block as claimed for processing until the set time
+	ClaimedUntil time.Time
+
+	// CompletedAt is the time the block was read from the chain and analysed for actor state changes
+	CompletedAt time.Time
+
+	// ErrorsDetected contains any error encountered when analysing the block for actor state changes
+	ErrorsDetected string
+}
+
+func (p *ProcessingStateChange) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	if _, err := tx.ModelContext(ctx, p).
+		OnConflict("do nothing").
+		Insert(); err != nil {
+		return fmt.Errorf("persisting processing block: %w", err)
+	}
+	return nil
+}
+
+func (p *ProcessingStateChange) TipSetKey() (types.TipSetKey, error) {
+	return TipSetKeyFromString(p.TipSet)
+}
+
+type ProcessingStateChangeList []*ProcessingStateChange
+
+func (pl ProcessingStateChangeList) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	ctx, span := global.Tracer("").Start(ctx, "ProcessingBlockList.PersistWithTx", trace.WithAttributes(label.Int("count", len(pl))))
+	defer span.End()
+	for _, p := range pl {
+		if err := p.PersistWithTx(ctx, tx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type ProcessingActor struct {
+	tableName struct{} `pg:"visor_processing_actors"`
+
+	Head            string `pg:",pk,notnull"`
+	Code            string `pg:",pk,notnull"`
+	Nonce           string
+	Balance         string
+	Address         string
+	ParentStateRoot string // cid
+	TipSet          string
+	ParentTipSet    string
+
+	Height int64 `pg:",use_zero"`
+
+	// AddedAt is the time the actor was discovered and written to the table
+	AddedAt time.Time `pg:",notnull"`
+
+	// ClaimedUntil marks the actor as claimed for processing until the set time
+	ClaimedUntil time.Time
+
+	// CompletedAt is the time the actor was read from the chain and its state read
+	CompletedAt time.Time
+
+	// ErrorsDetected contains any error encountered when reading the actor's state
+	ErrorsDetected string
+}
+
+func (p *ProcessingActor) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	if _, err := tx.ModelContext(ctx, p).
+		OnConflict("do nothing").
+		Insert(); err != nil {
+		return fmt.Errorf("persisting processing actor: %w", err)
+	}
+	return nil
+}
+
+func (p *ProcessingActor) TipSetKey() (types.TipSetKey, error) {
+	return TipSetKeyFromString(p.TipSet)
+}
+
+func (p *ProcessingActor) ParentTipSetKey() (types.TipSetKey, error) {
+	return TipSetKeyFromString(p.ParentTipSet)
+}
+
+type ProcessingActorList []*ProcessingActor
+
+func (pl ProcessingActorList) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	ctx, span := global.Tracer("").Start(ctx, "ProcessingActorList.PersistWithTx", trace.WithAttributes(label.Int("count", len(pl))))
+	defer span.End()
+	for _, p := range pl {
+		if err := p.PersistWithTx(ctx, tx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func NewProcessingMessage(ts *types.TipSet) *ProcessingMessage {
+	return &ProcessingMessage{
+		TipSet:  ts.Key().String(),
+		Height:  int64(ts.Height()),
+		AddedAt: time.Now(),
+	}
+}
+
+type ProcessingMessage struct {
+	tableName struct{} `pg:"visor_processing_messages"`
+
+	TipSet string `pg:",pk,notnull"`
+	Height int64  `pg:",use_zero"`
+
+	// AddedAt is the time the block was discovered and written to the table
+	AddedAt time.Time `pg:",notnull"`
+
+	// ClaimedUntil marks the block as claimed for message processing until the set time
+	ClaimedUntil time.Time
+
+	// CompletedAt is the time the block was read from the chain and its messages read
+	CompletedAt time.Time
+
+	// ErrorsDetected contains any error encountered when reading the block's messages
+	ErrorsDetected string
+}
+
+func (p *ProcessingMessage) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	if _, err := tx.ModelContext(ctx, p).
+		OnConflict("do nothing").
+		Insert(); err != nil {
+		return fmt.Errorf("persisting processing actor: %w", err)
+	}
+	return nil
+}
+
+func (p *ProcessingMessage) TipSetKey() (types.TipSetKey, error) {
+	return TipSetKeyFromString(p.TipSet)
+}
+
+type ProcessingMessageList []*ProcessingMessage
+
+func (pl ProcessingMessageList) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	ctx, span := global.Tracer("").Start(ctx, "ProcessingMessageList.PersistWithTx", trace.WithAttributes(label.Int("count", len(pl))))
+	defer span.End()
+	for _, p := range pl {
+		if err := p.PersistWithTx(ctx, tx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TipSetKeyFromString(s string) (types.TipSetKey, error) {
+	if len(s) < 2 {
+		return types.EmptyTSK, xerrors.Errorf("invalid tipset")
+	}
+
+	s = s[1 : len(s)-1]
+
+	cids := []cid.Cid{}
+	cidStrs := strings.Split(s, ",")
+	for _, cidStr := range cidStrs {
+		c, err := cid.Decode(cidStr)
+		if err != nil {
+			return types.EmptyTSK, xerrors.Errorf("invalid cid: %w", err)
+		}
+		cids = append(cids, c)
+	}
+
+	return types.NewTipSetKey(cids...), nil
+}

--- a/schedule/scheduler.go
+++ b/schedule/scheduler.go
@@ -1,0 +1,152 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/filecoin-project/sentinel-visor/storage"
+	"github.com/filecoin-project/sentinel-visor/wait"
+)
+
+var log = logging.Logger("schedule")
+
+type Task interface {
+	// Run starts running the task and blocks until the context is done or
+	// an error occurs.
+	Run(context.Context) error
+}
+
+type TaskConfig struct {
+	// Name is a human readable name for the task for use in logging
+	Name string
+
+	// Task is the task that will be executed.
+	Task Task
+
+	// Locker is an optional lock that must be taken before the task can execute.
+	Locker Locker
+
+	// RestartOnFailure controls whether the task should be restarted if it fails with an error.
+	RestartOnFailure bool
+
+	// RestartOnCompletion controls whether the task should be restarted if it fails without an error.
+	RestartOnCompletion bool
+}
+
+// Locker represents a general lock that a task may need to take before operating.
+type Locker interface {
+	Lock(context.Context) error
+	Unlock(context.Context) error
+}
+
+func NewScheduler() *Scheduler {
+	return &Scheduler{}
+}
+
+type Scheduler struct {
+	tasks []TaskConfig
+}
+
+// Add add a task config to the scheduler. This must not be called after Run.
+func (s *Scheduler) Add(tc TaskConfig) error {
+	s.tasks = append(s.tasks, tc)
+	return nil
+}
+
+// Run starts running the scheduler and blocks until the context is done or
+// all tasks have run to completion.
+func (s *Scheduler) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	taskComplete := make(chan struct{}, len(s.tasks))
+	tasksRunning := len(s.tasks)
+
+	for _, tc := range s.tasks {
+		go func(tc TaskConfig) {
+			// Report task is complete when this goroutine exits
+			defer func() {
+				taskComplete <- struct{}{}
+			}()
+
+			// Attempt to get the task lock if specified
+			if tc.Locker != nil {
+				if err := tc.Locker.Lock(ctx); err != nil {
+					if errors.Is(err, storage.ErrLockNotAcquired) {
+						log.Infow("task not started: lock not acquired", "task", tc.Name)
+						return
+					}
+					log.Errorw("task not started: lock not acquired", "task", tc.Name, "error", err.Error())
+					return
+				}
+				defer func() {
+					if err := tc.Locker.Unlock(ctx); err != nil {
+						if !errors.Is(err, context.Canceled) {
+							log.Errorw("failed to unlock task", "task", tc.Name, "error", err.Error())
+						}
+					}
+				}()
+			}
+
+			// Keep this task running forever
+			for {
+
+				// Is the context done?
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
+				log.Infow("running task", "task", tc.Name)
+				err := tc.Task.Run(ctx)
+				if err != nil {
+					if errors.Is(err, context.Canceled) {
+						break
+					}
+					if !tc.RestartOnFailure {
+						// Exit the task
+						log.Errorw("task exited with failure, not restarting", "task", tc.Name, "error", err.Error())
+						break
+					}
+					log.Errorw("task exited with failure, restarting", "task", tc.Name, "error", err.Error())
+				} else {
+					if !tc.RestartOnCompletion {
+						// Exit the task
+						log.Infow("task exited cleanly, not restarting", "task", tc.Name)
+						break
+					}
+					log.Infow("task exited cleanly, restarting", "task", tc.Name)
+				}
+			}
+
+		}(tc)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		// A little jitter between tasks to reduce thundering herd effects on api
+		wait.SleepWithJitter(500*time.Millisecond, 2)
+	}
+
+	// Wait until the context is done or all tasks have been completed
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-taskComplete:
+			// A task has completed
+			tasksRunning--
+			if tasksRunning == 0 {
+				// All tasks have completed successfully.
+				return nil
+			}
+		}
+	}
+
+}

--- a/storage/locks.go
+++ b/storage/locks.go
@@ -2,10 +2,14 @@ package storage
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-pg/pg/v10"
 	"golang.org/x/xerrors"
 )
+
+var ErrLockNotAcquired = errors.New("lock not acquired")
+var ErrLockNotReleased = errors.New("lock not released")
 
 // An AdvisoryLock is a lock that is managed by Postgres but is only enforced by the application. Advisory
 // locks are automatically released at the end of a session. It is safe to hold both a shared and exclusive
@@ -20,7 +24,7 @@ func (l AdvisoryLock) LockExclusive(ctx context.Context, db *pg.DB) error {
 		return xerrors.Errorf("acquiring exclusive lock: %w", err)
 	}
 	if !acquired {
-		return xerrors.Errorf("failed to acquire exclusive lock")
+		return ErrLockNotAcquired
 	}
 	return nil
 }
@@ -33,7 +37,7 @@ func (l AdvisoryLock) UnlockExclusive(ctx context.Context, db *pg.DB) error {
 		return xerrors.Errorf("unlocking exclusive lock: %w", err)
 	}
 	if !released {
-		return xerrors.Errorf("exclusive lock not released (maybe it was not held)")
+		return ErrLockNotReleased
 	}
 	return nil
 }
@@ -46,7 +50,7 @@ func (l AdvisoryLock) LockShared(ctx context.Context, db *pg.DB) error {
 		return xerrors.Errorf("acquiring exclusive lock: %w", err)
 	}
 	if !acquired {
-		return xerrors.Errorf("failed to acquire exclusive lock")
+		return ErrLockNotAcquired
 	}
 	return nil
 }
@@ -59,7 +63,7 @@ func (l AdvisoryLock) UnlockShared(ctx context.Context, db *pg.DB) error {
 		return xerrors.Errorf("unlocking shared lock: %w", err)
 	}
 	if !released {
-		return xerrors.Errorf("shared lock not released (maybe it was not held)")
+		return ErrLockNotReleased
 	}
 	return nil
 }

--- a/storage/migrations/1_chainwatch.go
+++ b/storage/migrations/1_chainwatch.go
@@ -15,14 +15,6 @@ func init() {
 
 CREATE EXTENSION IF NOT EXISTS timescaledb WITH SCHEMA public;
 
-
---
--- Name: EXTENSION timescaledb; Type: COMMENT; Schema: -; Owner:
---
-
-COMMENT ON EXTENSION timescaledb IS 'Enables scalable inserts and complex queries for time-series data';
-
-
 --
 -- Name: miner_sector_event_type; Type: TYPE; Schema: public; Owner: postgres
 --

--- a/storage/migrations/1_chainwatch.go
+++ b/storage/migrations/1_chainwatch.go
@@ -33,9 +33,6 @@ CREATE TYPE public.miner_sector_event_type AS ENUM (
 );
 
 
-ALTER TYPE public.miner_sector_event_type OWNER TO postgres;
-
-
 SET default_tablespace = '';
 
 --
@@ -48,8 +45,6 @@ CREATE TABLE public.actor_states (
     state json NOT NULL
 );
 
-
-ALTER TABLE public.actor_states OWNER TO postgres;
 
 --
 -- Name: actors; Type: TABLE; Schema: public; Owner: postgres
@@ -65,8 +60,6 @@ CREATE TABLE public.actors (
 );
 
 
-ALTER TABLE public.actors OWNER TO postgres;
-
 --
 -- Name: block_cids; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -75,8 +68,6 @@ CREATE TABLE public.block_cids (
     cid text NOT NULL
 );
 
-
-ALTER TABLE public.block_cids OWNER TO postgres;
 
 --
 -- Name: block_drand_entries; Type: TABLE; Schema: public; Owner: postgres
@@ -88,8 +79,6 @@ CREATE TABLE public.block_drand_entries (
 );
 
 
-ALTER TABLE public.block_drand_entries OWNER TO postgres;
-
 --
 -- Name: block_messages; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -100,8 +89,6 @@ CREATE TABLE public.block_messages (
 );
 
 
-ALTER TABLE public.block_messages OWNER TO postgres;
-
 --
 -- Name: block_parents; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -111,8 +98,6 @@ CREATE TABLE public.block_parents (
     parent text NOT NULL
 );
 
-
-ALTER TABLE public.block_parents OWNER TO postgres;
 
 --
 -- Name: blocks; Type: TABLE; Schema: public; Owner: postgres
@@ -133,8 +118,6 @@ CREATE TABLE public.blocks (
 );
 
 
-ALTER TABLE public.blocks OWNER TO postgres;
-
 --
 -- Name: blocks_synced; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -145,8 +128,6 @@ CREATE TABLE public.blocks_synced (
     processed_at integer
 );
 
-
-ALTER TABLE public.blocks_synced OWNER TO postgres;
 
 --
 -- Name: chain_economics; Type: TABLE; Schema: public; Owner: postgres
@@ -161,8 +142,6 @@ CREATE TABLE public.chain_economics (
     locked_fil text NOT NULL
 );
 
-
-ALTER TABLE public.chain_economics OWNER TO postgres;
 
 --
 -- Name: chain_power; Type: TABLE; Schema: public; Owner: postgres
@@ -185,8 +164,6 @@ CREATE TABLE public.chain_power (
 );
 
 
-ALTER TABLE public.chain_power OWNER TO postgres;
-
 --
 -- Name: chain_reward; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -205,8 +182,6 @@ CREATE TABLE public.chain_reward (
 );
 
 
-ALTER TABLE public.chain_reward OWNER TO postgres;
-
 --
 -- Name: drand_entries; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -217,8 +192,6 @@ CREATE TABLE public.drand_entries (
 );
 
 
-ALTER TABLE public.drand_entries OWNER TO postgres;
-
 --
 -- Name: id_address_map; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -228,8 +201,6 @@ CREATE TABLE public.id_address_map (
     address text NOT NULL
 );
 
-
-ALTER TABLE public.id_address_map OWNER TO postgres;
 
 --
 -- Name: market_deal_proposals; Type: TABLE; Schema: public; Owner: postgres
@@ -253,8 +224,6 @@ CREATE TABLE public.market_deal_proposals (
 );
 
 
-ALTER TABLE public.market_deal_proposals OWNER TO postgres;
-
 --
 -- Name: market_deal_states; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -267,8 +236,6 @@ CREATE TABLE public.market_deal_states (
     state_root text NOT NULL
 );
 
-
-ALTER TABLE public.market_deal_states OWNER TO postgres;
 
 --
 -- Name: messages; Type: TABLE; Schema: public; Owner: postgres
@@ -289,8 +256,6 @@ CREATE TABLE public.messages (
 );
 
 
-ALTER TABLE public.messages OWNER TO postgres;
-
 --
 -- Name: miner_info; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -304,8 +269,6 @@ CREATE TABLE public.miner_info (
 );
 
 
-ALTER TABLE public.miner_info OWNER TO postgres;
-
 --
 -- Name: miner_power; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -317,8 +280,6 @@ CREATE TABLE public.miner_power (
     quality_adjusted_power text NOT NULL
 );
 
-
-ALTER TABLE public.miner_power OWNER TO postgres;
 
 --
 -- Name: miner_sector_events; Type: TABLE; Schema: public; Owner: postgres
@@ -332,8 +293,6 @@ CREATE TABLE public.miner_sector_events (
 );
 
 
-ALTER TABLE public.miner_sector_events OWNER TO postgres;
-
 --
 -- Name: minerid_dealid_sectorid; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -345,8 +304,6 @@ CREATE TABLE public.minerid_dealid_sectorid (
 );
 
 
-ALTER TABLE public.minerid_dealid_sectorid OWNER TO postgres;
-
 --
 -- Name: mpool_messages; Type: TABLE; Schema: public; Owner: postgres
 --
@@ -356,8 +313,6 @@ CREATE TABLE public.mpool_messages (
     add_ts integer NOT NULL
 );
 
-
-ALTER TABLE public.mpool_messages OWNER TO postgres;
 
 --
 -- Name: receipts; Type: TABLE; Schema: public; Owner: postgres
@@ -372,8 +327,6 @@ CREATE TABLE public.receipts (
     return bytea
 );
 
-
-ALTER TABLE public.receipts OWNER TO postgres;
 
 --
 -- Name: sector_info; Type: TABLE; Schema: public; Owner: postgres
@@ -393,8 +346,6 @@ CREATE TABLE public.sector_info (
     expected_storage_pledge text NOT NULL
 );
 
-
-ALTER TABLE public.sector_info OWNER TO postgres;
 
 --
 -- Name: sector_precommit_info; Type: TABLE; Schema: public; Owner: postgres
@@ -418,8 +369,6 @@ CREATE TABLE public.sector_precommit_info (
 );
 
 
-ALTER TABLE public.sector_precommit_info OWNER TO postgres;
-
 --
 -- Name: state_heights; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
 --
@@ -430,8 +379,6 @@ CREATE MATERIALIZED VIEW public.state_heights AS
    FROM public.blocks
   WITH NO DATA;
 
-
-ALTER TABLE public.state_heights OWNER TO postgres;
 
 --
 -- Name: top_miners_by_base_reward; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
@@ -453,8 +400,6 @@ CREATE MATERIALIZED VIEW public.top_miners_by_base_reward AS
   WITH NO DATA;
 
 
-ALTER TABLE public.top_miners_by_base_reward OWNER TO postgres;
-
 --
 -- Name: top_miners_by_base_reward_max_height; Type: MATERIALIZED VIEW; Schema: public; Owner: postgres
 --
@@ -470,8 +415,6 @@ CREATE MATERIALIZED VIEW public.top_miners_by_base_reward_max_height AS
  LIMIT 1
   WITH NO DATA;
 
-
-ALTER TABLE public.top_miners_by_base_reward_max_height OWNER TO postgres;
 
 --
 -- Name: block_cids block_cids_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
@@ -896,8 +839,6 @@ CREATE FUNCTION public.actor_tips(epoch bigint) RETURNS TABLE(id text, code text
 		order by id, height desc;
 $_$;
 
-
-ALTER FUNCTION public.actor_tips(epoch bigint) OWNER TO postgres;
 
 
 --

--- a/storage/migrations/5_scheduler.go
+++ b/storage/migrations/5_scheduler.go
@@ -1,0 +1,57 @@
+package migrations
+
+import (
+	"github.com/go-pg/migrations/v8"
+)
+
+// Schema version 5 is the new scheduler schema
+
+func init() {
+
+	up := batch(`
+CREATE TABLE IF NOT EXISTS "visor_processing_statechanges" (
+	"tip_set" text NOT NULL,
+	"height" bigint,
+	"added_at" timestamptz NOT NULL,
+	"claimed_until" timestamptz,
+	"completed_at" timestamptz,
+	"errors_detected" text,
+	PRIMARY KEY ("tip_set")
+);
+
+CREATE TABLE IF NOT EXISTS "visor_processing_actors" (
+	"head" text NOT NULL,
+	"code" text NOT NULL,
+	"nonce" text, "balance"
+	text, "address" text,
+	"parent_state_root" text,
+	"tip_set" text,
+	"parent_tip_set" text,
+	"height" bigint,
+	"added_at" timestamptz NOT NULL,
+	"claimed_until" timestamptz,
+	"completed_at" timestamptz,
+	"errors_detected" text,
+	PRIMARY KEY ("head", "code")
+);
+
+CREATE TABLE IF NOT EXISTS "visor_processing_messages" (
+	"tip_set" text NOT NULL,
+	"height" bigint,
+	"added_at" timestamptz NOT NULL,
+	"claimed_until" timestamptz,
+	"completed_at" timestamptz,
+	"errors_detected" text,
+	PRIMARY KEY ("tip_set")
+);
+
+`)
+	down := batch(`
+DROP TABLE IF EXISTS public.visor_processing_statechanges;
+
+DROP TABLE IF EXISTS public.visor_processing_actors;
+
+DROP TABLE IF EXISTS public.visor_processing_messages;
+	`)
+	migrations.MustRegisterTx(up, down)
+}

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -362,7 +362,7 @@ func (d *Database) MarkStateChangeComplete(ctx context.Context, tsk string, heig
         completed_at = ?,
         errors_detected = ?
     WHERE tip_set = ? AND height = ?
-`, completedAt, errorsDetected, tsk, height)
+`, completedAt, useNullIfEmpty(errorsDetected), tsk, height)
 		if err != nil {
 			return err
 		}
@@ -417,7 +417,7 @@ func (d *Database) MarkActorComplete(ctx context.Context, head string, code stri
         completed_at = ?,
         errors_detected = ?
     WHERE head = ? AND code = ?
-`, completedAt, errorsDetected, head, code)
+`, completedAt, useNullIfEmpty(errorsDetected), head, code)
 		if err != nil {
 			return err
 		}
@@ -472,7 +472,7 @@ func (d *Database) MarkTipSetMessagesComplete(ctx context.Context, tipset string
         completed_at = ?,
         errors_detected = ?
     WHERE tip_set = ? AND height = ?
-`, completedAt, errorsDetected, tipset, height)
+`, completedAt, useNullIfEmpty(errorsDetected), tipset, height)
 		if err != nil {
 			return err
 		}
@@ -483,4 +483,12 @@ func (d *Database) MarkTipSetMessagesComplete(ctx context.Context, tipset string
 	}
 
 	return nil
+}
+
+func useNullIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+
+	return &s
 }

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -450,7 +450,7 @@ WITH leased AS (
 	    FROM visor_processing_messages
 	    WHERE completed_at IS null AND
 	          (claimed_until IS null OR claimed_until < ?) AND
-	          height >= minHeight AND height <= ?
+	          height >= ? AND height <= ?
 	    ORDER BY height DESC
 	    LIMIT ?
 	    FOR UPDATE SKIP LOCKED

--- a/storage/sql_test.go
+++ b/storage/sql_test.go
@@ -4,30 +4,33 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/go-pg/pg/v10"
 	"github.com/go-pg/pg/v10/orm"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/sentinel-visor/model/visor"
 	"github.com/filecoin-project/sentinel-visor/testutil"
 )
+
+func init() {
+	// Freeze time for tests
+	timeNow = testutil.KnownTimeNow
+}
 
 func TestSchemaIsCurrent(t *testing.T) {
 	if testing.Short() || !testutil.DatabaseAvailable() {
 		t.Skip("short testing requested or VISOR_TEST_DB not set")
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
 
-	d, err := NewDatabase(ctx, testutil.Database(), 10)
-	if !assert.NoError(t, err, "connecting to database") {
-		return
-	}
-
-	db, err := connect(ctx, d.opt)
-	if err != nil {
-		t.Fatalf("failed to connect: %v", err)
-	}
-	defer db.Close()
+	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
+	require.NoError(t, err)
+	defer cleanup()
 
 	for _, model := range models {
 		t.Run(fmt.Sprintf("%T", model), func(t *testing.T) {
@@ -40,4 +43,474 @@ func TestSchemaIsCurrent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLeaseStateChanges(t *testing.T) {
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
+	require.NoError(t, err)
+	defer cleanup()
+
+	truncateVisorProcessingTables(t, db)
+
+	indexedTipsets := visor.ProcessingStateChangeList{
+		// Unclaimed, incomplete tipset
+		{
+			TipSet:  "cid0a,cid0b",
+			Height:  0,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, incomplete tipset
+		{
+			TipSet:  "cid1a",
+			Height:  1,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, incomplete tipset
+		{
+			TipSet:  "cid2a,cid2b,cid2c",
+			Height:  2,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, incomplete tipset
+		{
+			TipSet:  "cid3a",
+			Height:  3,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// TipSet completed with stale claim
+		{
+			TipSet:       "cid4",
+			Height:       4,
+			AddedAt:      testutil.KnownTime,
+			ClaimedUntil: testutil.KnownTime.Add(-time.Minute * 15),
+			CompletedAt:  testutil.KnownTime.Add(-time.Minute * 5),
+		},
+
+		// TipSet claimed by another process that has expired
+		{
+			TipSet:       "cid5",
+			Height:       5,
+			AddedAt:      testutil.KnownTime,
+			ClaimedUntil: testutil.KnownTime.Add(-time.Minute * 5),
+		},
+
+		// TipSet claimed by another process
+		{
+			TipSet:       "cid6a,cid6b",
+			Height:       6,
+			AddedAt:      testutil.KnownTime,
+			ClaimedUntil: testutil.KnownTime.Add(time.Minute * 15),
+		},
+	}
+
+	if err := db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return indexedTipsets.PersistWithTx(ctx, tx)
+	}); err != nil {
+		t.Fatalf("persisting indexed blocks: %v", err)
+	}
+
+	const batchSize = 3
+
+	claimUntil := testutil.KnownTime.Add(time.Minute * 10)
+	d := &Database{DB: db}
+
+	claimed, err := d.LeaseStateChanges(ctx, claimUntil, batchSize, 500)
+	require.NoError(t, err)
+	require.Equal(t, batchSize, len(claimed), "number of claimed blocks")
+
+	// TipSets are selected in descending height order, ignoring completed and claimed tipset
+	assert.Equal(t, "cid5", claimed[0].TipSet, "first claimed tipset")
+	assert.Equal(t, "cid3a", claimed[1].TipSet, "second claimed tipset")
+	assert.Equal(t, "cid2a,cid2b,cid2c", claimed[2].TipSet, "third claimed tipset")
+
+	// Check the database contains the leases
+	var count int
+	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_statechanges WHERE claimed_until=?`, claimUntil)
+	require.NoError(t, err)
+	assert.Equal(t, batchSize, count)
+}
+
+func TestMarkStateChangeComplete(t *testing.T) {
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
+	require.NoError(t, err)
+	defer cleanup()
+
+	truncateVisorProcessingTables(t, db)
+
+	indexedBlocks := visor.ProcessingStateChangeList{
+		{
+			TipSet:  "cid0",
+			Height:  0,
+			AddedAt: testutil.KnownTime,
+		},
+
+		{
+			TipSet:  "cid1a,cid1b",
+			Height:  1,
+			AddedAt: testutil.KnownTime,
+		},
+
+		{
+			TipSet:  "cid2",
+			Height:  2,
+			AddedAt: testutil.KnownTime,
+		},
+	}
+
+	if err := db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return indexedBlocks.PersistWithTx(ctx, tx)
+	}); err != nil {
+		t.Fatalf("persisting indexed blocks: %v", err)
+	}
+
+	completedAt := testutil.KnownTime.Add(time.Minute * 1)
+	d := &Database{DB: db}
+
+	err = d.MarkStateChangeComplete(ctx, "cid1a,cid1b", 1, completedAt, "message")
+	require.NoError(t, err)
+
+	// Check the database contains the updated row
+	var count int
+	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_statechanges WHERE completed_at=?`, completedAt)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+// truncateVisorProcessingTables ensures the processing tables are empty
+func truncateVisorProcessingTables(tb testing.TB, db *pg.DB) {
+	tb.Helper()
+	_, err := db.Exec(`TRUNCATE TABLE visor_processing_statechanges`)
+	require.NoError(tb, err, "truncating visor_processing_statechanges")
+
+	_, err = db.Exec(`TRUNCATE TABLE visor_processing_actors`)
+	require.NoError(tb, err, "truncating visor_processing_actors")
+
+	_, err = db.Exec(`TRUNCATE TABLE visor_processing_messages`)
+	require.NoError(tb, err, "truncating visor_processing_messages")
+}
+
+func TestLeaseActors(t *testing.T) {
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
+	require.NoError(t, err)
+	defer cleanup()
+
+	truncateVisorProcessingTables(t, db)
+
+	indexedActors := visor.ProcessingActorList{
+		// Unclaimed, incomplete actor
+		{
+			Head:    "head0",
+			Code:    "codeA",
+			Height:  0,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, incomplete actor
+		{
+			Head:    "head1",
+			Code:    "codeB",
+			Height:  1,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, incomplete actor
+		{
+			Head:    "head2",
+			Code:    "codeC",
+			Height:  2,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, incomplete actor
+		{
+			Head:    "head3",
+			Code:    "codeA",
+			Height:  3,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Actor completed with stale claim
+		{
+			Head:         "head4",
+			Code:         "codeA",
+			Height:       4,
+			AddedAt:      testutil.KnownTime,
+			ClaimedUntil: testutil.KnownTime.Add(-time.Minute * 15),
+			CompletedAt:  testutil.KnownTime.Add(-time.Minute * 5),
+		},
+
+		// Actor claimed by another process that has expired
+		{
+			Head:         "head5",
+			Code:         "codeA",
+			Height:       5,
+			AddedAt:      testutil.KnownTime,
+			ClaimedUntil: testutil.KnownTime.Add(-time.Minute * 5),
+		},
+
+		// Actor claimed by another process
+		{
+			Head:         "head6",
+			Code:         "codeA",
+			Height:       6,
+			AddedAt:      testutil.KnownTime,
+			ClaimedUntil: testutil.KnownTime.Add(time.Minute * 15),
+		},
+	}
+
+	if err := db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return indexedActors.PersistWithTx(ctx, tx)
+	}); err != nil {
+		t.Fatalf("persisting indexed actors: %v", err)
+	}
+
+	const batchSize = 3
+	allowedCodes := []string{"codeA", "codeB"}
+
+	claimUntil := testutil.KnownTime.Add(time.Minute * 10)
+
+	d := &Database{DB: db}
+	claimed, err := d.LeaseActors(ctx, claimUntil, batchSize, 500, allowedCodes)
+	require.NoError(t, err)
+	require.Equal(t, batchSize, len(claimed), "number of claimed actors")
+
+	// Blocks are selected in descending height order, ignoring completed and claimed blocks and only those will
+	// allowed codes.
+	assert.Equal(t, "head5", claimed[0].Head, "first claimed actor")
+	assert.Equal(t, "head3", claimed[1].Head, "second claimed actor")
+	assert.Equal(t, "head1", claimed[2].Head, "third claimed actor")
+
+	// Check the database contains the leases
+	var count int
+	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_actors WHERE claimed_until=?`, claimUntil)
+	require.NoError(t, err)
+	assert.Equal(t, batchSize, count)
+}
+
+func TestMarkActorComplete(t *testing.T) {
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
+	require.NoError(t, err)
+	defer cleanup()
+
+	truncateVisorProcessingTables(t, db)
+
+	indexedActors := visor.ProcessingActorList{
+		{
+			Head:    "head0",
+			Code:    "codeA",
+			Height:  0,
+			AddedAt: testutil.KnownTime,
+		},
+		{
+			Head:    "head1",
+			Code:    "codeB",
+			Height:  1,
+			AddedAt: testutil.KnownTime,
+		},
+		{
+			Head:    "head2",
+			Code:    "codeC",
+			Height:  2,
+			AddedAt: testutil.KnownTime,
+		},
+	}
+
+	if err := db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return indexedActors.PersistWithTx(ctx, tx)
+	}); err != nil {
+		t.Fatalf("persisting indexed actors: %v", err)
+	}
+
+	completedAt := testutil.KnownTime.Add(time.Minute * 1)
+	d := &Database{DB: db}
+
+	err = d.MarkActorComplete(ctx, "head1", "codeB", completedAt, "message")
+	require.NoError(t, err)
+
+	// Check the database contains the updated row
+	var count int
+	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_actors WHERE completed_at=?`, completedAt)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestLeaseBlockMessages(t *testing.T) {
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
+	require.NoError(t, err)
+	defer cleanup()
+
+	truncateVisorProcessingTables(t, db)
+
+	indexedMessageTipSets := visor.ProcessingMessageList{
+		// Unclaimed, incomplete tipset
+		{
+			TipSet:  "cid0a,cid0b",
+			Height:  0,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, incomplete tipset
+		{
+			TipSet:  "cid1a",
+			Height:  1,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, incomplete tipset
+		{
+			TipSet:  "cid2a,cid2b,cid2c",
+			Height:  2,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, incomplete tipset
+		{
+			TipSet:  "cid3a",
+			Height:  3,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Tipset completed with stale claim
+		{
+			TipSet:       "cid4a",
+			Height:       4,
+			AddedAt:      testutil.KnownTime,
+			ClaimedUntil: testutil.KnownTime.Add(-time.Minute * 15),
+			CompletedAt:  testutil.KnownTime.Add(-time.Minute * 5),
+		},
+
+		// Tipset claimed by another process that has expired
+		{
+			TipSet:       "cid5a",
+			Height:       5,
+			AddedAt:      testutil.KnownTime,
+			ClaimedUntil: testutil.KnownTime.Add(-time.Minute * 5),
+		},
+
+		// Tipset claimed by another process
+		{
+			TipSet:       "cid6a,cid6b",
+			Height:       6,
+			AddedAt:      testutil.KnownTime,
+			ClaimedUntil: testutil.KnownTime.Add(time.Minute * 15),
+		},
+	}
+
+	if err := db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return indexedMessageTipSets.PersistWithTx(ctx, tx)
+	}); err != nil {
+		t.Fatalf("persisting indexed blocks: %v", err)
+	}
+
+	const batchSize = 3
+
+	claimUntil := testutil.KnownTime.Add(time.Minute * 10)
+	d := &Database{DB: db}
+
+	claimed, err := d.LeaseTipSetMessages(ctx, claimUntil, batchSize, 500)
+	require.NoError(t, err)
+	require.Equal(t, batchSize, len(claimed), "number of claimed message blocks")
+
+	// Blocks are selected in descending height order, ignoring completed and claimed blocks
+	assert.Equal(t, "cid5a", claimed[0].TipSet, "first claimed message tipset")
+	assert.Equal(t, "cid3a", claimed[1].TipSet, "second claimed message tipset")
+	assert.Equal(t, "cid2a,cid2b,cid2c", claimed[2].TipSet, "third claimed message tipset")
+
+	// Check the database contains the leases
+	var count int
+	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE claimed_until=?`, claimUntil)
+	require.NoError(t, err)
+	assert.Equal(t, batchSize, count)
+}
+
+func TestMarkTipSetMessagesComplete(t *testing.T) {
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
+	require.NoError(t, err)
+	defer cleanup()
+
+	truncateVisorProcessingTables(t, db)
+
+	indexedMessages := visor.ProcessingMessageList{
+		{
+			TipSet:  "cid0a,cid0b",
+			Height:  0,
+			AddedAt: testutil.KnownTime,
+		},
+
+		{
+			TipSet:  "cid1",
+			Height:  1,
+			AddedAt: testutil.KnownTime,
+		},
+
+		{
+			TipSet:  "cid2",
+			Height:  2,
+			AddedAt: testutil.KnownTime,
+		},
+	}
+
+	if err := db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return indexedMessages.PersistWithTx(ctx, tx)
+	}); err != nil {
+		t.Fatalf("persisting indexed message blocks: %v", err)
+	}
+
+	completedAt := testutil.KnownTime.Add(time.Minute * 1)
+	d := &Database{DB: db}
+
+	err = d.MarkTipSetMessagesComplete(ctx, "cid1", 1, completedAt, "message")
+	require.NoError(t, err)
+
+	// Check the database contains the updated row
+	var count int
+	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE completed_at=?`, completedAt)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
 }

--- a/storage/sql_test.go
+++ b/storage/sql_test.go
@@ -181,17 +181,31 @@ func TestMarkStateChangeComplete(t *testing.T) {
 		t.Fatalf("persisting indexed blocks: %v", err)
 	}
 
-	completedAt := testutil.KnownTime.Add(time.Minute * 1)
 	d := &Database{DB: db}
 
-	err = d.MarkStateChangeComplete(ctx, "cid1a,cid1b", 1, completedAt, "message")
-	require.NoError(t, err)
+	t.Run("with error message", func(t *testing.T) {
+		completedAt := testutil.KnownTime.Add(time.Minute * 1)
+		err = d.MarkStateChangeComplete(ctx, "cid1a,cid1b", 1, completedAt, "message")
+		require.NoError(t, err)
 
-	// Check the database contains the updated row
-	var count int
-	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_statechanges WHERE completed_at=?`, completedAt)
-	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+		// Check the database contains the updated row
+		var count int
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_statechanges WHERE completed_at=?`, completedAt)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("without error message", func(t *testing.T) {
+		completedAt := testutil.KnownTime.Add(time.Minute * 2)
+		err = d.MarkStateChangeComplete(ctx, "cid1a,cid1b", 1, completedAt, "")
+		require.NoError(t, err)
+
+		// Check the database contains the updated row with a null errors_detected column
+		var count int
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_statechanges WHERE completed_at=? AND errors_detected IS NULL`, completedAt)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
 }
 
 // truncateVisorProcessingTables ensures the processing tables are empty
@@ -353,17 +367,31 @@ func TestMarkActorComplete(t *testing.T) {
 		t.Fatalf("persisting indexed actors: %v", err)
 	}
 
-	completedAt := testutil.KnownTime.Add(time.Minute * 1)
 	d := &Database{DB: db}
 
-	err = d.MarkActorComplete(ctx, "head1", "codeB", completedAt, "message")
-	require.NoError(t, err)
+	t.Run("with error message", func(t *testing.T) {
+		completedAt := testutil.KnownTime.Add(time.Minute * 1)
+		err = d.MarkActorComplete(ctx, "head1", "codeB", completedAt, "message")
+		require.NoError(t, err)
 
-	// Check the database contains the updated row
-	var count int
-	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_actors WHERE completed_at=?`, completedAt)
-	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+		// Check the database contains the updated row
+		var count int
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_actors WHERE completed_at=?`, completedAt)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("without error message", func(t *testing.T) {
+		completedAt := testutil.KnownTime.Add(time.Minute * 2)
+		err = d.MarkActorComplete(ctx, "head1", "codeB", completedAt, "")
+		require.NoError(t, err)
+
+		// Check the database contains the updated row with a null errors_detected column
+		var count int
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_actors WHERE completed_at=? AND errors_detected IS NULL`, completedAt)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
 }
 
 func TestLeaseBlockMessages(t *testing.T) {
@@ -502,15 +530,30 @@ func TestMarkTipSetMessagesComplete(t *testing.T) {
 		t.Fatalf("persisting indexed message blocks: %v", err)
 	}
 
-	completedAt := testutil.KnownTime.Add(time.Minute * 1)
 	d := &Database{DB: db}
 
-	err = d.MarkTipSetMessagesComplete(ctx, "cid1", 1, completedAt, "message")
-	require.NoError(t, err)
+	t.Run("with error message", func(t *testing.T) {
+		completedAt := testutil.KnownTime.Add(time.Minute * 1)
+		err = d.MarkTipSetMessagesComplete(ctx, "cid1", 1, completedAt, "message")
+		require.NoError(t, err)
 
-	// Check the database contains the updated row
-	var count int
-	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE completed_at=?`, completedAt)
-	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+		// Check the database contains the updated row
+		var count int
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE completed_at=?`, completedAt)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("without error message", func(t *testing.T) {
+		completedAt := testutil.KnownTime.Add(time.Minute * 2)
+		err = d.MarkTipSetMessagesComplete(ctx, "cid1", 1, completedAt, "")
+		require.NoError(t, err)
+
+		// Check the database contains the updated row with a null errors_detected column
+		var count int
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE completed_at=? AND errors_detected IS NULL`, completedAt)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
 }

--- a/storage/sql_test.go
+++ b/storage/sql_test.go
@@ -125,7 +125,7 @@ func TestLeaseStateChanges(t *testing.T) {
 	claimUntil := testutil.KnownTime.Add(time.Minute * 10)
 	d := &Database{DB: db}
 
-	claimed, err := d.LeaseStateChanges(ctx, claimUntil, batchSize, 500)
+	claimed, err := d.LeaseStateChanges(ctx, claimUntil, batchSize, 0, 500)
 	require.NoError(t, err)
 	require.Equal(t, batchSize, len(claimed), "number of claimed blocks")
 
@@ -309,7 +309,7 @@ func TestLeaseActors(t *testing.T) {
 	claimUntil := testutil.KnownTime.Add(time.Minute * 10)
 
 	d := &Database{DB: db}
-	claimed, err := d.LeaseActors(ctx, claimUntil, batchSize, 500, allowedCodes)
+	claimed, err := d.LeaseActors(ctx, claimUntil, batchSize, 0, 500, allowedCodes)
 	require.NoError(t, err)
 	require.Equal(t, batchSize, len(claimed), "number of claimed actors")
 
@@ -474,7 +474,7 @@ func TestLeaseBlockMessages(t *testing.T) {
 	claimUntil := testutil.KnownTime.Add(time.Minute * 10)
 	d := &Database{DB: db}
 
-	claimed, err := d.LeaseTipSetMessages(ctx, claimUntil, batchSize, 500)
+	claimed, err := d.LeaseTipSetMessages(ctx, claimUntil, batchSize, 0, 500)
 	require.NoError(t, err)
 	require.Equal(t, batchSize, len(claimed), "number of claimed message blocks")
 

--- a/tasks/actorstate/actor.go
+++ b/tasks/actorstate/actor.go
@@ -1,0 +1,50 @@
+package actorstate
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"go.opentelemetry.io/otel/api/global"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/model"
+	commonmodel "github.com/filecoin-project/sentinel-visor/model/actors/common"
+)
+
+// was services/processor/tasks/common/actor.go
+
+// ActorExtracter extracts common actor state
+type ActorExtracter struct{}
+
+func (ActorExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	ctx, span := global.Tracer("").Start(ctx, "ActorExtracter")
+	defer span.End()
+
+	ast, err := node.StateReadState(ctx, a.Address, a.TipSet)
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := json.Marshal(ast.State)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugw("read full actor state", "addr", a.Address.String(), "size", len(state), "code", builtin.ActorNameByCode(a.Actor.Code))
+
+	return &commonmodel.ActorTaskResult{
+		Actor: &commonmodel.Actor{
+			ID:        a.Address.String(),
+			StateRoot: a.ParentStateRoot.String(),
+			Code:      builtin.ActorNameByCode(a.Actor.Code),
+			Head:      a.Actor.Head.String(),
+			Balance:   a.Actor.Balance.String(),
+			Nonce:     a.Actor.Nonce,
+		},
+		State: &commonmodel.ActorState{
+			Head:  a.Actor.Head.String(),
+			Code:  a.Actor.Code.String(),
+			State: string(state),
+		},
+	}, nil
+}

--- a/tasks/actorstate/actor.go
+++ b/tasks/actorstate/actor.go
@@ -14,11 +14,11 @@ import (
 
 // was services/processor/tasks/common/actor.go
 
-// ActorExtracter extracts common actor state
-type ActorExtracter struct{}
+// ActorExtractor extracts common actor state
+type ActorExtractor struct{}
 
-func (ActorExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
-	ctx, span := global.Tracer("").Start(ctx, "ActorExtracter")
+func (ActorExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	ctx, span := global.Tracer("").Start(ctx, "ActorExtractor")
 	defer span.End()
 
 	ast, err := node.StateReadState(ctx, a.Address, a.TipSet)

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -1,0 +1,249 @@
+package actorstate
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/model"
+	"github.com/filecoin-project/sentinel-visor/model/visor"
+	"github.com/filecoin-project/sentinel-visor/storage"
+	"github.com/filecoin-project/sentinel-visor/wait"
+)
+
+var log = logging.Logger("actorstate")
+
+var timeNow = time.Now
+
+const batchInterval = 100 * time.Millisecond // time to wait between batches
+
+type ActorInfo struct {
+	Actor           types.Actor
+	Address         address.Address
+	ParentStateRoot cid.Cid
+	TipSet          types.TipSetKey
+	ParentTipSet    types.TipSetKey
+}
+
+// An ActorStateExtracter extracts actor state into a persistable format
+type ActorStateExtracter interface {
+	Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error)
+}
+
+// All supported actor state extracters
+var (
+	extractersMu sync.Mutex
+	extracters   = map[cid.Cid]ActorStateExtracter{}
+)
+
+// Register adds an actor state extracter
+func Register(code cid.Cid, e ActorStateExtracter) {
+	extractersMu.Lock()
+	defer extractersMu.Unlock()
+	if _, ok := extracters[code]; ok {
+		log.Warningf("extracter overrides previously registered extracter for code %q", code.String())
+	}
+	extracters[code] = e
+}
+
+func SupportedActorCodes() []cid.Cid {
+	extractersMu.Lock()
+	defer extractersMu.Unlock()
+
+	var codes []cid.Cid
+	for code := range extracters {
+		codes = append(codes, code)
+	}
+	return codes
+}
+
+func NewActorStateProcessor(d *storage.Database, node lens.API, leaseLength time.Duration, batchSize int, maxHeight int64, actorCodes []cid.Cid) (*ActorStateProcessor, error) {
+	p := &ActorStateProcessor{
+		node:        node,
+		storage:     d,
+		leaseLength: leaseLength,
+		batchSize:   batchSize,
+		maxHeight:   maxHeight,
+		extracters:  map[cid.Cid]ActorStateExtracter{},
+	}
+
+	extractersMu.Lock()
+	defer extractersMu.Unlock()
+	for _, code := range actorCodes {
+		e, exists := extracters[code]
+		if !exists {
+			return nil, xerrors.Errorf("unsupport actor code: %s", code.String())
+		}
+		p.actorCodes = append(p.actorCodes, code.String())
+		p.extracters[code] = e
+	}
+
+	return p, nil
+}
+
+// ActorStateProcessor is a task that processes actor state changes and persists them to the database.
+// There will be multiple concurrent ActorStateProcessor instances.
+type ActorStateProcessor struct {
+	node        lens.API
+	storage     *storage.Database
+	leaseLength time.Duration                   // length of time to lease work for
+	batchSize   int                             // number of blocks to lease in a batch
+	maxHeight   int64                           // limit processing to tipsets equal to or below this height
+	actorCodes  []string                        // list of actor codes that will be requested
+	extracters  map[cid.Cid]ActorStateExtracter // list of extracters that will be used
+}
+
+// Run starts processing batches of actors and blocks until the context is done or
+// an error occurs.
+func (p *ActorStateProcessor) Run(ctx context.Context) error {
+	// Loop until context is done or processing encounters a fatal error
+	return wait.RepeatUntil(ctx, batchInterval, p.processBatch)
+}
+
+func (p *ActorStateProcessor) processBatch(ctx context.Context) (bool, error) {
+	ctx, span := global.Tracer("").Start(ctx, "ActorStateProcessor.processBatch")
+	defer span.End()
+
+	// Lease some blocks to work on
+	claimUntil := timeNow().Add(p.leaseLength)
+	ctx, cancel := context.WithDeadline(ctx, claimUntil)
+	defer cancel()
+
+	batch, err := p.storage.LeaseActors(ctx, claimUntil, p.batchSize, p.maxHeight, p.actorCodes)
+	if err != nil {
+		return true, err
+	}
+
+	// If we have no tipsets to work on then wait before trying again
+	if len(batch) == 0 {
+		sleepInterval := wait.Jitter(idleSleepInterval, 2)
+		log.Debugf("no actors to process, waiting for %s", sleepInterval)
+		time.Sleep(sleepInterval)
+		return false, nil
+	}
+
+	log.Debugw("leased batch of actors", "count", len(batch))
+
+	for _, actor := range batch {
+		// Stop processing if we have somehow passed our own lease time
+		select {
+		case <-ctx.Done():
+			return false, nil // Don't propagate cancelation error so we can resume processing cleanly
+		default:
+		}
+
+		info, err := NewActorInfo(actor)
+		if err != nil {
+			log.Errorw("unmarshal actor", "error", err.Error())
+			if err := p.storage.MarkActorComplete(ctx, actor.Head, actor.Code, timeNow(), err.Error()); err != nil {
+				log.Errorw("failed to mark actor complete", "error", err.Error())
+			}
+			continue
+		}
+
+		var errorsEncountered string
+		if err := p.processActor(ctx, info); err != nil {
+			log.Errorw("process actor", "error", err.Error())
+			errorsEncountered = err.Error()
+		}
+
+		if err := p.storage.MarkActorComplete(ctx, actor.Head, actor.Code, timeNow(), errorsEncountered); err != nil {
+			log.Errorw("failed to mark actor complete", "error", err.Error())
+		}
+	}
+
+	return false, nil
+}
+
+func (p *ActorStateProcessor) processActor(ctx context.Context, info ActorInfo) error {
+	ctx, span := global.Tracer("").Start(ctx, "ActorStateProcessor.processActor")
+	defer span.End()
+
+	var ae ActorExtracter
+
+	// Persist the raw state
+	data, err := ae.Extract(ctx, info, p.node)
+	if err != nil {
+		return xerrors.Errorf("extract actor state: %w", err)
+	}
+	if err := data.Persist(ctx, p.storage.DB); err != nil {
+		// TODO handle this case with a retry
+		return xerrors.Errorf("persisting raw state: %w", err)
+	}
+
+	// Find a specific extracter for the actor type
+	extracter, exists := p.extracters[info.Actor.Code]
+	if !exists {
+		return xerrors.Errorf("no extractor defined for actor code %q", info.Actor.Code.String())
+	}
+
+	data, err = extracter.Extract(ctx, info, p.node)
+	if err != nil {
+		return xerrors.Errorf("extract actor state: %w", err)
+	}
+
+	log.Debugw("persisting extracted state", "addr", info.Address.String())
+
+	if err := data.Persist(ctx, p.storage.DB); err != nil {
+		return xerrors.Errorf("persisting extracted state: %w", err)
+	}
+
+	return nil
+}
+
+func NewActorInfo(a *visor.ProcessingActor) (ActorInfo, error) {
+	var info ActorInfo
+
+	var err error
+	info.TipSet, err = a.TipSetKey()
+	if err != nil {
+		return ActorInfo{}, xerrors.Errorf("unmarshal tipset: %w", err)
+	}
+
+	info.ParentTipSet, err = a.ParentTipSetKey()
+	if err != nil {
+		return ActorInfo{}, xerrors.Errorf("unmarshal parent tipset: %w", err)
+	}
+
+	info.ParentStateRoot, err = cid.Decode(a.ParentStateRoot)
+	if err != nil {
+		return ActorInfo{}, xerrors.Errorf("decode parent stateroot cid: %w", err)
+	}
+
+	info.Address, err = address.NewFromString(a.Address)
+	if err != nil {
+		return ActorInfo{}, xerrors.Errorf("address: %w", err)
+	}
+
+	info.Actor.Code, err = cid.Decode(a.Code)
+	if err != nil {
+		return ActorInfo{}, xerrors.Errorf("decode code cid: %w", err)
+	}
+
+	info.Actor.Head, err = cid.Decode(a.Head)
+	if err != nil {
+		return ActorInfo{}, xerrors.Errorf("decode head cid: %w", err)
+	}
+
+	info.Actor.Balance, err = big.FromString(a.Balance)
+	if err != nil {
+		return ActorInfo{}, xerrors.Errorf("parse balance: %w", err)
+	}
+
+	info.Actor.Nonce, err = strconv.ParseUint(a.Nonce, 10, 64)
+	if err != nil {
+		return ActorInfo{}, xerrors.Errorf("parse nonce: %w", err)
+	}
+
+	return info, nil
+}

--- a/tasks/actorstate/actorstatechange.go
+++ b/tasks/actorstate/actorstatechange.go
@@ -1,0 +1,201 @@
+package actorstate
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/go-pg/pg/v10"
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/model/visor"
+	"github.com/filecoin-project/sentinel-visor/storage"
+	"github.com/filecoin-project/sentinel-visor/wait"
+)
+
+const idleSleepInterval = 60 * time.Second // time to wait if the processor runs out of blocks to process
+
+func NewActorStateChangeProcessor(d *storage.Database, node lens.API, leaseLength time.Duration, batchSize int, maxHeight int64) *ActorStateChangeProcessor {
+	return &ActorStateChangeProcessor{
+		node:        node,
+		storage:     d,
+		leaseLength: leaseLength,
+		batchSize:   batchSize,
+		maxHeight:   maxHeight,
+	}
+}
+
+// ActorStateChangeProcessor is a task that processes blocks to detect actors whose states have changed and persists
+// their details to the database.
+type ActorStateChangeProcessor struct {
+	node        lens.API
+	storage     *storage.Database
+	leaseLength time.Duration // length of time to lease work for
+	batchSize   int           // number of blocks to lease in a batch
+	maxHeight   int64         // limit processing to tipsets equal to or below this height
+}
+
+// Run starts processing batches of blocks and blocks until the context is done or
+// an error occurs.
+func (p *ActorStateChangeProcessor) Run(ctx context.Context) error {
+	// Loop until context is done or processing encounters a fatal error
+	return wait.RepeatUntil(ctx, batchInterval, p.processBatch)
+}
+
+func (p *ActorStateChangeProcessor) processBatch(ctx context.Context) (bool, error) {
+	ctx, span := global.Tracer("").Start(ctx, "ActorStateChangeProcessor.processBatch")
+	defer span.End()
+
+	claimUntil := timeNow().Add(p.leaseLength)
+	ctx, cancel := context.WithDeadline(ctx, claimUntil)
+	defer cancel()
+
+	// Lease some tipsets to work on
+	batch, err := p.storage.LeaseStateChanges(ctx, claimUntil, p.batchSize, p.maxHeight)
+	if err != nil {
+		return true, err
+	}
+
+	// If we have no tipsets to work on then wait before trying again
+	if len(batch) == 0 {
+		sleepInterval := wait.Jitter(idleSleepInterval, 2)
+		log.Debugf("no tipsets to process, waiting for %s", sleepInterval)
+		time.Sleep(sleepInterval)
+		return false, nil
+	}
+
+	log.Debugw("leased batch of tipsets", "count", len(batch))
+
+	for _, item := range batch {
+		// Stop processing if we have somehow passed our own lease time
+		select {
+		case <-ctx.Done():
+			return false, nil // Don't propagate cancelation error so we can resume processing cleanly
+		default:
+		}
+
+		if err := p.processItem(ctx, item); err != nil {
+			log.Errorw("failed to process tipset", "error", err.Error(), "height", item.Height)
+			if err := p.storage.MarkStateChangeComplete(ctx, item.TipSet, item.Height, timeNow(), err.Error()); err != nil {
+				log.Errorw("failed to mark tipset complete", "error", err.Error(), "height", item.Height)
+			}
+			continue
+		}
+
+		if err := p.storage.MarkStateChangeComplete(ctx, item.TipSet, item.Height, timeNow(), ""); err != nil {
+			log.Errorw("failed to mark tipset complete", "error", err.Error(), "height", item.Height)
+		}
+
+	}
+
+	return false, nil
+}
+
+func (p *ActorStateChangeProcessor) processItem(ctx context.Context, item *visor.ProcessingStateChange) error {
+	tsk, err := item.TipSetKey()
+	if err != nil {
+		return xerrors.Errorf("get tipsetkey: %w", err)
+	}
+
+	ts, err := p.node.ChainGetTipSet(ctx, tsk)
+	if err != nil {
+		return xerrors.Errorf("get tipset: %w", err)
+	}
+
+	if item.Height > 0 {
+		if err := p.processTipSet(ctx, ts); err != nil {
+			return xerrors.Errorf("process tipset: %w", err)
+		}
+	} else {
+		gp := NewGenesisProcessor(p.storage, p.node)
+		if err := gp.ProcessGenesis(ctx, ts); err != nil {
+			return xerrors.Errorf("process genesis: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (p *ActorStateChangeProcessor) processTipSet(ctx context.Context, ts *types.TipSet) error {
+	ctx, span := global.Tracer("").Start(ctx, "ActorStateChangeProcessor.processTipSet")
+	defer span.End()
+	ll := log.With("height", int64(ts.Height()))
+
+	ll.Debugw("processing tipset")
+
+	pts, err := p.node.ChainGetTipSet(ctx, ts.Parents())
+	if err != nil {
+		return xerrors.Errorf("get parent tipset: %w", err)
+	}
+
+	changes, err := p.node.StateChangedActors(ctx, pts.ParentState(), ts.ParentState())
+	if err != nil {
+		return xerrors.Errorf("get actor changes: %w", err)
+	}
+
+	ll.Debugw("found actor state changes", "count", len(changes))
+
+	var palist visor.ProcessingActorList
+
+	for str, act := range changes {
+		// Stop processing if we have somehow passed our own lease time
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		addr, err := address.NewFromString(str)
+		if err != nil {
+			return xerrors.Errorf("parse address: %w", err)
+		}
+
+		_, err = p.node.StateGetActor(ctx, addr, pts.Key())
+		if err != nil {
+			if strings.Contains(err.Error(), "actor not found") {
+				ll.Debugw("actor not found", "addr", str)
+				// TODO consider tracking deleted actors
+				continue
+			}
+			return xerrors.Errorf("get actor: %w", err)
+		}
+
+		_, err = p.node.StateGetActor(ctx, addr, pts.Parents())
+		if err != nil {
+			if strings.Contains(err.Error(), "actor not found") {
+				ll.Debugw("actor not found", "addr", str)
+				// TODO consider tracking deleted actors
+				continue
+			}
+			return xerrors.Errorf("get actor parent: %w", err)
+		}
+
+		palist = append(palist, &visor.ProcessingActor{
+			Head:            act.Head.String(),
+			Code:            act.Code.String(),
+			Nonce:           strconv.FormatUint(act.Nonce, 10),
+			Balance:         act.Balance.String(),
+			Address:         addr.String(),
+			TipSet:          pts.Key().String(),
+			ParentTipSet:    pts.Parents().String(),
+			ParentStateRoot: pts.ParentState().String(),
+			Height:          int64(ts.Height()),
+			AddedAt:         timeNow(),
+		})
+	}
+
+	ll.Debugw("persisting tipset", "state_changes", len(palist))
+	if err := p.storage.DB.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return palist.PersistWithTx(ctx, tx)
+	}); err != nil {
+		return xerrors.Errorf("persist: %w", err)
+	}
+
+	return nil
+
+}

--- a/tasks/actorstate/actorstatechange.go
+++ b/tasks/actorstate/actorstatechange.go
@@ -172,7 +172,7 @@ func (p *ActorStateChangeProcessor) processTipSet(ctx context.Context, ts *types
 		_, err = p.node.StateGetActor(ctx, addr, pts.Parents())
 		if err != nil {
 			if strings.Contains(err.Error(), "actor not found") {
-				ll.Debugw("actor not found", "addr", str)
+				ll.Debugw("parent actor not found", "addr", str)
 				// TODO consider tracking deleted actors
 				continue
 			}

--- a/tasks/actorstate/actorstatechange.go
+++ b/tasks/actorstate/actorstatechange.go
@@ -79,16 +79,18 @@ func (p *ActorStateChangeProcessor) processBatch(ctx context.Context) (bool, err
 		default:
 		}
 
+		errorLog := log.With("height", item.Height, "tipset", item.TipSet)
+
 		if err := p.processItem(ctx, item); err != nil {
-			log.Errorw("failed to process tipset", "error", err.Error(), "height", item.Height)
+			errorLog.Errorw("failed to process tipset", "error", err.Error())
 			if err := p.storage.MarkStateChangeComplete(ctx, item.TipSet, item.Height, timeNow(), err.Error()); err != nil {
-				log.Errorw("failed to mark tipset complete", "error", err.Error(), "height", item.Height)
+				errorLog.Errorw("failed to mark tipset complete", "error", err.Error())
 			}
 			continue
 		}
 
 		if err := p.storage.MarkStateChangeComplete(ctx, item.TipSet, item.Height, timeNow(), ""); err != nil {
-			log.Errorw("failed to mark tipset complete", "error", err.Error(), "height", item.Height)
+			errorLog.Errorw("failed to mark tipset complete", "error", err.Error())
 		}
 
 	}

--- a/tasks/actorstate/genesis.go
+++ b/tasks/actorstate/genesis.go
@@ -1,0 +1,233 @@
+package actorstate
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	init_ "github.com/filecoin-project/lotus/chain/actors/builtin/init"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	initmodel "github.com/filecoin-project/sentinel-visor/model/actors/init"
+	marketmodel "github.com/filecoin-project/sentinel-visor/model/actors/market"
+	minermodel "github.com/filecoin-project/sentinel-visor/model/actors/miner"
+	genesismodel "github.com/filecoin-project/sentinel-visor/model/genesis"
+	"github.com/filecoin-project/sentinel-visor/storage"
+)
+
+func NewGenesisProcessor(d *storage.Database, node lens.API) *GenesisProcessor {
+	return &GenesisProcessor{
+		node:    node,
+		storage: d,
+	}
+}
+
+// GenesisProcessor is a task that processes the genesis block
+type GenesisProcessor struct {
+	node    lens.API
+	storage *storage.Database
+}
+
+func (p *GenesisProcessor) ProcessGenesis(ctx context.Context, gen *types.TipSet) error {
+	ctx, span := global.Tracer("").Start(ctx, "GenesisProcessor.ProcessGenesis")
+	defer span.End()
+
+	genesisAddrs, err := p.node.StateListActors(ctx, gen.Key())
+	if err != nil {
+		return xerrors.Errorf("list actors: %w", err)
+	}
+
+	result := &genesismodel.ProcessGenesisSingletonResult{}
+	for _, addr := range genesisAddrs {
+		genesisAct, err := p.node.StateGetActor(ctx, addr, gen.Key())
+		if err != nil {
+			return xerrors.Errorf("get actor: %w", err)
+		}
+		switch genesisAct.Code {
+		case builtin.SystemActorCodeID:
+			// TODO
+		case builtin.InitActorCodeID:
+			res, err := p.initActorState(ctx, gen, genesisAct)
+			if err != nil {
+				return xerrors.Errorf("init actor state: %w", err)
+			}
+			result.SetInitActor(res)
+		case builtin.CronActorCodeID:
+			// TODO
+		case builtin.AccountActorCodeID:
+			// TODO
+		case builtin.StoragePowerActorCodeID:
+			// TODO
+		case builtin.StorageMarketActorCodeID:
+			res, err := p.storageMarketState(ctx, gen)
+			if err != nil {
+				return xerrors.Errorf("storage market actor state: %w", err)
+			}
+			result.SetMarket(res)
+		case builtin.StorageMinerActorCodeID:
+			res, err := p.storageMinerState(ctx, gen, addr, genesisAct)
+			if err != nil {
+				return xerrors.Errorf("storage miner actor state: %w", err)
+			}
+			result.AddMiner(res)
+		case builtin.PaymentChannelActorCodeID:
+			// TODO
+		case builtin.MultisigActorCodeID:
+			// TODO
+		case builtin.RewardActorCodeID:
+			// TODO
+		case builtin.VerifiedRegistryActorCodeID:
+			// TODO
+		default:
+			log.Warnf("unknown actor in genesis state. address: %s code: %s head: %s", addr, genesisAct.Code, genesisAct.Head)
+		}
+	}
+
+	if err := result.Persist(ctx, p.storage.DB); err != nil {
+		return xerrors.Errorf("persist genesis: %w", err)
+	}
+
+	return nil
+}
+
+func (p *GenesisProcessor) storageMinerState(ctx context.Context, gen *types.TipSet, addr address.Address, act *types.Actor) (*genesismodel.GenesisMinerTaskResult, error) {
+	// actual miner actor state and miner info
+	mstate, err := miner.Load(p.node.Store(), act)
+	if err != nil {
+		return nil, err
+	}
+
+	// miner raw and qual power
+	// TODO this needs caching so we don't re-fetch the power actors claim table for every tipset.
+	mpower, err := p.node.StateMinerPower(ctx, addr, gen.Key())
+	if err != nil {
+		return nil, err
+	}
+
+	msectors, err := mstate.LoadSectors(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	minfo, err := mstate.Info()
+	if err != nil {
+		return nil, err
+	}
+
+	powerModel := &minermodel.MinerPower{
+		MinerID:              addr.String(),
+		StateRoot:            gen.ParentState().String(),
+		RawBytePower:         mpower.MinerPower.RawBytePower.String(),
+		QualityAdjustedPower: mpower.MinerPower.QualityAdjPower.String(),
+	}
+
+	stateModel := &minermodel.MinerState{
+		MinerID:    addr.String(),
+		OwnerID:    minfo.Owner.String(),
+		WorkerID:   minfo.Worker.String(),
+		PeerID:     minfo.PeerId.String(),
+		SectorSize: minfo.SectorSize.ShortString(),
+	}
+
+	sectorsModel := make(minermodel.MinerSectorInfos, len(msectors))
+	dealsModel := minermodel.MinerDealSectors{}
+	for idx, sector := range msectors {
+		sectorsModel[idx] = &minermodel.MinerSectorInfo{
+			MinerID:               addr.String(),
+			SectorID:              uint64(sector.SectorNumber),
+			StateRoot:             gen.ParentState().String(),
+			SealedCID:             sector.SealedCID.String(),
+			ActivationEpoch:       int64(sector.Activation),
+			ExpirationEpoch:       int64(sector.Expiration),
+			DealWeight:            sector.DealWeight.String(),
+			VerifiedDealWeight:    sector.VerifiedDealWeight.String(),
+			InitialPledge:         sector.InitialPledge.String(),
+			ExpectedDayReward:     sector.ExpectedDayReward.String(),
+			ExpectedStoragePledge: sector.ExpectedStoragePledge.String(),
+		}
+		for _, dealID := range sector.DealIDs {
+			dealsModel = append(dealsModel, &minermodel.MinerDealSector{
+				MinerID:  addr.String(),
+				SectorID: uint64(sector.SectorNumber),
+				DealID:   uint64(dealID),
+			})
+		}
+	}
+	return &genesismodel.GenesisMinerTaskResult{
+		StateModel:   stateModel,
+		PowerModel:   powerModel,
+		SectorModels: sectorsModel,
+		DealModels:   dealsModel,
+	}, nil
+}
+
+func (p *GenesisProcessor) initActorState(ctx context.Context, gen *types.TipSet, act *types.Actor) (*genesismodel.GenesisInitActorTaskResult, error) {
+	initActorState, err := init_.Load(p.node.Store(), act)
+	if err != nil {
+		return nil, err
+	}
+
+	out := initmodel.IdAddressList{}
+	if err := initActorState.ForEachActor(func(id abi.ActorID, addr address.Address) error {
+		out = append(out, &initmodel.IdAddress{
+			ID:        id.String(),
+			Address:   addr.String(),
+			StateRoot: gen.ParentState().String(),
+		})
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return &genesismodel.GenesisInitActorTaskResult{AddressMap: out}, nil
+}
+
+func (p *GenesisProcessor) storageMarketState(ctx context.Context, gen *types.TipSet) (*genesismodel.GenesisMarketTaskResult, error) {
+	dealStates, err := p.node.StateMarketDeals(ctx, gen.Key())
+	if err != nil {
+		return nil, err
+	}
+
+	states := make(marketmodel.MarketDealStates, len(dealStates))
+	proposals := make(marketmodel.MarketDealProposals, len(dealStates))
+	idx := 0
+	for idStr, deal := range dealStates {
+		dealID, err := strconv.ParseUint(idStr, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		states[idx] = &marketmodel.MarketDealState{
+			DealID:           dealID,
+			SectorStartEpoch: int64(deal.State.SectorStartEpoch),
+			LastUpdateEpoch:  int64(deal.State.LastUpdatedEpoch),
+			SlashEpoch:       int64(deal.State.SlashEpoch),
+			StateRoot:        gen.ParentState().String(),
+		}
+		proposals[idx] = &marketmodel.MarketDealProposal{
+			DealID:               dealID,
+			StateRoot:            gen.ParentState().String(),
+			PaddedPieceSize:      uint64(deal.Proposal.PieceSize),
+			UnpaddedPieceSize:    uint64(deal.Proposal.PieceSize.Unpadded()),
+			StartEpoch:           int64(deal.Proposal.StartEpoch),
+			EndEpoch:             int64(deal.Proposal.EndEpoch),
+			ClientID:             deal.Proposal.Client.String(),
+			ProviderID:           deal.Proposal.Provider.String(),
+			ClientCollateral:     deal.Proposal.ClientCollateral.String(),
+			ProviderCollateral:   deal.Proposal.ProviderCollateral.String(),
+			StoragePricePerEpoch: deal.Proposal.StoragePricePerEpoch.String(),
+			PieceCID:             deal.Proposal.PieceCID.String(),
+			IsVerified:           deal.Proposal.VerifiedDeal,
+			Label:                deal.Proposal.Label,
+		}
+		idx++
+	}
+	return &genesismodel.GenesisMarketTaskResult{
+		DealModels:     states,
+		ProposalModels: proposals,
+	}, nil
+}

--- a/tasks/actorstate/genesis.go
+++ b/tasks/actorstate/genesis.go
@@ -104,7 +104,6 @@ func (p *GenesisProcessor) storageMinerState(ctx context.Context, gen *types.Tip
 	}
 
 	// miner raw and qual power
-	// TODO this needs caching so we don't re-fetch the power actors claim table for every tipset.
 	mpower, err := p.node.StateMinerPower(ctx, addr, gen.Key())
 	if err != nil {
 		return nil, err

--- a/tasks/actorstate/genesis_test.go
+++ b/tasks/actorstate/genesis_test.go
@@ -1,0 +1,146 @@
+package actorstate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-pg/pg/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	apitest "github.com/filecoin-project/lotus/api/test"
+	"github.com/filecoin-project/lotus/build"
+	nodetest "github.com/filecoin-project/lotus/node/test"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
+
+	"github.com/filecoin-project/sentinel-visor/lens/lotus"
+	"github.com/filecoin-project/sentinel-visor/storage"
+	"github.com/filecoin-project/sentinel-visor/testutil"
+)
+
+func init() {
+	build.InsecurePoStValidation = true
+	err := os.Setenv("TRUST_PARAMS", "1")
+	if err != nil {
+		panic(err)
+	}
+	miner.SupportedProofTypes = map[abi.RegisteredSealProof]struct{}{
+		abi.RegisteredSealProof_StackedDrg2KiBV1: {},
+	}
+	power.ConsensusMinerMinPower = big.NewInt(2048)
+	verifreg.MinVerifiedDealSize = big.NewInt(256)
+}
+
+func TestGenesisProcessor(t *testing.T) {
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
+	require.NoError(t, err)
+	defer cleanup()
+
+	t.Logf("truncating database tables")
+	err = truncateGenesisTables(t, db)
+	require.NoError(t, err, "truncating tables")
+
+	t.Logf("preparing chain")
+	nodes, sn := nodetest.Builder(t, 1, apitest.OneMiner)
+	cs, err := lotus.NewCacheCtxStore(ctx, nodes[0], 5)
+	require.NoError(t, err, "cache store")
+	node := lotus.NewAPIWrapper(nodes[0], cs)
+
+	apitest.MineUntilBlock(ctx, t, nodes[0], sn[0], nil)
+
+	t.Logf("initializing genesis processor")
+	d := &storage.Database{DB: db}
+	p := NewGenesisProcessor(d, node)
+
+	t.Logf("processing")
+	gen, err := node.ChainGetGenesis(ctx)
+	require.NoError(t, err, "chain genesis")
+	err = p.ProcessGenesis(ctx, gen)
+	require.NoError(t, err, "Run")
+
+	// Not brilliantly useful tests, but they do test that data was read from the chain and written to the database
+
+	t.Run("miner_deal_sectors", func(t *testing.T) {
+		var count int
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM miner_deal_sectors`)
+		require.NoError(t, err)
+		assert.NotEqual(t, 0, count)
+	})
+
+	t.Run("miner_sector_infos", func(t *testing.T) {
+		var count int
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM miner_sector_infos`)
+		require.NoError(t, err)
+		assert.NotEqual(t, 0, count)
+	})
+
+	t.Run("miner_powers", func(t *testing.T) {
+		var count int
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM miner_powers`)
+		require.NoError(t, err)
+		assert.NotEqual(t, 0, count)
+	})
+
+	t.Run("miner_states", func(t *testing.T) {
+		var count int
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM miner_states`)
+		require.NoError(t, err)
+		assert.NotEqual(t, 0, count)
+	})
+
+	t.Run("market_deal_states", func(t *testing.T) {
+		var count int
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM market_deal_states`)
+		require.NoError(t, err)
+		assert.NotEqual(t, 0, count)
+	})
+
+	t.Run("market_deal_proposals", func(t *testing.T) {
+		var count int
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM market_deal_proposals`)
+		require.NoError(t, err)
+		assert.NotEqual(t, 0, count)
+	})
+
+	t.Run("id_addresses", func(t *testing.T) {
+		var count int
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM id_addresses`)
+		require.NoError(t, err)
+		assert.NotEqual(t, 0, count)
+	})
+
+}
+
+// truncateGenesisTables ensures the indexing tables are empty
+func truncateGenesisTables(tb testing.TB, db *pg.DB) error {
+	tables := []string{
+		"miner_states",
+		"miner_powers",
+		"miner_sector_infos",
+		"miner_deal_sectors",
+		"market_deal_states",
+		"market_deal_proposals",
+		"id_addresses",
+	}
+
+	for _, tbl := range tables {
+		_, err := db.Exec(fmt.Sprintf(`TRUNCATE TABLE %s`, tbl))
+		require.NoError(tb, err, tbl)
+	}
+
+	return nil
+}

--- a/tasks/actorstate/init.go
+++ b/tasks/actorstate/init.go
@@ -1,0 +1,61 @@
+package actorstate
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/lotus/chain/events/state"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/model"
+	initmodel "github.com/filecoin-project/sentinel-visor/model/actors/init"
+)
+
+// was services/processor/tasks/init/init_actor.go
+
+// InitExtracter extracts init actor state
+type InitExtracter struct{}
+
+func init() {
+	Register(builtin.InitActorCodeID, InitExtracter{})
+}
+
+func (InitExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	ctx, span := global.Tracer("").Start(ctx, "InitExtracter")
+	defer span.End()
+
+	pred := state.NewStatePredicates(node)
+	stateDiff := pred.OnInitActorChange(pred.OnAddressMapChange())
+	changed, val, err := stateDiff(ctx, a.ParentTipSet, a.TipSet)
+	if err != nil {
+		return nil, err
+	}
+	if !changed {
+		return nil, xerrors.Errorf("no state change detected")
+	}
+	changes, ok := val.(*state.InitActorAddressChanges)
+	if !ok {
+		return nil, xerrors.Errorf("unknown type returned by init actor hamt predicate: %T", val)
+	}
+
+	out := make(initmodel.IdAddressList, 0, len(changes.Added)+len(changes.Modified))
+	for _, add := range changes.Added {
+		out = append(out, &initmodel.IdAddress{
+			ID:        add.ID.String(),
+			Address:   add.PK.String(),
+			StateRoot: a.ParentStateRoot.String(),
+		})
+	}
+	for _, mod := range changes.Modified {
+		out = append(out, &initmodel.IdAddress{
+			ID:        mod.To.ID.String(),
+			Address:   mod.To.PK.String(),
+			StateRoot: a.ParentStateRoot.String(),
+		})
+	}
+
+	return out, nil
+}

--- a/tasks/actorstate/init.go
+++ b/tasks/actorstate/init.go
@@ -16,15 +16,15 @@ import (
 
 // was services/processor/tasks/init/init_actor.go
 
-// InitExtracter extracts init actor state
-type InitExtracter struct{}
+// InitExtractor extracts init actor state
+type InitExtractor struct{}
 
 func init() {
-	Register(builtin.InitActorCodeID, InitExtracter{})
+	Register(builtin.InitActorCodeID, InitExtractor{})
 }
 
-func (InitExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
-	ctx, span := global.Tracer("").Start(ctx, "InitExtracter")
+func (InitExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	ctx, span := global.Tracer("").Start(ctx, "InitExtractor")
 	defer span.End()
 
 	pred := state.NewStatePredicates(node)

--- a/tasks/actorstate/market.go
+++ b/tasks/actorstate/market.go
@@ -17,15 +17,15 @@ import (
 
 // was services/processor/tasks/market/market.go
 
-// StorageMarketExtracter extracts market actor state
-type StorageMarketExtracter struct{}
+// StorageMarketExtractor extracts market actor state
+type StorageMarketExtractor struct{}
 
 func init() {
-	Register(builtin.StorageMarketActorCodeID, StorageMarketExtracter{})
+	Register(builtin.StorageMarketActorCodeID, StorageMarketExtractor{})
 }
 
-func (m StorageMarketExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
-	ctx, span := global.Tracer("").Start(ctx, "StorageMarketExtracter")
+func (m StorageMarketExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	ctx, span := global.Tracer("").Start(ctx, "StorageMarketExtractor")
 	defer span.End()
 
 	proposals, err := m.marketDealProposalChanges(ctx, a, node)
@@ -44,7 +44,7 @@ func (m StorageMarketExtracter) Extract(ctx context.Context, a ActorInfo, node l
 	}, nil
 }
 
-func (m StorageMarketExtracter) marketDealStateChanges(ctx context.Context, a ActorInfo, node lens.API) (marketmodel.MarketDealStates, error) {
+func (m StorageMarketExtractor) marketDealStateChanges(ctx context.Context, a ActorInfo, node lens.API) (marketmodel.MarketDealStates, error) {
 	// TODO: pass in diff to avoid doing it twice
 	pred := state.NewStatePredicates(node)
 	stateDiff := pred.OnStorageMarketActorChanged(pred.OnDealStateChanged(pred.OnDealStateAmtChanged()))
@@ -86,7 +86,7 @@ func (m StorageMarketExtracter) marketDealStateChanges(ctx context.Context, a Ac
 	return out, nil
 }
 
-func (m StorageMarketExtracter) marketDealProposalChanges(ctx context.Context, a ActorInfo, node lens.API) (marketmodel.MarketDealProposals, error) {
+func (m StorageMarketExtractor) marketDealProposalChanges(ctx context.Context, a ActorInfo, node lens.API) (marketmodel.MarketDealProposals, error) {
 	// TODO: pass in diff to avoid doing it twice
 	pred := state.NewStatePredicates(node)
 	stateDiff := pred.OnStorageMarketActorChanged(pred.OnDealProposalChanged(pred.OnDealProposalAmtChanged()))

--- a/tasks/actorstate/market.go
+++ b/tasks/actorstate/market.go
@@ -1,0 +1,127 @@
+package actorstate
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	market "github.com/filecoin-project/lotus/chain/actors/builtin/market"
+	"github.com/filecoin-project/lotus/chain/events/state"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/model"
+	marketmodel "github.com/filecoin-project/sentinel-visor/model/actors/market"
+)
+
+// was services/processor/tasks/market/market.go
+
+// StorageMarketExtracter extracts market actor state
+type StorageMarketExtracter struct{}
+
+func init() {
+	Register(builtin.StorageMarketActorCodeID, StorageMarketExtracter{})
+}
+
+func (m StorageMarketExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	ctx, span := global.Tracer("").Start(ctx, "StorageMarketExtracter")
+	defer span.End()
+
+	proposals, err := m.marketDealProposalChanges(ctx, a, node)
+	if err != nil {
+		return nil, err
+	}
+
+	states, err := m.marketDealStateChanges(ctx, a, node)
+	if err != nil {
+		return nil, err
+	}
+
+	return &marketmodel.MarketTaskResult{
+		Proposals: proposals,
+		States:    states,
+	}, nil
+}
+
+func (m StorageMarketExtracter) marketDealStateChanges(ctx context.Context, a ActorInfo, node lens.API) (marketmodel.MarketDealStates, error) {
+	// TODO: pass in diff to avoid doing it twice
+	pred := state.NewStatePredicates(node)
+	stateDiff := pred.OnStorageMarketActorChanged(pred.OnDealStateChanged(pred.OnDealStateAmtChanged()))
+	changed, val, err := stateDiff(ctx, a.ParentTipSet, a.TipSet)
+	if err != nil {
+		return nil, err
+	}
+	if !changed {
+		return nil, xerrors.Errorf("no state change detected")
+	}
+	changes, ok := val.(*market.DealStateChanges)
+	if !ok {
+		// indicates a developer error or breaking change in lotus
+		return nil, xerrors.Errorf("Unknown type returned by Deal State AMT predicate: %T", val)
+	}
+
+	out := make(marketmodel.MarketDealStates, len(changes.Added)+len(changes.Modified))
+	idx := 0
+	for _, add := range changes.Added {
+		out[idx] = &marketmodel.MarketDealState{
+			DealID:           uint64(add.ID),
+			StateRoot:        a.ParentStateRoot.String(),
+			SectorStartEpoch: int64(add.Deal.SectorStartEpoch),
+			LastUpdateEpoch:  int64(add.Deal.LastUpdatedEpoch),
+			SlashEpoch:       int64(add.Deal.SlashEpoch),
+		}
+		idx++
+	}
+	for _, mod := range changes.Modified {
+		out[idx] = &marketmodel.MarketDealState{
+			DealID:           uint64(mod.ID),
+			SectorStartEpoch: int64(mod.To.SectorStartEpoch),
+			LastUpdateEpoch:  int64(mod.To.LastUpdatedEpoch),
+			SlashEpoch:       int64(mod.To.SlashEpoch),
+			StateRoot:        a.ParentStateRoot.String(),
+		}
+		idx++
+	}
+	return out, nil
+}
+
+func (m StorageMarketExtracter) marketDealProposalChanges(ctx context.Context, a ActorInfo, node lens.API) (marketmodel.MarketDealProposals, error) {
+	// TODO: pass in diff to avoid doing it twice
+	pred := state.NewStatePredicates(node)
+	stateDiff := pred.OnStorageMarketActorChanged(pred.OnDealProposalChanged(pred.OnDealProposalAmtChanged()))
+	changed, val, err := stateDiff(ctx, a.ParentTipSet, a.TipSet)
+	if err != nil {
+		return nil, err
+	}
+	if !changed {
+		return nil, nil
+	}
+	changes, ok := val.(*market.DealProposalChanges)
+	if !ok {
+		// indicates a developer error or breaking change in lotus
+		return nil, xerrors.Errorf("Unknown type returned by Deal Proposal AMT predicate: %T", val)
+	}
+
+	out := make(marketmodel.MarketDealProposals, len(changes.Added))
+
+	for idx, add := range changes.Added {
+		out[idx] = &marketmodel.MarketDealProposal{
+			DealID:               uint64(add.ID),
+			StateRoot:            a.ParentStateRoot.String(),
+			PaddedPieceSize:      uint64(add.Proposal.PieceSize),
+			UnpaddedPieceSize:    uint64(add.Proposal.PieceSize.Unpadded()),
+			StartEpoch:           int64(add.Proposal.StartEpoch),
+			EndEpoch:             int64(add.Proposal.EndEpoch),
+			ClientID:             add.Proposal.Client.String(),
+			ProviderID:           add.Proposal.Provider.String(),
+			ClientCollateral:     add.Proposal.ClientCollateral.String(),
+			ProviderCollateral:   add.Proposal.ProviderCollateral.String(),
+			StoragePricePerEpoch: add.Proposal.StoragePricePerEpoch.String(),
+			PieceCID:             add.Proposal.PieceCID.String(),
+			IsVerified:           add.Proposal.VerifiedDeal,
+			Label:                add.Proposal.Label,
+		}
+	}
+	return out, nil
+}

--- a/tasks/actorstate/miner.go
+++ b/tasks/actorstate/miner.go
@@ -1,0 +1,102 @@
+package actorstate
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	miner "github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/model"
+	minermodel "github.com/filecoin-project/sentinel-visor/model/actors/miner"
+)
+
+// was services/processor/tasks/miner/miner.go
+
+// StorageMinerExtracter extracts miner actor state
+type StorageMinerExtracter struct{}
+
+func init() {
+	Register(builtin.StorageMinerActorCodeID, StorageMinerExtracter{})
+}
+
+func (m StorageMinerExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	// TODO:
+	// - all processing below can and probably should be done in parallel.
+	// - processing is incomplete, see below TODO about sector inspection.
+	// - need caching infront of the lotus api to avoid refetching power for same tipset.
+	ctx, span := global.Tracer("").Start(ctx, "StorageMinerExtracter")
+	defer span.End()
+
+	curActor, err := node.StateGetActor(ctx, a.Address, a.TipSet)
+	if err != nil {
+		return nil, xerrors.Errorf("loading current miner actor: %w", err)
+	}
+
+	curState, err := miner.Load(node.Store(), curActor)
+	if err != nil {
+		return nil, xerrors.Errorf("loading current miner state: %w", err)
+	}
+
+	minfo, err := curState.Info()
+	if err != nil {
+		return nil, xerrors.Errorf("loading miner info: %w", err)
+	}
+
+	// miner raw and qual power
+	// TODO this needs caching so we don't re-fetch the power actors claim table (that holds this info) for every tipset.
+	minerPower, err := node.StateMinerPower(ctx, a.Address, a.TipSet)
+	if err != nil {
+		return nil, xerrors.Errorf("loading miner power: %w", err)
+	}
+
+	// needed for diffing.
+	prevActor, err := node.StateGetActor(ctx, a.Address, a.ParentTipSet)
+	if err != nil {
+		return nil, xerrors.Errorf("loading previous miner actor: %w", err)
+	}
+
+	prevState, err := miner.Load(node.Store(), prevActor)
+	if err != nil {
+		return nil, xerrors.Errorf("loading previous miner actor state: %w", err)
+	}
+
+	preCommitChanges, err := miner.DiffPreCommits(prevState, curState)
+	if err != nil {
+		return nil, xerrors.Errorf("diffing miner precommits: %w", err)
+	}
+
+	sectorChanges, err := miner.DiffSectors(prevState, curState)
+	if err != nil {
+		return nil, xerrors.Errorf("diffing miner sectors: %w", err)
+	}
+
+	// miner partition changes
+	partitionsDiff, err := m.minerPartitionsDiff(ctx, prevState, curState)
+	if err != nil {
+		return nil, xerrors.Errorf("diffing miner partitions: %v", err)
+	}
+
+	// TODO we still need to do a little bit more processing here around sectors to get all the info we need, but this is okay for spike.
+
+	return &minermodel.MinerTaskResult{
+		Ts:               a.TipSet,
+		Pts:              a.ParentTipSet,
+		Addr:             a.Address,
+		StateRoot:        a.ParentStateRoot,
+		Actor:            curActor,
+		State:            curState,
+		Info:             minfo,
+		Power:            minerPower,
+		PreCommitChanges: preCommitChanges,
+		SectorChanges:    sectorChanges,
+		PartitionDiff:    partitionsDiff,
+	}, nil
+}
+
+func (m StorageMinerExtracter) minerPartitionsDiff(ctx context.Context, prevState, curState miner.State) (map[uint64]*minermodel.PartitionStatus, error) {
+	return nil, nil
+}

--- a/tasks/actorstate/miner.go
+++ b/tasks/actorstate/miner.go
@@ -16,19 +16,19 @@ import (
 
 // was services/processor/tasks/miner/miner.go
 
-// StorageMinerExtracter extracts miner actor state
-type StorageMinerExtracter struct{}
+// StorageMinerExtractor extracts miner actor state
+type StorageMinerExtractor struct{}
 
 func init() {
-	Register(builtin.StorageMinerActorCodeID, StorageMinerExtracter{})
+	Register(builtin.StorageMinerActorCodeID, StorageMinerExtractor{})
 }
 
-func (m StorageMinerExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+func (m StorageMinerExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
 	// TODO:
 	// - all processing below can and probably should be done in parallel.
 	// - processing is incomplete, see below TODO about sector inspection.
 	// - need caching infront of the lotus api to avoid refetching power for same tipset.
-	ctx, span := global.Tracer("").Start(ctx, "StorageMinerExtracter")
+	ctx, span := global.Tracer("").Start(ctx, "StorageMinerExtractor")
 	defer span.End()
 
 	curActor, err := node.StateGetActor(ctx, a.Address, a.TipSet)
@@ -97,6 +97,6 @@ func (m StorageMinerExtracter) Extract(ctx context.Context, a ActorInfo, node le
 	}, nil
 }
 
-func (m StorageMinerExtracter) minerPartitionsDiff(ctx context.Context, prevState, curState miner.State) (map[uint64]*minermodel.PartitionStatus, error) {
+func (m StorageMinerExtractor) minerPartitionsDiff(ctx context.Context, prevState, curState miner.State) (map[uint64]*minermodel.PartitionStatus, error) {
 	return nil, nil
 }

--- a/tasks/actorstate/power.go
+++ b/tasks/actorstate/power.go
@@ -1,0 +1,73 @@
+package actorstate
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/model"
+	powermodel "github.com/filecoin-project/sentinel-visor/model/actors/power"
+)
+
+// was services/processor/tasks/power/power.go
+
+// StoragePowerExtracter extracts power actor state
+type StoragePowerExtracter struct{}
+
+func init() {
+	Register(builtin.StoragePowerActorCodeID, StoragePowerExtracter{})
+}
+
+func (StoragePowerExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	ctx, span := global.Tracer("").Start(ctx, "StoragePowerExtracter")
+	defer span.End()
+
+	powerActor, err := node.StateGetActor(ctx, builtin.StoragePowerActorAddr, a.TipSet)
+	if err != nil {
+		return nil, xerrors.Errorf("loading power actor: %w", err)
+	}
+
+	pstate, err := power.Load(node.Store(), powerActor)
+	if err != nil {
+		return nil, xerrors.Errorf("loading power actor state: %w", err)
+	}
+
+	locked, err := pstate.TotalLocked()
+	if err != nil {
+		return nil, err
+	}
+	pow, err := pstate.TotalPower()
+	if err != nil {
+		return nil, err
+	}
+	commit, err := pstate.TotalCommitted()
+	if err != nil {
+		return nil, err
+	}
+	smoothed, err := pstate.TotalPowerSmoothed()
+	if err != nil {
+		return nil, err
+	}
+	participating, total, err := pstate.MinerCounts()
+	if err != nil {
+		return nil, err
+	}
+
+	return &powermodel.ChainPower{
+		StateRoot:                  a.ParentStateRoot.String(),
+		TotalRawBytesPower:         pow.RawBytePower.String(),
+		TotalQABytesPower:          pow.QualityAdjPower.String(),
+		TotalRawBytesCommitted:     commit.RawBytePower.String(),
+		TotalQABytesCommitted:      commit.QualityAdjPower.String(),
+		TotalPledgeCollateral:      locked.String(),
+		QASmoothedPositionEstimate: smoothed.PositionEstimate.String(),
+		QASmoothedVelocityEstimate: smoothed.VelocityEstimate.String(),
+		MinerCount:                 total,
+		ParticipatingMinerCount:    participating,
+	}, nil
+}

--- a/tasks/actorstate/power.go
+++ b/tasks/actorstate/power.go
@@ -16,15 +16,15 @@ import (
 
 // was services/processor/tasks/power/power.go
 
-// StoragePowerExtracter extracts power actor state
-type StoragePowerExtracter struct{}
+// StoragePowerExtractor extracts power actor state
+type StoragePowerExtractor struct{}
 
 func init() {
-	Register(builtin.StoragePowerActorCodeID, StoragePowerExtracter{})
+	Register(builtin.StoragePowerActorCodeID, StoragePowerExtractor{})
 }
 
-func (StoragePowerExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
-	ctx, span := global.Tracer("").Start(ctx, "StoragePowerExtracter")
+func (StoragePowerExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	ctx, span := global.Tracer("").Start(ctx, "StoragePowerExtractor")
 	defer span.End()
 
 	powerActor, err := node.StateGetActor(ctx, builtin.StoragePowerActorAddr, a.TipSet)

--- a/tasks/actorstate/reward.go
+++ b/tasks/actorstate/reward.go
@@ -1,0 +1,51 @@
+package actorstate
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
+	"go.opentelemetry.io/otel/api/global"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/model"
+	rewardmodel "github.com/filecoin-project/sentinel-visor/model/actors/reward"
+)
+
+// was services/processor/tasks/reward/reward.go
+
+// RewardExtracter extracts reward actor state
+type RewardExtracter struct{}
+
+func init() {
+	Register(builtin.RewardActorCodeID, RewardExtracter{})
+}
+
+func (RewardExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	ctx, span := global.Tracer("").Start(ctx, "RewardExtracter")
+	defer span.End()
+
+	rewardStateRaw, err := node.ChainReadObj(ctx, a.Actor.Head)
+	if err != nil {
+		return nil, err
+	}
+
+	var rwdState reward.State
+	if err := rwdState.UnmarshalCBOR(bytes.NewReader(rewardStateRaw)); err != nil {
+		return nil, err
+	}
+
+	return &rewardmodel.ChainReward{
+		StateRoot:                         a.ParentStateRoot.String(),
+		CumSumBaseline:                    rwdState.CumsumBaseline.String(),
+		CumSumRealized:                    rwdState.CumsumRealized.String(),
+		EffectiveBaselinePower:            rwdState.EffectiveBaselinePower.String(),
+		NewBaselinePower:                  rwdState.ThisEpochBaselinePower.String(),
+		NewRewardSmoothedPositionEstimate: rwdState.ThisEpochRewardSmoothed.PositionEstimate.String(),
+		NewRewardSmoothedVelocityEstimate: rwdState.ThisEpochRewardSmoothed.VelocityEstimate.String(),
+		TotalMinedReward:                  rwdState.TotalMined.String(),
+		NewReward:                         rwdState.ThisEpochReward.String(),
+		EffectiveNetworkTime:              int64(rwdState.EffectiveNetworkTime),
+	}, nil
+}

--- a/tasks/actorstate/reward.go
+++ b/tasks/actorstate/reward.go
@@ -15,15 +15,15 @@ import (
 
 // was services/processor/tasks/reward/reward.go
 
-// RewardExtracter extracts reward actor state
-type RewardExtracter struct{}
+// RewardExtractor extracts reward actor state
+type RewardExtractor struct{}
 
 func init() {
-	Register(builtin.RewardActorCodeID, RewardExtracter{})
+	Register(builtin.RewardActorCodeID, RewardExtractor{})
 }
 
-func (RewardExtracter) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
-	ctx, span := global.Tracer("").Start(ctx, "RewardExtracter")
+func (RewardExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+	ctx, span := global.Tracer("").Start(ctx, "RewardExtractor")
 	defer span.End()
 
 	rewardStateRaw, err := node.ChainReadObj(ctx, a.Actor.Head)

--- a/tasks/indexer/blockdata.go
+++ b/tasks/indexer/blockdata.go
@@ -1,0 +1,128 @@
+package indexer
+
+import (
+	"context"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/go-pg/pg/v10"
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/model/blocks"
+	"github.com/filecoin-project/sentinel-visor/model/visor"
+)
+
+func NewUnindexedBlockData() *UnindexedBlockData {
+	return &UnindexedBlockData{
+		has: make(map[types.TipSetKey]struct{}),
+	}
+}
+
+type UnindexedBlockData struct {
+	has map[types.TipSetKey]struct{}
+
+	blks              blocks.BlockHeaders
+	parents           blocks.BlockParents
+	drandEntries      blocks.DrandEntries
+	drandBlockEntries blocks.DrandBlockEntries
+	pstateChanges     visor.ProcessingStateChangeList
+	pmessages         visor.ProcessingMessageList
+}
+
+func (u *UnindexedBlockData) AddTipSet(ts *types.TipSet) {
+	u.MarkSeen(ts.Key())
+	u.pstateChanges = append(u.pstateChanges, visor.NewProcessingStateChange(ts))
+	u.pmessages = append(u.pmessages, visor.NewProcessingMessage(ts))
+	for _, header := range ts.Blocks() {
+		u.AddBlock(header)
+	}
+}
+
+func (u *UnindexedBlockData) AddBlock(bh *types.BlockHeader) {
+	u.blks = append(u.blks, blocks.NewBlockHeader(bh))
+	u.parents = append(u.parents, blocks.NewBlockParents(bh)...)
+	u.drandEntries = append(u.drandEntries, blocks.NewDrandEnties(bh)...)
+	u.drandBlockEntries = append(u.drandBlockEntries, blocks.NewDrandBlockEntries(bh)...)
+}
+
+func (u *UnindexedBlockData) Persist(ctx context.Context, db *pg.DB) error {
+	ctx, span := global.Tracer("").Start(ctx, "Indexer.PersistBlockData")
+	defer span.End()
+
+	return db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		grp, ctx := errgroup.WithContext(ctx)
+
+		grp.Go(func() error {
+			if err := u.blks.PersistWithTx(ctx, tx); err != nil {
+				return xerrors.Errorf("persist block headers: %w", err)
+			}
+			return nil
+		})
+
+		grp.Go(func() error {
+			if err := u.parents.PersistWithTx(ctx, tx); err != nil {
+				return xerrors.Errorf("persist block parents: %w", err)
+			}
+			return nil
+		})
+
+		grp.Go(func() error {
+			if err := u.drandEntries.PersistWithTx(ctx, tx); err != nil {
+				return xerrors.Errorf("persist drand entries: %w", err)
+			}
+			return nil
+		})
+
+		grp.Go(func() error {
+			if err := u.drandBlockEntries.PersistWithTx(ctx, tx); err != nil {
+				return xerrors.Errorf("persist drand block entries: %w", err)
+			}
+			return nil
+		})
+
+		grp.Go(func() error {
+			if err := u.pstateChanges.PersistWithTx(ctx, tx); err != nil {
+				return xerrors.Errorf("persist processing state changes: %w", err)
+			}
+			return nil
+		})
+
+		grp.Go(func() error {
+			if err := u.pmessages.PersistWithTx(ctx, tx); err != nil {
+				return xerrors.Errorf("persist processing messages: %w", err)
+			}
+			return nil
+		})
+
+		if err := grp.Wait(); err != nil {
+			log.Warnf("rolling back unindexed block data", "error", err)
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (u *UnindexedBlockData) Size() int {
+	return len(u.pstateChanges)
+}
+
+func (u *UnindexedBlockData) Seen(tsk types.TipSetKey) bool {
+	_, has := u.has[tsk]
+	return has
+}
+
+func (u *UnindexedBlockData) MarkSeen(tsk types.TipSetKey) {
+	u.has[tsk] = struct{}{}
+}
+
+// Reset clears the unindexed data but keeps the history of which cids have been seen.
+func (u *UnindexedBlockData) Reset() {
+	u.blks = u.blks[:0]
+	u.parents = u.parents[:0]
+	u.drandEntries = u.drandEntries[:0]
+	u.drandBlockEntries = u.drandBlockEntries[:0]
+	u.pstateChanges = u.pstateChanges[:0]
+	u.pmessages = u.pmessages[:0]
+}

--- a/tasks/indexer/chainheadindexer.go
+++ b/tasks/indexer/chainheadindexer.go
@@ -1,0 +1,88 @@
+package indexer
+
+import (
+	"context"
+
+	logging "github.com/ipfs/go-log/v2"
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	lotus_api "github.com/filecoin-project/lotus/api"
+	store "github.com/filecoin-project/lotus/chain/store"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/storage"
+)
+
+var log = logging.Logger("indexer")
+
+func NewChainHeadIndexer(d *storage.Database, node lens.API) *ChainHeadIndexer {
+	return &ChainHeadIndexer{
+		node:    node,
+		storage: d,
+	}
+}
+
+// ChainHeadIndexer is a task that indexes blocks by following the chain head.
+type ChainHeadIndexer struct {
+	node    lens.API
+	storage *storage.Database
+}
+
+// Run starts following the chain head and blocks until the context is done or
+// an error occurs.
+func (c *ChainHeadIndexer) Run(ctx context.Context) error {
+	log.Info("starting chain head indexer")
+	hc, err := c.node.ChainNotify(ctx)
+	if err != nil {
+		return xerrors.Errorf("chain notify: %w", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("stopping Indexer")
+			return nil
+		case headEvents, ok := <-hc:
+			if !ok {
+				log.Warn("ChainNotify channel closed, stopping Indexer")
+				return nil
+			}
+			if err := c.index(ctx, headEvents); err != nil {
+				return xerrors.Errorf("index: %w", err)
+			}
+		}
+	}
+}
+
+func (c *ChainHeadIndexer) index(ctx context.Context, headEvents []*lotus_api.HeadChange) error {
+	ctx, span := global.Tracer("").Start(ctx, "ChainHeadIndexer.index")
+	defer span.End()
+
+	data := NewUnindexedBlockData()
+
+	var height int64
+	for _, head := range headEvents {
+		log.Debugw("index", "event", head.Type)
+		switch head.Type {
+		case store.HCCurrent:
+			fallthrough
+		case store.HCApply:
+			data.AddTipSet(head.Val)
+			if int64(head.Val.Height()) > height {
+				height = int64(head.Val.Height())
+			}
+		case store.HCRevert:
+			// TODO
+		}
+	}
+
+	// persist the blocks to storage
+	log.Debugw("persisting batch", "count", data.Size(), "current_height", height)
+	if err := data.Persist(ctx, c.storage.DB); err != nil {
+		return xerrors.Errorf("persist: %w", err)
+	}
+
+	return nil
+
+}

--- a/tasks/indexer/chainheadindexer_test.go
+++ b/tasks/indexer/chainheadindexer_test.go
@@ -73,7 +73,7 @@ func TestChainHeadIndexer(t *testing.T) {
 
 	d := &storage.Database{DB: db}
 	t.Logf("initializing indexer")
-	idx := NewChainHeadIndexer(d, node)
+	idx := NewChainHeadIndexer(d, node, 0)
 
 	newHeads, err := node.ChainNotify(ctx)
 	require.NoError(t, err, "chain notify")

--- a/tasks/indexer/chainheadindexer_test.go
+++ b/tasks/indexer/chainheadindexer_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/sentinel-visor/model/blocks"
+	"github.com/filecoin-project/sentinel-visor/model/visor"
 	"github.com/filecoin-project/sentinel-visor/storage"
 	"github.com/filecoin-project/sentinel-visor/testutil"
 )
@@ -48,12 +49,12 @@ func (nodeWrapper) Store() adt.Store {
 	panic("not supported")
 }
 
-func TestIndex(t *testing.T) {
+func TestChainHeadIndexer(t *testing.T) {
 	if testing.Short() || !testutil.DatabaseAvailable() {
 		t.Skip("short testing requested or VISOR_TEST_DB not set")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
 	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
@@ -61,7 +62,7 @@ func TestIndex(t *testing.T) {
 	defer cleanup()
 
 	t.Logf("truncating database tables")
-	err = truncateBlockTables(db)
+	err = truncateBlockTables(t, db)
 	require.NoError(t, err, "truncating tables")
 
 	t.Logf("preparing chain")
@@ -70,43 +71,30 @@ func TestIndex(t *testing.T) {
 
 	apitest.MineUntilBlock(ctx, t, nodes[0], sn[0], nil)
 
-	head, err := node.ChainHead(ctx)
-	require.NoError(t, err, "chain head")
-
-	t.Logf("collecting chain blocks")
-	bhs, err := collectBlockHeaders(node, head)
-	require.NoError(t, err, "collect chain blocks")
-
-	cids := bhs.Cids()
-	rounds := bhs.Rounds()
-
 	d := &storage.Database{DB: db}
 	t.Logf("initializing indexer")
-	idx := NewIndexer(d, node)
-	err = idx.InitHandler(ctx)
-	require.NoError(t, err, "init handler")
+	idx := NewChainHeadIndexer(d, node)
 
 	newHeads, err := node.ChainNotify(ctx)
 	require.NoError(t, err, "chain notify")
 
 	t.Logf("indexing chain")
 	nh := <-newHeads
+
+	var bhs blockHeaderList
+	for _, head := range nh {
+		bhs = append(bhs, head.Val.Blocks()...)
+	}
+
+	cids := bhs.Cids()
+	rounds := bhs.Rounds()
+	chainHead, err := node.ChainHead(ctx)
+	require.NoError(t, err, "ChainHead")
+
+	tipSetKeys := []string{chainHead.Key().String()}
+
 	err = idx.index(ctx, nh)
 	require.NoError(t, err, "index")
-
-	t.Run("blocks_synced", func(t *testing.T) {
-		var count int
-		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM blocks_synced`)
-		require.NoError(t, err)
-		assert.Equal(t, len(cids), count)
-
-		var m *blocks.BlockSynced
-		for _, cid := range cids {
-			exists, err := db.Model(m).Where("cid = ?", cid).Exists()
-			require.NoError(t, err)
-			assert.True(t, exists, "cid: %s", cid)
-		}
-	})
 
 	t.Run("block_headers", func(t *testing.T) {
 		var count int
@@ -164,6 +152,34 @@ func TestIndex(t *testing.T) {
 		}
 	})
 
+	t.Run("visor_processing_statechanges", func(t *testing.T) {
+		var count int
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_statechanges`)
+		require.NoError(t, err)
+		assert.Equal(t, len(tipSetKeys), count)
+
+		var m *visor.ProcessingStateChange
+		for _, tsk := range tipSetKeys {
+			exists, err := db.Model(m).Where("tip_set = ?", tsk).Exists()
+			require.NoError(t, err)
+			assert.True(t, exists, "tsk: %s", tsk)
+		}
+	})
+
+	t.Run("visor_processing_messages", func(t *testing.T) {
+		var count int
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages`)
+		require.NoError(t, err)
+		assert.Equal(t, len(tipSetKeys), count)
+
+		var m *visor.ProcessingMessage
+		for _, tsk := range tipSetKeys {
+			exists, err := db.Model(m).Where("tip_set = ?", tsk).Exists()
+			require.NoError(t, err)
+			assert.True(t, exists, "tsk: %s", tsk)
+		}
+	})
+
 }
 
 type blockHeaderList []*types.BlockHeader
@@ -185,6 +201,21 @@ func (b blockHeaderList) Rounds() []uint64 {
 	}
 
 	return rounds
+}
+
+func collectTipSetKeys(n lens.API, ts *types.TipSet) ([]string, error) {
+	keys := []string{ts.Key().String()}
+
+	for ts.Height() > 0 {
+		parent, err := n.ChainGetTipSet(context.TODO(), ts.Parents())
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, parent.Key().String())
+		ts = parent
+	}
+
+	return keys, nil
 }
 
 // collectBlockHeaders walks the chain to collect blocks that should be indexed
@@ -212,26 +243,24 @@ func collectBlockHeaders(n lens.API, ts *types.TipSet) (blockHeaderList, error) 
 }
 
 // truncateBlockTables ensures the indexing tables are empty
-func truncateBlockTables(db *pg.DB) error {
-	if _, err := db.Exec(`TRUNCATE TABLE blocks_synced`); err != nil {
-		return err
-	}
+func truncateBlockTables(tb testing.TB, db *pg.DB) error {
+	_, err := db.Exec(`TRUNCATE TABLE block_headers`)
+	require.NoError(tb, err, "block_headers")
 
-	if _, err := db.Exec(`TRUNCATE TABLE block_headers`); err != nil {
-		return err
-	}
+	_, err = db.Exec(`TRUNCATE TABLE block_parents`)
+	require.NoError(tb, err, "block_parents")
 
-	if _, err := db.Exec(`TRUNCATE TABLE block_parents`); err != nil {
-		return err
-	}
+	_, err = db.Exec(`TRUNCATE TABLE drand_entries`)
+	require.NoError(tb, err, "drand_entries")
 
-	if _, err := db.Exec(`TRUNCATE TABLE drand_entries`); err != nil {
-		return err
-	}
+	_, err = db.Exec(`TRUNCATE TABLE drand_block_entries`)
+	require.NoError(tb, err, "drand_block_entries")
 
-	if _, err := db.Exec(`TRUNCATE TABLE drand_block_entries`); err != nil {
-		return err
-	}
+	_, err = db.Exec(`TRUNCATE TABLE visor_processing_statechanges`)
+	require.NoError(tb, err, "visor_processing_statechanges")
+
+	_, err = db.Exec(`TRUNCATE TABLE visor_processing_messages`)
+	require.NoError(tb, err, "visor_processing_messages")
 
 	return nil
 }

--- a/tasks/indexer/chainhistoryindexer.go
+++ b/tasks/indexer/chainhistoryindexer.go
@@ -131,7 +131,7 @@ func (c *ChainHistoryIndexer) mostRecentlySyncedBlockHeight(ctx context.Context)
 	ctx, span := global.Tracer("").Start(ctx, "ChainHistoryIndexer.mostRecentlySyncedBlockHeight")
 	defer span.End()
 
-	recent, err := c.storage.MostRecentSyncedBlock(ctx)
+	recent, err := c.storage.MostRecentAddedTipSet(ctx)
 	if err != nil {
 		if err == pg.ErrNoRows {
 			return 0, nil

--- a/tasks/indexer/chainhistoryindexer.go
+++ b/tasks/indexer/chainhistoryindexer.go
@@ -17,12 +17,9 @@ import (
 
 func NewChainHistoryIndexer(d *storage.Database, node lens.API) *ChainHistoryIndexer {
 	return &ChainHistoryIndexer{
-		node:    node,
-		storage: d,
-
-		// TODO base finality value on the spec: https://github.com/filecoin-project/specs-actors/pull/702
-		finality: 1400,
-
+		node:      node,
+		storage:   d,
+		finality:  900,
 		batchSize: 500,
 	}
 }
@@ -111,7 +108,7 @@ func (c *ChainHistoryIndexer) WalkChain(ctx context.Context, maxHeight int64) er
 		if ts.Height() == 0 {
 			continue
 		}
-
+		// TODO: LOOK FOR websocket connection closed ERROR and retry after a delay
 		pts, err := c.node.ChainGetTipSet(ctx, ts.Parents())
 		if err != nil {
 			return xerrors.Errorf("get tipset: %w", err)

--- a/tasks/indexer/chainhistoryindexer.go
+++ b/tasks/indexer/chainhistoryindexer.go
@@ -1,0 +1,143 @@
+package indexer
+
+import (
+	"container/list"
+	"context"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	pg "github.com/go-pg/pg/v10"
+	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/label"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/storage"
+)
+
+func NewChainHistoryIndexer(d *storage.Database, node lens.API) *ChainHistoryIndexer {
+	return &ChainHistoryIndexer{
+		node:    node,
+		storage: d,
+
+		// TODO base finality value on the spec: https://github.com/filecoin-project/specs-actors/pull/702
+		finality: 1400,
+
+		batchSize: 500,
+	}
+}
+
+// ChainHistoryIndexer is a task that indexes blocks by following the chain history.
+type ChainHistoryIndexer struct {
+	node      lens.API
+	storage   *storage.Database
+	finality  int // epochs after which chain state is considered final
+	batchSize int // number of blocks to persist in a batch
+}
+
+// Run starts walking the chain history and continues until the context is done or
+// the start of the chain is reached.
+func (c *ChainHistoryIndexer) Run(ctx context.Context) error {
+	height, err := c.mostRecentlySyncedBlockHeight(ctx)
+	if err != nil {
+		return xerrors.Errorf("get synced block height: %w", err)
+	}
+
+	if err := c.WalkChain(ctx, height); err != nil {
+		return xerrors.Errorf("collect blocks: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ChainHistoryIndexer) WalkChain(ctx context.Context, maxHeight int64) error {
+	ctx, span := global.Tracer("").Start(ctx, "ChainHistoryIndexer.WalkChain", trace.WithAttributes(label.Int64("height", maxHeight)))
+	defer span.End()
+
+	// get at most finality tipsets not exceeding maxHeight. These are blocks we have in the database but have not processed.
+	// Now we are going to walk down the chain from `head` until we have visited all blocks not in the database.
+	initialTipSets, err := c.storage.UnprocessedIndexedTipSets(ctx, int(maxHeight), c.finality)
+	if err != nil {
+		return xerrors.Errorf("get unprocessed blocks: %w", err)
+	}
+	log.Debugw("collect initial unprocessed tipsets", "count", len(initialTipSets))
+
+	// Data extracted from tipsets and block headers awaiting persistence
+	blockData := NewUnindexedBlockData()
+
+	// A queue of tipsets that are yet to be visited
+	toVisit := list.New()
+
+	// Mark all visited blocks from the database as already seen
+	for _, t := range initialTipSets {
+		tsk, err := t.TipSetKey()
+		if err != nil {
+			return xerrors.Errorf("decode tipsetkey: %w", err)
+		}
+		blockData.MarkSeen(tsk)
+	}
+
+	// walk backwards from head until we find a block that we have
+	head, err := c.node.ChainHead(ctx)
+	if err != nil {
+		return xerrors.Errorf("get chain head: %w", err)
+	}
+
+	toVisit.PushBack(head)
+
+	for toVisit.Len() > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		ts := toVisit.Remove(toVisit.Back()).(*types.TipSet)
+		if blockData.Seen(ts.Key()) {
+			continue
+		}
+
+		blockData.AddTipSet(ts)
+
+		if blockData.Size() >= c.batchSize {
+			log.Debugw("persisting batch", "count", blockData.Size(), "queued", toVisit.Len(), "current_height", ts.Height())
+			// persist the batch of blocks to storage
+			if err := blockData.Persist(ctx, c.storage.DB); err != nil {
+				return xerrors.Errorf("persist: %w", err)
+			}
+			blockData.Reset()
+		}
+
+		if ts.Height() == 0 {
+			continue
+		}
+
+		pts, err := c.node.ChainGetTipSet(ctx, ts.Parents())
+		if err != nil {
+			return xerrors.Errorf("get tipset: %w", err)
+		}
+
+		toVisit.PushBack(pts)
+	}
+
+	log.Debugw("persisting final batch", "count", blockData.Size(), "toVisit", toVisit.Len())
+	if err := blockData.Persist(ctx, c.storage.DB); err != nil {
+		return xerrors.Errorf("persist: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ChainHistoryIndexer) mostRecentlySyncedBlockHeight(ctx context.Context) (int64, error) {
+	ctx, span := global.Tracer("").Start(ctx, "ChainHistoryIndexer.mostRecentlySyncedBlockHeight")
+	defer span.End()
+
+	recent, err := c.storage.MostRecentSyncedBlock(ctx)
+	if err != nil {
+		if err == pg.ErrNoRows {
+			return 0, nil
+		}
+		return 0, xerrors.Errorf("query recent synced: %w", err)
+	}
+	return recent.Height, nil
+}

--- a/tasks/indexer/chainhistoryindexer.go
+++ b/tasks/indexer/chainhistoryindexer.go
@@ -82,6 +82,8 @@ func (c *ChainHistoryIndexer) WalkChain(ctx context.Context, maxHeight int64) er
 
 	toVisit.PushBack(head)
 
+	// TODO: revisit this loop which was designed to collect blocks but could now be a lot simpler since we are
+	// just walking the chain
 	for toVisit.Len() > 0 {
 		select {
 		case <-ctx.Done():
@@ -108,7 +110,7 @@ func (c *ChainHistoryIndexer) WalkChain(ctx context.Context, maxHeight int64) er
 		if ts.Height() == 0 {
 			continue
 		}
-		// TODO: LOOK FOR websocket connection closed ERROR and retry after a delay
+		// TODO: Look for websocket connection closed error and retry after a delay to avoid hot loop
 		pts, err := c.node.ChainGetTipSet(ctx, ts.Parents())
 		if err != nil {
 			return xerrors.Errorf("get tipset: %w", err)

--- a/tasks/indexer/tipset.go
+++ b/tasks/indexer/tipset.go
@@ -68,7 +68,10 @@ func (c *TipSetCache) Add(ts *types.TipSet) (*types.TipSet, error) {
 	c.buffer[c.idxHead] = ts
 	if c.len < len(c.buffer) {
 		c.len++
+		return nil, nil
 	}
+
+	// Return old tipset that was displaced
 	return old, nil
 }
 
@@ -79,10 +82,11 @@ func (c *TipSetCache) Revert(ts *types.TipSet) error {
 	}
 
 	// Can only revert the most recent tipset
-	if c.buffer[c.idxHead] != ts {
+	if c.buffer[c.idxHead].Key() != ts.Key() {
 		return ErrRevertOutOfOrder
 	}
 
+	c.buffer[c.idxHead] = nil
 	c.idxHead = normalModulo(c.idxHead-1, len(c.buffer))
 	c.len--
 

--- a/tasks/indexer/tipset.go
+++ b/tasks/indexer/tipset.go
@@ -1,0 +1,108 @@
+package indexer
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+var _ = fmt.Printf
+
+var ErrCacheEmpty = errors.New("cache empty")
+var ErrAddOutOfOrder = errors.New("added tipset height lower than current head")
+var ErrRevertOutOfOrder = errors.New("reverted tipset does not match current head")
+
+// TipSetCache is a cache of recent tipsets that can keep track of reversions.
+// Inspired by tipSetCache in Lotus chain/events package.
+type TipSetCache struct {
+	buffer  []*types.TipSet
+	idxHead int // idxHead is the current position of the head tipset in the buffer
+	len     int // len is the number of items in the cache
+}
+
+func NewTipSetCache(size int) *TipSetCache {
+	return &TipSetCache{
+		buffer: make([]*types.TipSet, size),
+	}
+}
+
+// Head returns the tipset at the head of the cache.
+func (c *TipSetCache) Head() (*types.TipSet, error) {
+	if c.len == 0 {
+		return nil, ErrCacheEmpty
+	}
+	return c.buffer[c.idxHead], nil
+}
+
+// Tail returns the tipset at the tail of the cache.
+func (c *TipSetCache) Tail() (*types.TipSet, error) {
+	if c.len == 0 {
+		return nil, ErrCacheEmpty
+	}
+	idxTail := normalModulo(c.idxHead-c.len+1, len(c.buffer))
+	return c.buffer[idxTail], nil
+}
+
+// Add adds a new tipset which becomes the new head of the cache. If the buffer is full, the tail
+// being evicted is also returned.
+func (c *TipSetCache) Add(ts *types.TipSet) (*types.TipSet, error) {
+	if c.len == 0 {
+		// Special case for zero length caches, simply pass back the added tipset
+		if len(c.buffer) == 0 {
+			return ts, nil
+		}
+
+		c.buffer[c.idxHead] = ts
+		c.len++
+		return nil, nil
+	}
+
+	headHeight := c.buffer[c.idxHead].Height()
+	if headHeight >= ts.Height() {
+		return nil, ErrAddOutOfOrder
+	}
+
+	c.idxHead = normalModulo(c.idxHead+1, len(c.buffer))
+	old := c.buffer[c.idxHead]
+	c.buffer[c.idxHead] = ts
+	if c.len < len(c.buffer) {
+		c.len++
+	}
+	return old, nil
+}
+
+// Revert removes the head tipset
+func (c *TipSetCache) Revert(ts *types.TipSet) error {
+	if c.len == 0 {
+		return nil
+	}
+
+	// Can only revert the most recent tipset
+	if c.buffer[c.idxHead] != ts {
+		return ErrRevertOutOfOrder
+	}
+
+	c.idxHead = normalModulo(c.idxHead-1, len(c.buffer))
+	c.len--
+
+	return nil
+}
+
+// Len returns the number of tipsets in the cache. This will never exceed the size of the cache.
+func (c *TipSetCache) Len() int {
+	return c.len
+}
+
+// Reset removes all tipsets from the cache
+func (c *TipSetCache) Reset() {
+	for i := range c.buffer {
+		c.buffer[i] = nil
+	}
+	c.idxHead = 0
+	c.len = 0
+}
+
+func normalModulo(n, m int) int {
+	return ((n % m) + m) % m
+}

--- a/tasks/indexer/tipset_test.go
+++ b/tasks/indexer/tipset_test.go
@@ -425,6 +425,39 @@ func TestTipSetCacheSetCurrent(t *testing.T) {
 
 }
 
+func TestTipSetCacheAddOnlyReturnsOldTailWhenFull(t *testing.T) {
+	c := NewTipSetCache(3)
+	ts14 := mustMakeTs(nil, 14, dummyCid)
+	oldTail, err := c.Add(ts14)
+	require.NoError(t, err)
+	assert.Nil(t, oldTail)
+
+	ts15 := mustMakeTs(nil, 15, dummyCid)
+	oldTail, err = c.Add(ts15)
+	require.NoError(t, err)
+	assert.Nil(t, oldTail)
+
+	ts15Revert := mustMakeTs(nil, 15, dummyCid)
+	err = c.Revert(ts15Revert)
+	require.NoError(t, err)
+
+	ts15New := mustMakeTs(nil, 15, dummyCid)
+	oldTail, err = c.Add(ts15New)
+	require.NoError(t, err)
+	assert.Nil(t, oldTail) // must be nil since cache is not full
+
+	ts16 := mustMakeTs(nil, 16, dummyCid)
+	oldTail, err = c.Add(ts16)
+	require.NoError(t, err)
+	assert.Nil(t, oldTail)
+
+	ts17 := mustMakeTs(nil, 17, dummyCid)
+	oldTail, err = c.Add(ts17)
+	require.NoError(t, err)
+	assert.Same(t, oldTail, ts14) // cache is now full so oldest is evicted
+
+}
+
 func mustMakeTs(parents []cid.Cid, h abi.ChainEpoch, msgcid cid.Cid) *types.TipSet {
 	a, _ := address.NewFromString("t00")
 	b, _ := address.NewFromString("t02")

--- a/tasks/indexer/tipset_test.go
+++ b/tasks/indexer/tipset_test.go
@@ -1,0 +1,341 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var dummyCid cid.Cid
+var dummyTs *types.TipSet
+
+func init() {
+	dummyCid, _ = cid.Parse("bafkqaaa")
+	dummyTs = mustMakeTs(nil, 1, dummyCid)
+}
+
+func TestTipSetCacheInvariants(t *testing.T) {
+
+	t.Run("empty cache", func(t *testing.T) {
+		c := NewTipSetCache(3)
+		ts, err := c.Head()
+		assert.Error(t, err, ErrCacheEmpty)
+		assert.Nil(t, ts)
+
+		ts, err = c.Tail()
+		assert.Error(t, err, ErrCacheEmpty)
+		assert.Nil(t, ts)
+
+		err = c.Revert(dummyTs)
+		assert.NoError(t, err)
+
+		oldTail, err := c.Add(dummyTs)
+		assert.NoError(t, err)
+		assert.Nil(t, oldTail)
+
+		assert.Equal(t, 1, c.Len())
+
+	})
+
+	t.Run("reset empties cache", func(t *testing.T) {
+		c := NewTipSetCache(3)
+
+		_, err := c.Add(dummyTs)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, c.Len())
+
+		c.Reset()
+		assert.Equal(t, 0, c.Len())
+
+		ts, err := c.Head()
+		assert.Error(t, err, ErrCacheEmpty)
+		assert.Nil(t, ts)
+
+		ts, err = c.Tail()
+		assert.Error(t, err, ErrCacheEmpty)
+		assert.Nil(t, ts)
+
+		err = c.Revert(dummyTs)
+		assert.NoError(t, err)
+
+		_, err = c.Add(dummyTs)
+		assert.NoError(t, err)
+
+	})
+
+	t.Run("head returns last added", func(t *testing.T) {
+		c := NewTipSetCache(3)
+		ts1 := mustMakeTs(nil, 1, dummyCid)
+		_, err := c.Add(ts1)
+		require.NoError(t, err)
+
+		head, err := c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts1, head)
+
+		ts2 := mustMakeTs(nil, 2, dummyCid)
+		_, err = c.Add(ts2)
+		require.NoError(t, err)
+
+		head, err = c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts2, head)
+	})
+
+	t.Run("tail returns first added", func(t *testing.T) {
+		c := NewTipSetCache(3)
+		ts1 := mustMakeTs(nil, 1, dummyCid)
+		_, err := c.Add(ts1)
+		require.NoError(t, err)
+
+		tail, err := c.Tail()
+		require.NoError(t, err)
+		assert.Same(t, ts1, tail)
+
+		ts2 := mustMakeTs(nil, 2, dummyCid)
+		_, err = c.Add(ts2)
+		require.NoError(t, err)
+
+		tail, err = c.Tail()
+		require.NoError(t, err)
+		assert.Same(t, ts1, tail)
+	})
+
+	t.Run("length is capped by size", func(t *testing.T) {
+		c := NewTipSetCache(3)
+		ts1 := mustMakeTs(nil, 1, dummyCid)
+		_, err := c.Add(ts1)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, c.Len())
+
+		ts2 := mustMakeTs(nil, 2, dummyCid)
+		_, err = c.Add(ts2)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, c.Len())
+
+		ts3 := mustMakeTs(nil, 3, dummyCid)
+		_, err = c.Add(ts3)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, c.Len())
+
+		ts4 := mustMakeTs(nil, 4, dummyCid)
+		_, err = c.Add(ts4)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, c.Len())
+	})
+
+	t.Run("buffer is a ring", func(t *testing.T) {
+		c := NewTipSetCache(3)
+
+		// Add first
+		ts1 := mustMakeTs(nil, 1, dummyCid)
+		oldTail1, err := c.Add(ts1)
+		require.NoError(t, err)
+		assert.Nil(t, oldTail1)
+
+		head, err := c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts1, head)
+
+		tail, err := c.Tail()
+		require.NoError(t, err)
+		assert.Same(t, ts1, tail)
+
+		// Add second
+		ts2 := mustMakeTs(nil, 2, dummyCid)
+		oldTail2, err := c.Add(ts2)
+		require.NoError(t, err)
+		assert.Nil(t, oldTail2)
+
+		head, err = c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts2, head)
+
+		tail, err = c.Tail()
+		require.NoError(t, err)
+		assert.Same(t, ts1, tail)
+
+		// Add third (buffer is at capacity)
+		ts3 := mustMakeTs(nil, 3, dummyCid)
+		oldTail3, err := c.Add(ts3)
+		require.NoError(t, err)
+		assert.Nil(t, oldTail3)
+
+		head, err = c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts3, head)
+
+		tail, err = c.Tail()
+		require.NoError(t, err)
+		assert.Same(t, ts1, tail)
+
+		// Add fourth (bumps ts1 out of the buffer which is returned)
+		ts4 := mustMakeTs(nil, 4, dummyCid)
+		oldTail4, err := c.Add(ts4)
+		require.NoError(t, err)
+		assert.Same(t, ts1, oldTail4)
+
+		head, err = c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts4, head)
+
+		tail, err = c.Tail()
+		require.NoError(t, err)
+		assert.Same(t, ts2, tail)
+	})
+
+	t.Run("revert moves head back", func(t *testing.T) {
+		c := NewTipSetCache(3)
+		ts1 := mustMakeTs(nil, 1, dummyCid)
+		_, err := c.Add(ts1)
+		require.NoError(t, err)
+
+		head, err := c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts1, head)
+
+		ts2 := mustMakeTs(nil, 2, dummyCid)
+		_, err = c.Add(ts2)
+		require.NoError(t, err)
+
+		head, err = c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts2, head)
+
+		err = c.Revert(ts2)
+		require.NoError(t, err)
+
+		head, err = c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts1, head)
+
+	})
+
+	t.Run("revert ring", func(t *testing.T) {
+		c := NewTipSetCache(3)
+		ts1 := mustMakeTs(nil, 1, dummyCid)
+		_, err := c.Add(ts1)
+		require.NoError(t, err)
+
+		ts2 := mustMakeTs(nil, 2, dummyCid)
+		_, err = c.Add(ts2)
+		require.NoError(t, err)
+
+		ts3 := mustMakeTs(nil, 3, dummyCid)
+		_, err = c.Add(ts3)
+		require.NoError(t, err)
+
+		ts4 := mustMakeTs(nil, 4, dummyCid)
+		_, err = c.Add(ts4)
+		require.NoError(t, err)
+
+		err = c.Revert(ts4)
+		require.NoError(t, err)
+
+		head, err := c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts3, head)
+
+	})
+
+	t.Run("zero sized cache", func(t *testing.T) {
+		c := NewTipSetCache(0)
+
+		ts1 := mustMakeTs(nil, 1, dummyCid)
+		oldTail1, err := c.Add(ts1)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, c.Len())
+		assert.Same(t, ts1, oldTail1)
+
+		ts, err := c.Head()
+		assert.Error(t, err, ErrCacheEmpty)
+		assert.Nil(t, ts)
+
+		ts, err = c.Tail()
+		assert.Error(t, err, ErrCacheEmpty)
+		assert.Nil(t, ts)
+
+		err = c.Revert(dummyTs)
+		assert.NoError(t, err)
+
+	})
+
+}
+
+func TestTipSetCacheAddOutOfOrder(t *testing.T) {
+	c := NewTipSetCache(3)
+	ts14 := mustMakeTs(nil, 14, dummyCid)
+	_, err := c.Add(ts14)
+	require.NoError(t, err)
+
+	ts15 := mustMakeTs(nil, 15, dummyCid)
+	_, err = c.Add(ts15)
+	require.NoError(t, err)
+
+	ts13 := mustMakeTs(nil, 13, dummyCid)
+	_, err = c.Add(ts13)
+	require.Error(t, err, ErrAddOutOfOrder)
+}
+
+func TestTipSetCacheRevertOutOfOrder(t *testing.T) {
+	c := NewTipSetCache(3)
+	ts14 := mustMakeTs(nil, 14, dummyCid)
+	_, err := c.Add(ts14)
+	require.NoError(t, err)
+
+	ts15 := mustMakeTs(nil, 15, dummyCid)
+	_, err = c.Add(ts15)
+	require.NoError(t, err)
+
+	err = c.Revert(ts14)
+	require.Error(t, err, ErrRevertOutOfOrder)
+}
+
+func mustMakeTs(parents []cid.Cid, h abi.ChainEpoch, msgcid cid.Cid) *types.TipSet {
+	a, _ := address.NewFromString("t00")
+	b, _ := address.NewFromString("t02")
+	ts, err := types.NewTipSet([]*types.BlockHeader{
+		{
+			Height: h,
+			Miner:  a,
+
+			Parents: parents,
+
+			Ticket: &types.Ticket{VRFProof: []byte{byte(h % 2)}},
+
+			ParentStateRoot:       dummyCid,
+			Messages:              msgcid,
+			ParentMessageReceipts: dummyCid,
+
+			BlockSig:     &crypto.Signature{Type: crypto.SigTypeBLS},
+			BLSAggregate: &crypto.Signature{Type: crypto.SigTypeBLS},
+		},
+		{
+			Height: h,
+			Miner:  b,
+
+			Parents: parents,
+
+			Ticket: &types.Ticket{VRFProof: []byte{byte((h + 1) % 2)}},
+
+			ParentStateRoot:       dummyCid,
+			Messages:              msgcid,
+			ParentMessageReceipts: dummyCid,
+
+			BlockSig:     &crypto.Signature{Type: crypto.SigTypeBLS},
+			BLSAggregate: &crypto.Signature{Type: crypto.SigTypeBLS},
+		},
+	})
+
+	if err != nil {
+		panic("mustMakeTs: " + err.Error())
+	}
+
+	return ts
+}

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -1,0 +1,246 @@
+package message
+
+import (
+	"context"
+	"time"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	messagemodel "github.com/filecoin-project/sentinel-visor/model/messages"
+	"github.com/filecoin-project/sentinel-visor/model/visor"
+	"github.com/filecoin-project/sentinel-visor/storage"
+	"github.com/filecoin-project/sentinel-visor/wait"
+)
+
+const idleSleepInterval = 60 * time.Second   // time to wait if the processor runs out of blocks to process
+const batchInterval = 100 * time.Millisecond // time to wait between batches
+
+var log = logging.Logger("message")
+
+var timeNow = time.Now
+
+func NewMessageProcessor(d *storage.Database, node lens.API, leaseLength time.Duration, batchSize int, maxHeight int64) *MessageProcessor {
+	return &MessageProcessor{
+		node:        node,
+		storage:     d,
+		leaseLength: leaseLength,
+		batchSize:   batchSize,
+		maxHeight:   maxHeight,
+	}
+}
+
+// MessageProcessor is a task that processes blocks to detect messages and persists
+// their details to the database.
+type MessageProcessor struct {
+	node        lens.API
+	storage     *storage.Database
+	leaseLength time.Duration // length of time to lease work for
+	batchSize   int           // number of tipsets to lease in a batch
+	maxHeight   int64         // limit processing to tipsets equal to or below this height
+}
+
+// Run starts processing batches of tipsets and blocks until the context is done or
+// an error occurs.
+func (p *MessageProcessor) Run(ctx context.Context) error {
+	// Loop until context is done or processing encounters a fatal error
+	return wait.RepeatUntil(ctx, batchInterval, p.processBatch)
+}
+
+func (p *MessageProcessor) processBatch(ctx context.Context) (bool, error) {
+	ctx, span := global.Tracer("").Start(ctx, "MessageProcessor.processBatch")
+	defer span.End()
+
+	claimUntil := timeNow().Add(p.leaseLength)
+	ctx, cancel := context.WithDeadline(ctx, claimUntil)
+	defer cancel()
+
+	// Lease some blocks to work on
+	batch, err := p.storage.LeaseTipSetMessages(ctx, claimUntil, p.batchSize, p.maxHeight)
+	if err != nil {
+		return true, err
+	}
+
+	// If we have no tipsets to work on then wait before trying again
+	if len(batch) == 0 {
+		sleepInterval := wait.Jitter(idleSleepInterval, 2)
+		log.Infof("no tipsets to process, waiting for %s", sleepInterval)
+		time.Sleep(sleepInterval)
+		return false, nil
+	}
+
+	for _, item := range batch {
+		// Stop processing if we have somehow passed our own lease time
+		select {
+		case <-ctx.Done():
+			return false, nil // Don't propagate cancelation error so we can resume processing cleanly
+		default:
+		}
+
+		if err := p.processItem(ctx, item); err != nil {
+			log.Errorw("failed to process tipset", "error", err.Error(), "height", item.Height)
+			if err := p.storage.MarkTipSetMessagesComplete(ctx, item.TipSet, item.Height, timeNow(), err.Error()); err != nil {
+				log.Errorw("failed to mark tipset messages complete", "error", err.Error(), "height", item.Height)
+			}
+			continue
+		}
+
+		if err := p.storage.MarkTipSetMessagesComplete(ctx, item.TipSet, item.Height, timeNow(), ""); err != nil {
+			log.Errorw("failed to mark tipset message complete", "error", err.Error(), "height", item.Height)
+		}
+
+	}
+
+	return false, nil
+}
+
+func (p *MessageProcessor) processItem(ctx context.Context, item *visor.ProcessingMessage) error {
+	tsk, err := item.TipSetKey()
+	if err != nil {
+		return xerrors.Errorf("get tipsetkey: %w", err)
+	}
+
+	ts, err := p.node.ChainGetTipSet(ctx, tsk)
+	if err != nil {
+		return xerrors.Errorf("get tipset: %w", err)
+	}
+
+	if err := p.processTipSet(ctx, ts); err != nil {
+		return xerrors.Errorf("process tipset: %w", err)
+	}
+
+	return nil
+
+}
+
+func (p *MessageProcessor) processTipSet(ctx context.Context, ts *types.TipSet) error {
+	ctx, span := global.Tracer("").Start(ctx, "MessageProcessor.processTipSet")
+	defer span.End()
+
+	ll := log.With("height", int64(ts.Height()))
+
+	ll.Debugw("processing tipset")
+
+	msgs, blkMsgs, err := p.fetchMessages(ctx, ts)
+	if err != nil {
+		return xerrors.Errorf("fetch messages: %w", err)
+	}
+
+	rcts, err := p.fetchReceipts(ctx, ts)
+	if err != nil {
+		return xerrors.Errorf("fetch receipts: %w", err)
+	}
+
+	result := &messagemodel.MessageTaskResult{
+		Messages:      msgs,
+		BlockMessages: blkMsgs,
+		Receipts:      rcts,
+	}
+
+	ll.Debugw("persisting tipset", "messages", len(msgs), "block_messages", len(blkMsgs), "receipts", len(rcts))
+	if err := result.Persist(ctx, p.storage.DB); err != nil {
+		return xerrors.Errorf("persist: %w", err)
+	}
+
+	return nil
+}
+
+func (p *MessageProcessor) fetchMessages(ctx context.Context, ts *types.TipSet) (messagemodel.Messages, messagemodel.BlockMessages, error) {
+	msgs := messagemodel.Messages{}
+	bmsgs := messagemodel.BlockMessages{}
+	msgsSeen := map[cid.Cid]struct{}{}
+
+	// TODO consider performing this work in parallel.
+	for _, blk := range ts.Cids() {
+		// Stop processing if we have somehow passed our own lease time
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		default:
+		}
+
+		blkMsgs, err := p.node.ChainGetBlockMessages(ctx, blk)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		vmm := make([]*types.Message, 0, len(blkMsgs.Cids))
+		for _, m := range blkMsgs.BlsMessages {
+			vmm = append(vmm, m)
+		}
+
+		for _, m := range blkMsgs.SecpkMessages {
+			vmm = append(vmm, &m.Message)
+		}
+
+		for _, message := range vmm {
+			bmsgs = append(bmsgs, &messagemodel.BlockMessage{
+				Block:   blk.String(),
+				Message: message.Cid().String(),
+			})
+
+			// so we don't create duplicate message models.
+			if _, seen := msgsSeen[message.Cid()]; seen {
+				continue
+			}
+
+			var msgSize int
+			if b, err := message.Serialize(); err == nil {
+				msgSize = len(b)
+			}
+			msgs = append(msgs, &messagemodel.Message{
+				Cid:        message.Cid().String(),
+				From:       message.From.String(),
+				To:         message.To.String(),
+				Value:      message.Value.String(),
+				GasFeeCap:  message.GasFeeCap.String(),
+				GasPremium: message.GasPremium.String(),
+				GasLimit:   message.GasLimit,
+				SizeBytes:  msgSize,
+				Nonce:      message.Nonce,
+				Method:     uint64(message.Method),
+				Params:     message.Params,
+			})
+			msgsSeen[message.Cid()] = struct{}{}
+		}
+	}
+	return msgs, bmsgs, nil
+}
+
+func (p *MessageProcessor) fetchReceipts(ctx context.Context, ts *types.TipSet) (messagemodel.Receipts, error) {
+	out := messagemodel.Receipts{}
+
+	for _, blk := range ts.Cids() {
+		// Stop processing if we have somehow passed our own lease time
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		recs, err := p.node.ChainGetParentReceipts(ctx, blk)
+		if err != nil {
+			return nil, err
+		}
+		msgs, err := p.node.ChainGetParentMessages(ctx, blk)
+		if err != nil {
+			return nil, err
+		}
+
+		for i, r := range recs {
+			out = append(out, &messagemodel.Receipt{
+				Message:   msgs[i].Cid.String(),
+				StateRoot: ts.ParentState().String(),
+				Idx:       i,
+				ExitCode:  int64(r.ExitCode),
+				GasUsed:   r.GasUsed,
+				Return:    r.Return,
+			})
+		}
+	}
+	return out, nil
+}

--- a/testutil/db.go
+++ b/testutil/db.go
@@ -1,7 +1,16 @@
 package testutil
 
 import (
+	"context"
 	"os"
+	"testing"
+	"time"
+
+	"github.com/go-pg/pg/v10"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/wait"
 )
 
 var testDatabase = os.Getenv("VISOR_TEST_DB")
@@ -14,4 +23,64 @@ func DatabaseAvailable() bool {
 // Database returns the connection string for connecting to the test database
 func Database() string {
 	return testDatabase
+}
+
+// WaitForExclusiveDatabase waits for exclusive access to the test database until the context is done or the
+// exclusive access is granted. It returns a cleanup function that should be called to close the database connection.
+func WaitForExclusiveDatabase(ctx context.Context, tb testing.TB) (*pg.DB, func() error, error) {
+	require.NotEmpty(tb, testDatabase, "set VISOR_TEST_DB")
+
+	opt, err := pg.ParseURL(testDatabase)
+	require.NoError(tb, err)
+
+	db := pg.Connect(opt)
+	db = db.WithContext(ctx)
+
+	release, err := WaitForExclusiveDatabaseLock(ctx, db)
+	if err != nil {
+		db.Close()
+		tb.Fatalf("failed to get exclusive database access: %v", err)
+	}
+
+	cleanup := func() error {
+		release()
+		return db.Close()
+	}
+
+	return db, cleanup, nil
+}
+
+const testDatabaseLockID = 88899888
+const testDatabaseLockCheckInterval = 2 * time.Millisecond
+
+// WaitForExclusiveDatabaseLock waits for a an exclusive lock on the test database until the context is done or the
+// exclusive access is granted. It returns a cleanup function that should be called to release the exclusive lock. In any
+// case the lock will be automatically released when the database session ends.
+func WaitForExclusiveDatabaseLock(ctx context.Context, db *pg.DB) (func() error, error) {
+	err := wait.RepeatUntil(ctx, testDatabaseLockCheckInterval, tryTestDatabaseLock(ctx, db))
+	if err != nil {
+		return nil, err
+	}
+
+	release := func() error {
+		var released bool
+		_, err := db.QueryOneContext(ctx, pg.Scan(&released), `SELECT pg_advisory_unlock(?);`, int64(testDatabaseLockID))
+		if err != nil {
+			return xerrors.Errorf("unlocking exclusive lock: %w", err)
+		}
+		if !released {
+			return xerrors.Errorf("exclusive lock not released")
+		}
+		return nil
+	}
+
+	return release, nil
+}
+
+func tryTestDatabaseLock(ctx context.Context, db *pg.DB) func(context.Context) (bool, error) {
+	return func(context.Context) (bool, error) {
+		var acquired bool
+		_, err := db.QueryOneContext(ctx, pg.Scan(&acquired), `SELECT pg_try_advisory_lock(?);`, int64(testDatabaseLockID))
+		return acquired, err
+	}
 }

--- a/testutil/time.go
+++ b/testutil/time.go
@@ -1,0 +1,13 @@
+package testutil
+
+import (
+	"time"
+)
+
+// Some time functions used for working with fixed times.
+
+var KnownTime = time.Unix(1601378000, 0).UTC()
+
+func KnownTimeNow() time.Time {
+	return KnownTime
+}

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -1,0 +1,90 @@
+package wait
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+// A CheckFunc returns true when the check has been passed and false if it has not.
+type CheckFunc func(context.Context) (bool, error)
+
+// RepeatUntil runs c every period until the context is done, c returns an error or c returns true to indicate completion.
+func RepeatUntil(ctx context.Context, period time.Duration, c CheckFunc) error {
+	timer := time.NewTimer(period)
+
+	defer func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Perform the check
+		done, err := c(ctx)
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+
+		// Shortcut the timer if there is no wait period
+		if period == 0 {
+			continue
+		}
+
+		// Wait for the next check
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(period)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// Until runs f until the context is done or f returns.
+func Until(ctx context.Context, f func(context.Context) error) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errch := make(chan error, 1)
+
+	go func() {
+		errch <- f(ctx)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errch:
+		return err
+	}
+}
+
+// Jitter returns a random duration ranging from base to base+base*factor
+func Jitter(base time.Duration, factor float64) time.Duration {
+	return base + time.Duration(float64(base)*factor*rand.Float64())
+}
+
+// SleepWithJitter sleeps for a random duration ranging from base to base+base*factor
+func SleepWithJitter(base time.Duration, factor float64) {
+	time.Sleep(Jitter(base, factor))
+}


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/sentinel/issues/153

This is a major refactoring of the scheduling system for Visor tasks. This is the additive change, a subsequent
commit will remove the old scheduler code including redis.

A new Scheduler type is added that runs a set of Tasks, restarting them when they fail. Concurrency levels can
be managed by adding more or less tasks of a specific type. Each task runs in a single goroutine, usually in
a loop to process work in batches. 

New tasks added (in tasks package):

 - ChainHeadIndexer - follows the chain head recording new tipsets
 - ChainHistoryIndexer - walks the chain history recording historic tipsets
 - ActorStateChangeProcessor - processes tipsets to extract actor state changes
 - ActorStateProcessor - processes actor state changes found by the ActorStateChangeProcessor
 - MessageProcessor - processes tipsets to extract messages

The postgres database is used as a global coordination point. ChainHeadIndexer and ChainHistoryIndexer write
newly discovered tipsets to the visor_processing_statechanges and visor_processing_messages tables. The
ActorStateChangeProcessor and MessageProcessor tasks lease tipsets from these tables in a batch to process.
The ActorStateChangeProcessor writes actor information to the visor_processing_actors table which 
the ActorStateProcessor task uses to determine which actors require processing.

Tasks may be marked as global singletons by using a GlobalLock when registering with the Scheduler. The
GlobalLock takes an exclusive advisory lock in postgres for the duration of the session which ensures that
only one task of that type may run anywhere. The ChainHeadIndexer and ChainHistoryIndexer tasks are expected
to be global singletons.

A new cli subcommand called run is added which instantiates the new scheduler with a sample number of each type
of task. This is suitable for testing but further configuration of task arrangement and concurrency needs to
be added in the future. The index and process subcommands will be changed to use the new scheduler in a later
change.

