### PR TITLE
fix: chain history indexer includes genesis

### DIFF
--- a/tasks/indexer/chainhistoryindexer.go
+++ b/tasks/indexer/chainhistoryindexer.go
@@ -93,17 +93,16 @@ func (c *ChainHistoryIndexer) WalkChain(ctx context.Context, maxHeight int64) er
 		}
 
 		ts := toVisit.Remove(toVisit.Back()).(*types.TipSet)
-		if ts.Height() == 0 {
-			continue
-		}
 
-		// TODO: Look for websocket connection closed error and retry after a delay to avoid hot loop
-		pts, err := c.node.ChainGetTipSet(ctx, ts.Parents())
-		if err != nil {
-			return xerrors.Errorf("get tipset: %w", err)
-		}
+		if ts.Height() != 0 {
+			// TODO: Look for websocket connection closed error and retry after a delay to avoid hot loop
+			pts, err := c.node.ChainGetTipSet(ctx, ts.Parents())
+			if err != nil {
+				return xerrors.Errorf("get tipset: %w", err)
+			}
 
-		toVisit.PushBack(pts)
+			toVisit.PushBack(pts)
+		}
 
 		if blockData.Seen(ts.Key()) {
 			continue

--- a/tasks/indexer/chainhistoryindexer_test.go
+++ b/tasks/indexer/chainhistoryindexer_test.go
@@ -7,6 +7,7 @@ import (
 
 	apitest "github.com/filecoin-project/lotus/api/test"
 	nodetest "github.com/filecoin-project/lotus/node/test"
+	logging "github.com/ipfs/go-log/v2"
 
 	"github.com/go-pg/pg/v10"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,8 @@ import (
 )
 
 func TestChainHistoryIndexer(t *testing.T) {
+	logging.SetLogLevel("*", "debug")
+
 	if testing.Short() || !testutil.DatabaseAvailable() {
 		t.Skip("short testing requested or VISOR_TEST_DB not set")
 	}


### PR DESCRIPTION
Commit 3b98708 broke the chain indexer test after a reorganization of the chain
walking logic. It stopped processing when reaching genesis but omitted to
persist the genesis block infomation. This change fixes the bug.