### PR TITLE
fix: use context deadlines only if task has been assigned work

### DIFF
--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -121,8 +121,6 @@ func (p *ActorStateProcessor) processBatch(ctx context.Context) (bool, error) {
 
 	// Lease some blocks to work on
 	claimUntil := p.clock.Now().Add(p.leaseLength)
-	ctx, cancel := context.WithDeadline(ctx, claimUntil)
-	defer cancel()
 
 	batch, err := p.storage.LeaseActors(ctx, claimUntil, p.batchSize, p.minHeight, p.maxHeight, p.actorCodes)
 	if err != nil {
@@ -138,6 +136,8 @@ func (p *ActorStateProcessor) processBatch(ctx context.Context) (bool, error) {
 	}
 
 	log.Debugw("leased batch of actors", "count", len(batch))
+	ctx, cancel := context.WithDeadline(ctx, claimUntil)
+	defer cancel()
 
 	for _, actor := range batch {
 		// Stop processing if we have somehow passed our own lease time

--- a/tasks/actorstate/actorstatechange.go
+++ b/tasks/actorstate/actorstatechange.go
@@ -57,8 +57,6 @@ func (p *ActorStateChangeProcessor) processBatch(ctx context.Context) (bool, err
 	defer span.End()
 
 	claimUntil := p.clock.Now().Add(p.leaseLength)
-	ctx, cancel := context.WithDeadline(ctx, claimUntil)
-	defer cancel()
 
 	// Lease some tipsets to work on
 	batch, err := p.storage.LeaseStateChanges(ctx, claimUntil, p.batchSize, p.minHeight, p.maxHeight)
@@ -75,6 +73,8 @@ func (p *ActorStateChangeProcessor) processBatch(ctx context.Context) (bool, err
 	}
 
 	log.Debugw("leased batch of tipsets", "count", len(batch))
+	ctx, cancel := context.WithDeadline(ctx, claimUntil)
+	defer cancel()
 
 	for _, item := range batch {
 		// Stop processing if we have somehow passed our own lease time

--- a/tasks/message/gasoutputs.go
+++ b/tasks/message/gasoutputs.go
@@ -51,8 +51,6 @@ func (p *GasOutputsProcessor) processBatch(ctx context.Context) (bool, error) {
 	defer span.End()
 
 	claimUntil := p.clock.Now().Add(p.leaseLength)
-	ctx, cancel := context.WithDeadline(ctx, claimUntil)
-	defer cancel()
 
 	// Lease some messages with receipts to work on
 	batch, err := p.storage.LeaseGasOutputsMessages(ctx, claimUntil, p.batchSize, p.minHeight, p.maxHeight)
@@ -69,6 +67,8 @@ func (p *GasOutputsProcessor) processBatch(ctx context.Context) (bool, error) {
 	}
 
 	log.Debugw("leased batch of messages", "count", len(batch))
+	ctx, cancel := context.WithDeadline(ctx, claimUntil)
+	defer cancel()
 
 	for _, item := range batch {
 		// Stop processing if we have somehow passed our own lease time

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -60,8 +60,6 @@ func (p *MessageProcessor) processBatch(ctx context.Context) (bool, error) {
 	defer span.End()
 
 	claimUntil := p.clock.Now().Add(p.leaseLength)
-	ctx, cancel := context.WithDeadline(ctx, claimUntil)
-	defer cancel()
 
 	// Lease some blocks to work on
 	batch, err := p.storage.LeaseTipSetMessages(ctx, claimUntil, p.batchSize, p.minHeight, p.maxHeight)
@@ -78,6 +76,8 @@ func (p *MessageProcessor) processBatch(ctx context.Context) (bool, error) {
 	}
 
 	log.Debugw("leased batch of tipsets", "count", len(batch))
+	ctx, cancel := context.WithDeadline(ctx, claimUntil)
+	defer cancel()
 
 	for _, item := range batch {
 		// Stop processing if we have somehow passed our own lease time


### PR DESCRIPTION
This change alters tasks to avoid setting a context deadline when no work has been
leased.