### PR TITLE
chore(cli): nice supported actor args

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -98,13 +98,13 @@ var Run = &cli.Command{
 		},
 		&cli.StringSliceFlag{
 			Name:        "actorstate-include",
-			Usage:       "List of actor codes that should be procesed by actor state processors",
+			Usage:       fmt.Sprintf("List of actor names that should be processed by actor state processors: %v", supportedActorArgs),
 			DefaultText: "all supported",
 			EnvVars:     []string{"VISOR_ACTORSTATE_INCLUDE"},
 		},
 		&cli.StringSliceFlag{
 			Name:        "actorstate-exclude",
-			Usage:       "List of actor codes that should be not be procesed by actor state processors",
+			Usage:       fmt.Sprintf("List of actor names that should be not be processed by actor state processors: %v", supportedActorArgs),
 			DefaultText: "none",
 			EnvVars:     []string{"VISOR_ACTORSTATE_EXCLUDE"},
 		},
@@ -293,16 +293,44 @@ func parseActorCodes(ss []string) ([]cid.Cid, error) {
 	return codes, nil
 }
 
+const (
+	AccountActor          = "account"
+	CronActor             = "cron"
+	InitActor             = "init"
+	StorageMarketActor    = "market"
+	StorageMinerActor     = "miner"
+	MultiSigActor         = "multisig"
+	PaymentChannelActor   = "payment"
+	StoragePowerActor     = "power"
+	VerifiedRegistryActor = "registry"
+	RewardActor           = "reward"
+	SystemActor           = "system"
+)
+
+var supportedActorArgs = []string{
+	AccountActor,
+	CronActor,
+	InitActor,
+	StorageMarketActor,
+	StorageMinerActor,
+	MultiSigActor,
+	PaymentChannelActor,
+	StoragePowerActor,
+	VerifiedRegistryActor,
+	RewardActor,
+	SystemActor,
+}
+
 var actorNamesToCodes = map[string]cid.Cid{
-	"fil/2/system":           builtin.SystemActorCodeID,
-	"fil/2/init":             builtin.InitActorCodeID,
-	"fil/2/cron":             builtin.CronActorCodeID,
-	"fil/2/storagepower":     builtin.StoragePowerActorCodeID,
-	"fil/2/storageminer":     builtin.StorageMinerActorCodeID,
-	"fil/2/storagemarket":    builtin.StorageMarketActorCodeID,
-	"fil/2/paymentchannel":   builtin.PaymentChannelActorCodeID,
-	"fil/2/reward":           builtin.RewardActorCodeID,
-	"fil/2/verifiedregistry": builtin.VerifiedRegistryActorCodeID,
-	"fil/2/account":          builtin.AccountActorCodeID,
-	"fil/2/multisig":         builtin.MultisigActorCodeID,
+	SystemActor:           builtin.SystemActorCodeID,
+	InitActor:             builtin.InitActorCodeID,
+	CronActor:             builtin.CronActorCodeID,
+	StoragePowerActor:     builtin.StoragePowerActorCodeID,
+	StorageMinerActor:     builtin.StorageMinerActorCodeID,
+	StorageMarketActor:    builtin.StorageMarketActorCodeID,
+	PaymentChannelActor:   builtin.PaymentChannelActorCodeID,
+	RewardActor:           builtin.RewardActorCodeID,
+	VerifiedRegistryActor: builtin.VerifiedRegistryActorCodeID,
+	AccountActor:          builtin.AccountActorCodeID,
+	MultiSigActor:         builtin.MultisigActorCodeID,
 }

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,7 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -1275,6 +1276,7 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0 h1:G9tHG9lebljV9mfp9SNPDL36nCDxmo3zTlAf1YgvzmI=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -1381,6 +1383,7 @@ github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=


### PR DESCRIPTION
Usage now reads (irrelevant parts omitted for clarity):
```
frrist@sequoia:~/s/g/f/sentinel-visor|frrist/actor-by-name✓
➤ ./visor run --help
NAME:
   visor run - Index and process blocks from the filecoin blockchain

USAGE:
   visor run [command options] [arguments...]

OPTIONS:
...
   --actorstate-include value                List of actor names that should be processed by actor state processors: [account cron init market miner multisig payment power registry reward system] [$VISOR_ACTORSTATE_INCLUDE]
   --actorstate-exclude value                List of actor names that should be not be processed by actor state processors: [account cron init market miner multisig payment power registry reward system] [$VISOR_ACTORSTATE_EXCLUDE]
...