### PR TITLE
convert json to jsonb actor_states table

### DIFF
--- a/storage/migrations/2_visor_initial.go
+++ b/storage/migrations/2_visor_initial.go
@@ -12,6 +12,8 @@ func init() {
 ALTER TABLE public.actors RENAME COLUMN stateroot TO state_root;
 ALTER TABLE public.actors ALTER nonce type bigint;
 
+ALTER TABLE public.actor_states ALTER COLUMN state SET DATA TYPE jsonb using state::JSONB;
+
 ALTER TABLE public.blocks RENAME TO block_headers;
 ALTER TABLE public.block_headers RENAME COLUMN forksig TO fork_signaling;
 ALTER TABLE public.block_headers RENAME COLUMN parentstateroot TO parent_state_root;


### PR DESCRIPTION
The issue I hit that required this fix is that with a brand new database running the following fails:
```
$ env LOTUS_DB='postgres://postgres:password@127.0.0.1:5432/postgres?sslmode=disable' ./visor --allow-schema-migration index 15:45
2020-10-01T15:46:15.848+1000	INFO	visor/lens/lotus	lotus/lotus.go:54	Lotus API version: 0.8.0+git.2c1d96bca
2020-10-01T15:46:15.853+1000	INFO	visor	commands/setup.go:58	connect database: database schema is too old and requires migration
2020-10-01T15:46:15.853+1000	INFO	visor	commands/setup.go:61	Migrating schema to latest version
2020-10-01T15:46:15.857+1000	INFO	storage	storage/migrate.go:68	current database schema is version 0
2020-10-01T15:46:15.857+1000	INFO	storage	storage/migrate.go:88	running schema migration from version 0 to version 3
2020-10-01T15:46:19.722+1000	INFO	storage	storage/migrate.go:93	current database schema is now version 3
2020-10-01T15:46:19.951+1000	ERROR	storage	storage/sql.go:241	verify schema: column actor_states.state had datatype json, expected jsonb
2020-10-01T15:46:19.956+1000	FATAL	visor	sentinel-visor/main.go:101	verify schema: database schema was not compatible with current models
```