### PR TITLE
feat: compute gas outputs

### DIFF
--- a/commands/setup.go
+++ b/commands/setup.go
@@ -156,8 +156,8 @@ func setupLogging(cctx *cli.Context) error {
 }
 
 const (
-	ChainHeadIndexerLockID    = 9898981111
-	ChainHistoryIndexerLockID = 9898981112
+	ChainHeadIndexerLockID    = 98981111
+	ChainHistoryIndexerLockID = 98981112
 )
 
 func NewGlobalSingleton(id int64, d *storage.Database) *GlobalSingleton {

--- a/lens/interface.go
+++ b/lens/interface.go
@@ -1,11 +1,14 @@
 package lens
 
 import (
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 )
 
 type API interface {
 	Store() adt.Store
 	api.FullNode
+	ComputeGasOutputs(gasUsed, gasLimit int64, baseFee, feeCap, gasPremium abi.TokenAmount) vm.GasOutputs
 }

--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/api"
 	miner "github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/sentinel-visor/lens"
@@ -122,4 +124,8 @@ func (aw *APIWrapper) StateReadState(ctx context.Context, actor address.Address,
 	ctx, span := global.Tracer("").Start(ctx, "Lotus.StateReadState")
 	defer span.End()
 	return aw.FullNode.StateReadState(ctx, actor, tsk)
+}
+
+func (aw *APIWrapper) ComputeGasOutputs(gasUsed, gasLimit int64, baseFee, feeCap, gasPremium abi.TokenAmount) vm.GasOutputs {
+	return vm.ComputeGasOutputs(gasUsed, gasLimit, baseFee, feeCap, gasPremium)
 }

--- a/model/derived/gasoutputs.go
+++ b/model/derived/gasoutputs.go
@@ -1,0 +1,64 @@
+package derived
+
+import (
+	"context"
+
+	"github.com/go-pg/pg/v10"
+	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/label"
+	"golang.org/x/xerrors"
+)
+
+type GasOutputs struct {
+	tableName          struct{} `pg:"derived_gas_outputs"`
+	Cid                string   `pg:",pk,notnull"`
+	From               string   `pg:",notnull"`
+	To                 string   `pg:",notnull"`
+	Value              string   `pg:",notnull"`
+	GasFeeCap          string   `pg:",notnull"`
+	GasPremium         string   `pg:",notnull"`
+	GasLimit           int64    `pg:",use_zero,notnull"`
+	SizeBytes          int      `pg:",use_zero,notnull"`
+	Nonce              uint64   `pg:",use_zero,notnull"`
+	Method             uint64   `pg:",use_zero,notnull"`
+	StateRoot          string   `pg:",notnull"`
+	ExitCode           int64    `pg:",use_zero,notnull"`
+	GasUsed            int64    `pg:",use_zero,notnull"`
+	ParentBaseFee      string   `pg:",notnull"`
+	BaseFeeBurn        string   `pg:",notnull"`
+	OverEstimationBurn string   `pg:",notnull"`
+	MinerPenalty       string   `pg:",notnull"`
+	MinerTip           string   `pg:",notnull"`
+	Refund             string   `pg:",notnull"`
+	GasRefund          int64    `pg:",use_zero,notnull"`
+	GasBurned          int64    `pg:",use_zero,notnull"`
+}
+
+func (g *GasOutputs) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	if _, err := tx.ModelContext(ctx, g).
+		OnConflict("do nothing").
+		Insert(); err != nil {
+		return xerrors.Errorf("persisting derived gas outputs: %w", err)
+	}
+	return nil
+}
+
+type GasOutputsList []*GasOutputs
+
+func (l GasOutputsList) Persist(ctx context.Context, db *pg.DB) error {
+	return db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return l.PersistWithTx(ctx, tx)
+	})
+}
+
+func (l GasOutputsList) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	ctx, span := global.Tracer("").Start(ctx, "GasOutputsList.PersistWithTx", trace.WithAttributes(label.Int("count", len(l))))
+	defer span.End()
+	for _, p := range l {
+		if err := p.PersistWithTx(ctx, tx); err != nil {
+			return nil
+		}
+	}
+	return nil
+}

--- a/model/messages/task.go
+++ b/model/messages/task.go
@@ -14,18 +14,25 @@ type MessageTaskResult struct {
 }
 
 func (mtr *MessageTaskResult) Persist(ctx context.Context, db *pg.DB) error {
-	ctx, span := global.Tracer("").Start(ctx, "MessageTaskResult.Persist")
-	defer span.End()
 	return db.RunInTransaction(ctx, func(tx *pg.Tx) error {
-		if err := mtr.Messages.PersistWithTx(ctx, tx); err != nil {
-			return err
-		}
-		if err := mtr.BlockMessages.PersistWithTx(ctx, tx); err != nil {
-			return err
-		}
-		if err := mtr.Receipts.PersistWithTx(ctx, tx); err != nil {
-			return err
-		}
-		return nil
+		return mtr.PersistWithTx(ctx, tx)
 	})
+
+}
+
+func (mtr *MessageTaskResult) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	ctx, span := global.Tracer("").Start(ctx, "MessageTaskResult.PersistWithTx")
+	defer span.End()
+
+	if err := mtr.Messages.PersistWithTx(ctx, tx); err != nil {
+		return err
+	}
+	if err := mtr.BlockMessages.PersistWithTx(ctx, tx); err != nil {
+		return err
+	}
+	if err := mtr.Receipts.PersistWithTx(ctx, tx); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/storage/migrations/6_tipset_processing_tables.go
+++ b/storage/migrations/6_tipset_processing_tables.go
@@ -1,0 +1,117 @@
+package migrations
+
+import (
+	"github.com/go-pg/migrations/v8"
+)
+
+// Schema version 6 merges tipset oriented processing tables
+
+func init() {
+
+	up := batch(`
+-- Merge visor_processing_statechanges and visor_processing_messages tables into a new tipset table
+ALTER TABLE public.visor_processing_statechanges RENAME TO visor_processing_tipsets;
+ALTER TABLE public.visor_processing_tipsets RENAME COLUMN claimed_until TO statechange_claimed_until;
+ALTER TABLE public.visor_processing_tipsets RENAME COLUMN completed_at TO statechange_completed_at;
+ALTER TABLE public.visor_processing_tipsets RENAME COLUMN errors_detected TO statechange_errors_detected;
+ALTER TABLE public.visor_processing_tipsets ADD COLUMN message_claimed_until timestamptz;
+ALTER TABLE public.visor_processing_tipsets ADD COLUMN message_completed_at timestamptz;
+ALTER TABLE public.visor_processing_tipsets ADD COLUMN message_errors_detected text;
+
+-- Copy data from visor_processing_messages before it is repurposed
+UPDATE public.visor_processing_tipsets t
+SET message_claimed_until = m.claimed_until,
+    message_completed_at = m.completed_at,
+    message_errors_detected = m.errors_detected
+FROM public.visor_processing_messages m
+WHERE m.tip_set = t.tip_set;
+
+
+-- Repurpose visor_processing_messages table
+DROP TABLE IF EXISTS public.visor_processing_messages;
+
+CREATE TABLE public.visor_processing_messages (
+	"cid" text NOT NULL,
+	"height" bigint,
+	"added_at" timestamptz NOT NULL,
+	"gas_outputs_claimed_until" timestamptz,
+	"gas_outputs_completed_at" timestamptz,
+	"gas_outputs_errors_detected" text,
+	PRIMARY KEY ("cid")
+);
+
+CREATE TABLE IF NOT EXISTS public.derived_gas_outputs (
+	"cid" text NOT NULL,
+	"from" text NOT NULL,
+	"to" text NOT NULL,
+	"value" text NOT NULL,
+	"gas_fee_cap" text NOT NULL,
+	"gas_premium" text NOT NULL,
+	"gas_limit" bigint,
+	"size_bytes" bigint,
+	"nonce" bigint,
+	"method" bigint,
+	"state_root" text NOT NULL,
+	"exit_code" bigint NOT NULL,
+	"gas_used" bigint NOT NULL,
+	"parent_base_fee" text NOT NULL,
+	"base_fee_burn" text NOT NULL,
+	"over_estimation_burn" text NOT NULL,
+	"miner_penalty" text NOT NULL,
+	"miner_tip" text NOT NULL,
+	"refund" text NOT NULL,
+	"gas_refund" bigint NOT NULL,
+	"gas_burned" bigint NOT NULL,
+	PRIMARY KEY ("cid")
+);
+
+CREATE INDEX derived_gas_outputs_from_index ON public.derived_gas_outputs USING hash ("from");
+CREATE INDEX derived_gas_outputs_to_index ON public.derived_gas_outputs USING hash ("to");
+CREATE INDEX derived_gas_outputs_method_index ON public.derived_gas_outputs USING btree (method);
+CREATE INDEX derived_gas_outputs_exit_code_index ON public.derived_gas_outputs USING btree (exit_code);
+
+`)
+	down := batch(`
+
+
+-- Restore visor_processing_messages table
+DROP TABLE IF EXISTS public.visor_processing_messages;
+
+CREATE TABLE public.visor_processing_messages (
+	"tip_set" text NOT NULL,
+	"height" bigint,
+	"added_at" timestamptz NOT NULL,
+	"claimed_until" timestamptz,
+	"completed_at" timestamptz,
+	"errors_detected" text,
+	PRIMARY KEY ("tip_set")
+);
+
+-- Copy data back from visor_processing_tipsets
+UPDATE public.visor_processing_messages m
+SET claimed_until = t.message_claimed_until,
+    completed_at = t.message_completed_at,
+    errors_detected = t.message_errors_detected
+FROM public.visor_processing_tipsets t
+WHERE m.tip_set = t.tip_set;
+
+-- Merge visor_processing_statechanges and visor_processing_messages tables into a new tipset table
+ALTER TABLE public.visor_processing_tipsets RENAME TO visor_processing_statechanges;
+ALTER TABLE public.visor_processing_statechanges RENAME COLUMN statechange_claimed_until TO claimed_until;
+ALTER TABLE public.visor_processing_statechanges RENAME COLUMN statechange_completed_at TO completed_at;
+ALTER TABLE public.visor_processing_statechanges RENAME COLUMN statechange_errors_detected TO errors_detected;
+ALTER TABLE public.visor_processing_statechanges DROP COLUMN IF EXISTS message_claimed_until;
+ALTER TABLE public.visor_processing_statechanges DROP COLUMN IF EXISTS message_completed_at;
+ALTER TABLE public.visor_processing_statechanges DROP COLUMN IF EXISTS message_errors_detected;
+
+DROP INDEX IF EXISTS public.derived_gas_outputs_from_index;
+DROP INDEX IF EXISTS public.derived_gas_outputs_to_index;
+DROP INDEX IF EXISTS public.derived_gas_outputs_method_index;
+DROP INDEX IF EXISTS public.derived_gas_outputs_exit_code_index;
+
+
+DROP TABLE IF EXISTS public.derived_gas_outputs;
+
+	`)
+	migrations.MustRegisterTx(up, down)
+}

--- a/storage/sql_test.go
+++ b/storage/sql_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/sentinel-visor/model/blocks"
+	"github.com/filecoin-project/sentinel-visor/model/messages"
 	"github.com/filecoin-project/sentinel-visor/model/visor"
 	"github.com/filecoin-project/sentinel-visor/testutil"
 )
@@ -54,7 +56,7 @@ func TestLeaseStateChanges(t *testing.T) {
 
 	truncateVisorProcessingTables(t, db)
 
-	indexedTipsets := visor.ProcessingStateChangeList{
+	indexedTipsets := visor.ProcessingTipSetList{
 		// Unclaimed, incomplete tipset
 		{
 			TipSet:  "cid0a,cid0b",
@@ -85,27 +87,27 @@ func TestLeaseStateChanges(t *testing.T) {
 
 		// TipSet completed with stale claim
 		{
-			TipSet:       "cid4",
-			Height:       4,
-			AddedAt:      testutil.KnownTime,
-			ClaimedUntil: testutil.KnownTime.Add(-time.Minute * 15),
-			CompletedAt:  testutil.KnownTime.Add(-time.Minute * 5),
+			TipSet:                  "cid4",
+			Height:                  4,
+			AddedAt:                 testutil.KnownTime,
+			StatechangeClaimedUntil: testutil.KnownTime.Add(-time.Minute * 15),
+			StatechangeCompletedAt:  testutil.KnownTime.Add(-time.Minute * 5),
 		},
 
 		// TipSet claimed by another process that has expired
 		{
-			TipSet:       "cid5",
-			Height:       5,
-			AddedAt:      testutil.KnownTime,
-			ClaimedUntil: testutil.KnownTime.Add(-time.Minute * 5),
+			TipSet:                  "cid5",
+			Height:                  5,
+			AddedAt:                 testutil.KnownTime,
+			StatechangeClaimedUntil: testutil.KnownTime.Add(-time.Minute * 5),
 		},
 
 		// TipSet claimed by another process
 		{
-			TipSet:       "cid6a,cid6b",
-			Height:       6,
-			AddedAt:      testutil.KnownTime,
-			ClaimedUntil: testutil.KnownTime.Add(time.Minute * 15),
+			TipSet:                  "cid6a,cid6b",
+			Height:                  6,
+			AddedAt:                 testutil.KnownTime,
+			StatechangeClaimedUntil: testutil.KnownTime.Add(time.Minute * 15),
 		},
 	}
 
@@ -134,7 +136,7 @@ func TestLeaseStateChanges(t *testing.T) {
 
 	// Check the database contains the leases
 	var count int
-	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_statechanges WHERE claimed_until=?`, claimUntil)
+	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_tipsets WHERE statechange_claimed_until=?`, claimUntil)
 	require.NoError(t, err)
 	assert.Equal(t, batchSize, count)
 }
@@ -153,7 +155,7 @@ func TestMarkStateChangeComplete(t *testing.T) {
 
 	truncateVisorProcessingTables(t, db)
 
-	indexedBlocks := visor.ProcessingStateChangeList{
+	indexedBlocks := visor.ProcessingTipSetList{
 		{
 			TipSet:  "cid0",
 			Height:  0,
@@ -191,7 +193,7 @@ func TestMarkStateChangeComplete(t *testing.T) {
 
 		// Check the database contains the updated row
 		var count int
-		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_statechanges WHERE completed_at=?`, completedAt)
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_tipsets WHERE statechange_completed_at=?`, completedAt)
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 	})
@@ -203,7 +205,7 @@ func TestMarkStateChangeComplete(t *testing.T) {
 
 		// Check the database contains the updated row with a null errors_detected column
 		var count int
-		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_statechanges WHERE completed_at=? AND errors_detected IS NULL`, completedAt)
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_tipsets WHERE statechange_completed_at=? AND statechange_errors_detected IS NULL`, completedAt)
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 	})
@@ -212,14 +214,26 @@ func TestMarkStateChangeComplete(t *testing.T) {
 // truncateVisorProcessingTables ensures the processing tables are empty
 func truncateVisorProcessingTables(tb testing.TB, db *pg.DB) {
 	tb.Helper()
-	_, err := db.Exec(`TRUNCATE TABLE visor_processing_statechanges`)
-	require.NoError(tb, err, "truncating visor_processing_statechanges")
+	_, err := db.Exec(`TRUNCATE TABLE visor_processing_tipsets`)
+	require.NoError(tb, err, "truncating visor_processing_tipsets")
 
 	_, err = db.Exec(`TRUNCATE TABLE visor_processing_actors`)
 	require.NoError(tb, err, "truncating visor_processing_actors")
 
 	_, err = db.Exec(`TRUNCATE TABLE visor_processing_messages`)
 	require.NoError(tb, err, "truncating visor_processing_messages")
+
+	_, err = db.Exec(`TRUNCATE TABLE messages`)
+	require.NoError(tb, err, "truncating messages")
+
+	_, err = db.Exec(`TRUNCATE TABLE receipts`)
+	require.NoError(tb, err, "truncating receipts")
+
+	_, err = db.Exec(`TRUNCATE TABLE block_headers`)
+	require.NoError(tb, err, "truncating block_headers")
+
+	_, err = db.Exec(`TRUNCATE TABLE block_messages`)
+	require.NoError(tb, err, "truncating block_messages")
 }
 
 func TestLeaseActors(t *testing.T) {
@@ -317,7 +331,7 @@ func TestLeaseActors(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, batchSize, len(claimed), "number of claimed actors")
 
-	// Blocks are selected in descending height order, ignoring completed and claimed blocks and only those will
+	// Actors are selected in descending height order, ignoring completed and claimed actors only those with
 	// allowed codes.
 	assert.Equal(t, "head5", claimed[0].Head, "first claimed actor")
 	assert.Equal(t, "head3", claimed[1].Head, "second claimed actor")
@@ -415,7 +429,7 @@ func TestLeaseBlockMessages(t *testing.T) {
 
 	truncateVisorProcessingTables(t, db)
 
-	indexedMessageTipSets := visor.ProcessingMessageList{
+	indexedMessageTipSets := visor.ProcessingTipSetList{
 		// Unclaimed, incomplete tipset
 		{
 			TipSet:  "cid0a,cid0b",
@@ -446,27 +460,27 @@ func TestLeaseBlockMessages(t *testing.T) {
 
 		// Tipset completed with stale claim
 		{
-			TipSet:       "cid4a",
-			Height:       4,
-			AddedAt:      testutil.KnownTime,
-			ClaimedUntil: testutil.KnownTime.Add(-time.Minute * 15),
-			CompletedAt:  testutil.KnownTime.Add(-time.Minute * 5),
+			TipSet:              "cid4a",
+			Height:              4,
+			AddedAt:             testutil.KnownTime,
+			MessageClaimedUntil: testutil.KnownTime.Add(-time.Minute * 15),
+			MessageCompletedAt:  testutil.KnownTime.Add(-time.Minute * 5),
 		},
 
 		// Tipset claimed by another process that has expired
 		{
-			TipSet:       "cid5a",
-			Height:       5,
-			AddedAt:      testutil.KnownTime,
-			ClaimedUntil: testutil.KnownTime.Add(-time.Minute * 5),
+			TipSet:              "cid5a",
+			Height:              5,
+			AddedAt:             testutil.KnownTime,
+			MessageClaimedUntil: testutil.KnownTime.Add(-time.Minute * 5),
 		},
 
 		// Tipset claimed by another process
 		{
-			TipSet:       "cid6a,cid6b",
-			Height:       6,
-			AddedAt:      testutil.KnownTime,
-			ClaimedUntil: testutil.KnownTime.Add(time.Minute * 15),
+			TipSet:              "cid6a,cid6b",
+			Height:              6,
+			AddedAt:             testutil.KnownTime,
+			MessageClaimedUntil: testutil.KnownTime.Add(time.Minute * 15),
 		},
 	}
 
@@ -488,14 +502,14 @@ func TestLeaseBlockMessages(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, batchSize, len(claimed), "number of claimed message blocks")
 
-	// Blocks are selected in descending height order, ignoring completed and claimed blocks
+	// Tipsets are selected in descending height order, ignoring completed and claimed blocks
 	assert.Equal(t, "cid5a", claimed[0].TipSet, "first claimed message tipset")
 	assert.Equal(t, "cid3a", claimed[1].TipSet, "second claimed message tipset")
 	assert.Equal(t, "cid2a,cid2b,cid2c", claimed[2].TipSet, "third claimed message tipset")
 
 	// Check the database contains the leases
 	var count int
-	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE claimed_until=?`, claimUntil)
+	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_tipsets WHERE message_claimed_until=?`, claimUntil)
 	require.NoError(t, err)
 	assert.Equal(t, batchSize, count)
 }
@@ -514,7 +528,7 @@ func TestMarkTipSetMessagesComplete(t *testing.T) {
 
 	truncateVisorProcessingTables(t, db)
 
-	indexedMessages := visor.ProcessingMessageList{
+	indexedMessages := visor.ProcessingTipSetList{
 		{
 			TipSet:  "cid0a,cid0b",
 			Height:  0,
@@ -552,7 +566,7 @@ func TestMarkTipSetMessagesComplete(t *testing.T) {
 
 		// Check the database contains the updated row
 		var count int
-		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE completed_at=?`, completedAt)
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_tipsets WHERE message_completed_at=?`, completedAt)
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 	})
@@ -564,7 +578,277 @@ func TestMarkTipSetMessagesComplete(t *testing.T) {
 
 		// Check the database contains the updated row with a null errors_detected column
 		var count int
-		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE completed_at=? AND errors_detected IS NULL`, completedAt)
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_tipsets WHERE message_completed_at=? AND message_errors_detected IS NULL`, completedAt)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
+}
+
+func TestLeaseGasOutputsMessages(t *testing.T) {
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
+	require.NoError(t, err)
+	defer cleanup()
+
+	truncateVisorProcessingTables(t, db)
+
+	indexedMessages := visor.ProcessingMessageList{
+		// Unclaimed, unprocessed message
+		{
+			Cid:     "cid0",
+			Height:  0,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, unprocessed message,
+		{
+			Cid:     "cid1",
+			Height:  1,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, unprocessed message
+		{
+			Cid:     "cid2",
+			Height:  2,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Unclaimed, unprocessed message, no receipt
+		{
+			Cid:     "cid3",
+			Height:  3,
+			AddedAt: testutil.KnownTime,
+		},
+
+		// Message completed with stale claim
+		{
+			Cid:                    "cid4",
+			Height:                 4,
+			AddedAt:                testutil.KnownTime,
+			GasOutputsClaimedUntil: testutil.KnownTime.Add(-time.Minute * 15),
+			GasOutputsCompletedAt:  testutil.KnownTime.Add(-time.Minute * 5),
+		},
+
+		// Message claimed by another process that has expired
+		{
+			Cid:                    "cid5",
+			Height:                 5,
+			AddedAt:                testutil.KnownTime,
+			GasOutputsClaimedUntil: testutil.KnownTime.Add(-time.Minute * 5),
+		},
+
+		// Message claimed by another process
+		{
+			Cid:                    "cid6",
+			Height:                 6,
+			AddedAt:                testutil.KnownTime,
+			GasOutputsClaimedUntil: testutil.KnownTime.Add(time.Minute * 15),
+		},
+	}
+
+	dummyMessage := func(cid string) *messages.Message {
+		return &messages.Message{
+			Cid:        cid,
+			From:       "from",
+			To:         "to",
+			Value:      "val",
+			GasFeeCap:  "gasfeecap",
+			GasPremium: "gaspremium",
+		}
+	}
+
+	msgs := messages.Messages{
+		dummyMessage("cid0"),
+		dummyMessage("cid1"),
+		dummyMessage("cid2"),
+		dummyMessage("cid3"),
+		dummyMessage("cid4"),
+		dummyMessage("cid5"),
+		dummyMessage("cid6"),
+	}
+
+	dummyReceipt := func(cid string) *messages.Receipt {
+		return &messages.Receipt{
+			Message:   cid,
+			StateRoot: "stateroot",
+		}
+	}
+
+	receipts := messages.Receipts{
+		dummyReceipt("cid0"),
+		dummyReceipt("cid1"),
+		dummyReceipt("cid2"),
+		// no receipt for cid3
+		dummyReceipt("cid4"),
+		dummyReceipt("cid5"),
+		dummyReceipt("cid6"),
+	}
+
+	dummyBlockHeader := func(cid string) *blocks.BlockHeader {
+		return &blocks.BlockHeader{
+			Cid:             cid,
+			Miner:           "miner",
+			ParentWeight:    "parentweight",
+			ParentBaseFee:   "parentbasefee",
+			ParentStateRoot: "parentstateroot",
+			Ticket:          []byte("ticket"),
+		}
+	}
+
+	blockHeaders := blocks.BlockHeaders{
+		dummyBlockHeader("blocka"),
+		dummyBlockHeader("blockb"),
+	}
+
+	blockMessages := messages.BlockMessages{
+		{
+			Block:   "blocka",
+			Message: "cid0",
+		},
+		{
+			Block:   "blocka",
+			Message: "cid1",
+		},
+		{
+			Block:   "blocka",
+			Message: "cid2",
+		},
+		{
+			Block:   "blockb",
+			Message: "cid3",
+		},
+		{
+			Block:   "blockb",
+			Message: "cid4",
+		},
+		{
+			Block:   "blockb",
+			Message: "cid5",
+		},
+		{
+			Block:   "blockb",
+			Message: "cid6",
+		},
+	}
+
+	if err := db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		if err := indexedMessages.PersistWithTx(ctx, tx); err != nil {
+			return fmt.Errorf("indexedMessages: %w", err)
+		}
+		if err := receipts.PersistWithTx(ctx, tx); err != nil {
+			return fmt.Errorf("receipts: %w", err)
+		}
+		if err := msgs.PersistWithTx(ctx, tx); err != nil {
+			return fmt.Errorf("msgs: %w", err)
+		}
+		if err := blockHeaders.PersistWithTx(ctx, tx); err != nil {
+			return fmt.Errorf("blockHeaders: %w", err)
+		}
+		if err := blockMessages.PersistWithTx(ctx, tx); err != nil {
+			return fmt.Errorf("blockMessages: %w", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("persisting indexed messages: %v", err)
+	}
+
+	const batchSize = 3
+
+	claimUntil := testutil.KnownTime.Add(time.Minute * 10)
+	d := &Database{
+		DB:    db,
+		Clock: testutil.NewMockClock(),
+	}
+
+	claimed, err := d.LeaseGasOutputsMessages(ctx, claimUntil, batchSize, 0, 500)
+	require.NoError(t, err)
+	require.Equal(t, batchSize, len(claimed), "number of claimed message blocks")
+
+	// Messages are selected in descending height order, only if they have a receipt and a block header, ignoring completed and claimed messages
+	assert.Equal(t, "cid5", claimed[0].Cid, "first claimed message")
+	assert.Equal(t, "cid2", claimed[1].Cid, "second claimed message")
+	assert.Equal(t, "cid1", claimed[2].Cid, "third claimed message")
+
+	// Check the database contains the leases
+	var count int
+	_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE gas_outputs_claimed_until=?`, claimUntil)
+	require.NoError(t, err)
+	assert.Equal(t, batchSize, count)
+}
+
+func TestMarkGasOutputsMessagesComplete(t *testing.T) {
+	if testing.Short() || !testutil.DatabaseAvailable() {
+		t.Skip("short testing requested or VISOR_TEST_DB not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)
+	require.NoError(t, err)
+	defer cleanup()
+
+	truncateVisorProcessingTables(t, db)
+
+	indexedMessages := visor.ProcessingMessageList{
+		{
+			Cid:     "cid0",
+			Height:  0,
+			AddedAt: testutil.KnownTime,
+		},
+
+		{
+			Cid:     "cid1",
+			Height:  1,
+			AddedAt: testutil.KnownTime,
+		},
+
+		{
+			Cid:     "cid2",
+			Height:  2,
+			AddedAt: testutil.KnownTime,
+		},
+	}
+
+	if err := db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return indexedMessages.PersistWithTx(ctx, tx)
+	}); err != nil {
+		t.Fatalf("persisting indexed message blocks: %v", err)
+	}
+
+	d := &Database{
+		DB:    db,
+		Clock: testutil.NewMockClock(),
+	}
+
+	t.Run("with error message", func(t *testing.T) {
+		completedAt := testutil.KnownTime.Add(time.Minute * 1)
+		err = d.MarkGasOutputsMessagesComplete(ctx, "cid1", completedAt, "message")
+		require.NoError(t, err)
+
+		// Check the database contains the updated row
+		var count int
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE gas_outputs_completed_at=?`, completedAt)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("without error message", func(t *testing.T) {
+		completedAt := testutil.KnownTime.Add(time.Minute * 2)
+		err = d.MarkGasOutputsMessagesComplete(ctx, "cid1", completedAt, "")
+		require.NoError(t, err)
+
+		// Check the database contains the updated row with a null errors_detected column
+		var count int
+		_, err = db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM visor_processing_messages WHERE gas_outputs_completed_at=? AND gas_outputs_errors_detected IS NULL`, completedAt)
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 	})

--- a/tasks/actorstate/actorstatechange.go
+++ b/tasks/actorstate/actorstatechange.go
@@ -103,7 +103,7 @@ func (p *ActorStateChangeProcessor) processBatch(ctx context.Context) (bool, err
 	return false, nil
 }
 
-func (p *ActorStateChangeProcessor) processItem(ctx context.Context, item *visor.ProcessingStateChange) error {
+func (p *ActorStateChangeProcessor) processItem(ctx context.Context, item *visor.ProcessingTipSet) error {
 	tsk, err := item.TipSetKey()
 	if err != nil {
 		return xerrors.Errorf("get tipsetkey: %w", err)

--- a/tasks/message/gasoutputs.go
+++ b/tasks/message/gasoutputs.go
@@ -1,0 +1,131 @@
+package message
+
+import (
+	"context"
+	"time"
+
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/go-pg/pg/v10"
+	"github.com/raulk/clock"
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/model/derived"
+	"github.com/filecoin-project/sentinel-visor/storage"
+	"github.com/filecoin-project/sentinel-visor/wait"
+)
+
+func NewGasOutputsProcessor(d *storage.Database, node lens.API, leaseLength time.Duration, batchSize int, minHeight, maxHeight int64) *GasOutputsProcessor {
+	return &GasOutputsProcessor{
+		node:        node,
+		storage:     d,
+		leaseLength: leaseLength,
+		batchSize:   batchSize,
+		minHeight:   minHeight,
+		maxHeight:   maxHeight,
+		clock:       clock.New(),
+	}
+}
+
+// GasOutputsProcessor is a task that processes messages with receipts to determine gas outputs.
+type GasOutputsProcessor struct {
+	node        lens.API
+	storage     *storage.Database
+	leaseLength time.Duration // length of time to lease work for
+	batchSize   int           // number of messages to lease in a batch
+	minHeight   int64         // limit processing to messages from tipsets equal to or above this height
+	maxHeight   int64         // limit processing to messages from tipsets equal to or below this height
+	clock       clock.Clock
+}
+
+// Run starts processing batches of messages until the context is done or
+// an error occurs.
+func (p *GasOutputsProcessor) Run(ctx context.Context) error {
+	// Loop until context is done or processing encounters a fatal error
+	return wait.RepeatUntil(ctx, batchInterval, p.processBatch)
+}
+
+func (p *GasOutputsProcessor) processBatch(ctx context.Context) (bool, error) {
+	ctx, span := global.Tracer("").Start(ctx, "GasOutputsProcessor.processBatch")
+	defer span.End()
+
+	claimUntil := p.clock.Now().Add(p.leaseLength)
+	ctx, cancel := context.WithDeadline(ctx, claimUntil)
+	defer cancel()
+
+	// Lease some messages with receipts to work on
+	batch, err := p.storage.LeaseGasOutputsMessages(ctx, claimUntil, p.batchSize, p.minHeight, p.maxHeight)
+	if err != nil {
+		return true, err
+	}
+
+	// If we have no messages to work on then wait before trying again
+	if len(batch) == 0 {
+		sleepInterval := wait.Jitter(idleSleepInterval, 2)
+		log.Debugf("no messages to process, waiting for %s", sleepInterval)
+		time.Sleep(sleepInterval)
+		return false, nil
+	}
+
+	log.Debugw("leased batch of messages", "count", len(batch))
+
+	for _, item := range batch {
+		// Stop processing if we have somehow passed our own lease time
+		select {
+		case <-ctx.Done():
+			return false, nil // Don't propagate cancelation error so we can resume processing cleanly
+		default:
+		}
+
+		errorLog := log.With("cid", item.Cid)
+
+		if err := p.processItem(ctx, item); err != nil {
+			errorLog.Errorw("failed to process message", "error", err.Error())
+			if err := p.storage.MarkGasOutputsMessagesComplete(ctx, item.Cid, p.clock.Now(), err.Error()); err != nil {
+				errorLog.Errorw("failed to mark message complete", "error", err.Error())
+			}
+			continue
+		}
+
+		if err := p.storage.MarkGasOutputsMessagesComplete(ctx, item.Cid, p.clock.Now(), ""); err != nil {
+			errorLog.Errorw("failed to mark message complete", "error", err.Error())
+		}
+
+	}
+
+	return false, nil
+}
+
+func (p *GasOutputsProcessor) processItem(ctx context.Context, item *derived.GasOutputs) error {
+	baseFee, err := big.FromString(item.ParentBaseFee)
+	if err != nil {
+		return xerrors.Errorf("parse fee cap: %w", err)
+	}
+	feeCap, err := big.FromString(item.GasFeeCap)
+	if err != nil {
+		return xerrors.Errorf("parse fee cap: %w", err)
+	}
+	gasPremium, err := big.FromString(item.GasPremium)
+	if err != nil {
+		return xerrors.Errorf("parse gas premium: %w", err)
+	}
+
+	outputs := p.node.ComputeGasOutputs(item.GasUsed, item.GasLimit, baseFee, feeCap, gasPremium)
+
+	item.BaseFeeBurn = outputs.BaseFeeBurn.String()
+	item.OverEstimationBurn = outputs.OverEstimationBurn.String()
+	item.MinerPenalty = outputs.MinerPenalty.String()
+	item.MinerTip = outputs.MinerTip.String()
+	item.Refund = outputs.Refund.String()
+	item.GasRefund = outputs.GasRefund
+	item.GasBurned = outputs.GasBurned
+
+	if err := p.storage.DB.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return item.PersistWithTx(ctx, tx)
+	}); err != nil {
+		return xerrors.Errorf("persisting gas outputs: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This change adds a gas outputs processing task. The results of the task are written to
a new table derived_gas_outputs. The task fetches batches of messages that have receipts
and calls the lotus vm ComputeGasOutputs method, persisting the results.

This change also performs a significant refactor of the visor processing tables. Previously
the chain indexers would write duplicate rows to visor_processing_statechanges and
visor_processing_messages. Each of those tables contained claimed_until, completed_at and
errors_detected columns. They were used by the ActorStateChange and Message tasks. However
if we were to add another task that processed tipsets we would need to add another processing
table and then reindex the entire chain to populate it.

To avoid this, the visor_processing_statechanges and visor_processing_messages tables have
been combined into a single visor_processing_tipsets table. Each task now has a set of three
columns in this table to track its work: statechange_claimed_until/statechange_completed_at/
statechange_errors_detected and message_claimed_until/message_completed_at/message_errors_detected.

Adding a new tipset-oriented task is then a matter of adding three columns to this table.

The visor_processing_messages table has been repurposed to track work that needs to be performed
on each message seen. The GasOutputs task is the first task to use this table. It uses the
gas_outputs_claimed_until, gas_outputs_completed_at and gas_outputs_errors_detected columns.

Additional message-oriented tasks can be supported by adding new columns to this table, avoiding
the need to read every message in the chain again.

fixes https://github.com/filecoin-project/sentinel-visor/issues/63

