### PR TITLE
perf: minor optimization of market actor diffing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipld-cbor v0.0.5-0.20200428170625-a0bd04d3cbdf
 	github.com/ipfs/go-log/v2 v2.1.2-0.20200626104915-0016c0b4b3e4
-	github.com/kortschak/utter v1.0.1
 	github.com/lib/pq v1.8.0
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/multiformats/go-multiaddr v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -18,10 +18,13 @@ require (
 	github.com/go-pg/pgext v0.1.4
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-cid v0.0.7
+	github.com/ipfs/go-ipld-cbor v0.0.5-0.20200428170625-a0bd04d3cbdf
 	github.com/ipfs/go-log/v2 v2.1.2-0.20200626104915-0016c0b4b3e4
+	github.com/kortschak/utter v1.0.1
 	github.com/lib/pq v1.8.0
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/multiformats/go-multiaddr v0.3.1
+	github.com/multiformats/go-multihash v0.0.14
 	github.com/raulk/clock v1.1.0
 	github.com/prometheus/client_golang v1.6.0
 	github.com/stretchr/objx v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -714,8 +714,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
 github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d h1:68u9r4wEvL3gYg2jvAOgROwZ3H+Y3hIDk4tbbmIjcYQ=
 github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
-github.com/kortschak/utter v1.0.1 h1:AJVccwLrdrikvkH0aI5JKlzZIORLpfMeGBQ5tHfIXis=
-github.com/kortschak/utter v1.0.1/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/go.sum
+++ b/go.sum
@@ -153,7 +153,6 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -715,6 +714,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
 github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d h1:68u9r4wEvL3gYg2jvAOgROwZ3H+Y3hIDk4tbbmIjcYQ=
 github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
+github.com/kortschak/utter v1.0.1 h1:AJVccwLrdrikvkH0aI5JKlzZIORLpfMeGBQ5tHfIXis=
+github.com/kortschak/utter v1.0.1/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -1277,7 +1278,6 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0 h1:G9tHG9lebljV9mfp9SNPDL36nCDxmo3zTlAf1YgvzmI=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -1384,7 +1384,6 @@ github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=

--- a/tasks/actorstate/actor.go
+++ b/tasks/actorstate/actor.go
@@ -7,7 +7,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"go.opentelemetry.io/otel/api/global"
 
-	"github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 	commonmodel "github.com/filecoin-project/sentinel-visor/model/actors/common"
@@ -18,7 +17,7 @@ import (
 // ActorExtractor extracts common actor state
 type ActorExtractor struct{}
 
-func (ActorExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+func (ActorExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := global.Tracer("").Start(ctx, "ActorExtractor")
 	defer span.End()
 

--- a/tasks/actorstate/actorstate_test.go
+++ b/tasks/actorstate/actorstate_test.go
@@ -1,0 +1,237 @@
+package actorstate
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
+	samarket "github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/ipfs/go-cid"
+	cbornode "github.com/ipfs/go-ipld-cbor"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/testutil"
+)
+
+func mockTipset(minerAddr address.Address, timestamp uint64) (*types.TipSet, error) {
+	return types.NewTipSet([]*types.BlockHeader{{
+		Miner:                 minerAddr,
+		Height:                5,
+		ParentStateRoot:       testutil.RandomCid(),
+		Messages:              testutil.RandomCid(),
+		ParentMessageReceipts: testutil.RandomCid(),
+		BlockSig:              &crypto.Signature{Type: crypto.SigTypeBLS},
+		BLSAggregate:          &crypto.Signature{Type: crypto.SigTypeBLS},
+		Timestamp:             timestamp,
+	}})
+}
+
+var _ ActorStateAPI = (*MockAPI)(nil)
+
+type MockAPI struct {
+	actors map[actorKey]*types.Actor
+	bs     bstore.Blockstore
+	store  adt.Store
+}
+
+func NewMockAPI() *MockAPI {
+	bs := bstore.NewTemporarySync()
+	return &MockAPI{
+		bs:     bs,
+		actors: make(map[actorKey]*types.Actor),
+		store:  adt.WrapStore(context.Background(), cbornode.NewCborStore(bs)),
+	}
+}
+
+type actorKey struct {
+	tsk  types.TipSetKey
+	addr address.Address
+}
+
+func (m *MockAPI) Store() adt.Store {
+	return m.store
+}
+
+func (m *MockAPI) ChainHasObj(ctx context.Context, c cid.Cid) (bool, error) {
+	return m.bs.Has(c)
+}
+
+func (m *MockAPI) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
+	blk, err := m.bs.Get(c)
+	if err != nil {
+		return nil, xerrors.Errorf("blockstore get: %w", err)
+	}
+
+	return blk.RawData(), nil
+}
+
+func (m *MockAPI) StateReadState(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*api.ActorState, error) {
+	act, err := m.StateGetActor(ctx, actor, tsk)
+	if err != nil {
+		return nil, xerrors.Errorf("getting actor: %w", err)
+	}
+
+	var state interface{}
+	if err := m.store.Get(ctx, act.Head, &state); err != nil {
+		return nil, xerrors.Errorf("getting actor head: %w", err)
+	}
+
+	return &api.ActorState{
+		Balance: act.Balance,
+		State:   state,
+	}, nil
+}
+
+func (m *MockAPI) StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error) {
+	key := actorKey{
+		tsk:  tsk,
+		addr: actor,
+	}
+	act, ok := m.actors[key]
+	if !ok {
+		return nil, xerrors.Errorf("actor not found addr:%s tsk=%s", actor, tsk)
+	}
+	return act, nil
+}
+
+func (m *MockAPI) StateMinerPower(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*api.MinerPower, error) {
+	panic("not implemented yet")
+}
+
+// ----------------- MockAPI Helpers ----------------------------
+
+func (m *MockAPI) setActor(tsk types.TipSetKey, addr address.Address, actor *types.Actor) {
+	key := actorKey{
+		tsk:  tsk,
+		addr: addr,
+	}
+	m.actors[key] = actor
+}
+
+func (m *MockAPI) createMarketState(ctx context.Context, deals map[abi.DealID]*samarket.DealState, props map[abi.DealID]*samarket.DealProposal, balances map[address.Address]balance) (cid.Cid, error) {
+	dealRootCid, err := m.createDealAMT(deals)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	propRootCid, err := m.createProposalAMT(props)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	balancesCids, err := m.createBalanceTable(balances)
+	if err != nil {
+		return cid.Undef, err
+	}
+	state, err := m.newEmptyMarketState()
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	state.States = dealRootCid
+	state.Proposals = propRootCid
+	state.EscrowTable = balancesCids[0]
+	state.LockedTable = balancesCids[1]
+
+	stateCid, err := m.store.Put(ctx, state)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return stateCid, nil
+}
+
+func (m *MockAPI) newEmptyMarketState() (*samarket.State, error) {
+	emptyArrayCid, err := adt.MakeEmptyArray(m.store).Root()
+	if err != nil {
+		return nil, err
+	}
+	emptyMap, err := adt.MakeEmptyMap(m.store).Root()
+	if err != nil {
+		return nil, err
+	}
+	return samarket.ConstructState(emptyArrayCid, emptyMap, emptyMap), nil
+}
+
+func (m *MockAPI) createDealAMT(deals map[abi.DealID]*samarket.DealState) (cid.Cid, error) {
+	root := adt.MakeEmptyArray(m.store)
+	for dealID, dealState := range deals {
+		err := root.Set(uint64(dealID), dealState)
+		if err != nil {
+			return cid.Undef, err
+		}
+	}
+	rootCid, err := root.Root()
+	if err != nil {
+		return cid.Undef, err
+	}
+	return rootCid, nil
+}
+
+func (m *MockAPI) createProposalAMT(props map[abi.DealID]*samarket.DealProposal) (cid.Cid, error) {
+	root := adt.MakeEmptyArray(m.store)
+	for dealID, prop := range props {
+		err := root.Set(uint64(dealID), prop)
+		if err != nil {
+			return cid.Undef, err
+		}
+	}
+	rootCid, err := root.Root()
+	if err != nil {
+		return cid.Undef, err
+	}
+	return rootCid, nil
+}
+
+func (m *MockAPI) createBalanceTable(balances map[address.Address]balance) ([2]cid.Cid, error) {
+	escrowMapRoot := adt.MakeEmptyMap(m.store)
+	escrowMapRootCid, err := escrowMapRoot.Root()
+	if err != nil {
+		return [2]cid.Cid{}, err
+	}
+	escrowRoot, err := adt.AsBalanceTable(m.store, escrowMapRootCid)
+	if err != nil {
+		return [2]cid.Cid{}, err
+	}
+
+	lockedMapRoot := adt.MakeEmptyMap(m.store)
+	lockedMapRootCid, err := lockedMapRoot.Root()
+	if err != nil {
+		return [2]cid.Cid{}, err
+	}
+
+	lockedRoot, err := adt.AsBalanceTable(m.store, lockedMapRootCid)
+	if err != nil {
+		return [2]cid.Cid{}, err
+	}
+
+	for addr, balance := range balances {
+		err := escrowRoot.Add(addr, big.Add(balance.available, balance.locked))
+		if err != nil {
+			return [2]cid.Cid{}, err
+		}
+
+		err = lockedRoot.Add(addr, balance.locked)
+		if err != nil {
+			return [2]cid.Cid{}, err
+		}
+
+	}
+	escrowRootCid, err := escrowRoot.Root()
+	if err != nil {
+		return [2]cid.Cid{}, err
+	}
+
+	lockedRootCid, err := lockedRoot.Root()
+	if err != nil {
+		return [2]cid.Cid{}, err
+	}
+
+	return [2]cid.Cid{escrowRootCid, lockedRootCid}, nil
+}

--- a/tasks/actorstate/genesis_test.go
+++ b/tasks/actorstate/genesis_test.go
@@ -122,7 +122,6 @@ func TestGenesisProcessor(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEqual(t, 0, count)
 	})
-
 }
 
 // truncateGenesisTables ensures the indexing tables are empty

--- a/tasks/actorstate/init.go
+++ b/tasks/actorstate/init.go
@@ -9,7 +9,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/events/state"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 
-	"github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 	initmodel "github.com/filecoin-project/sentinel-visor/model/actors/init"
@@ -24,7 +23,7 @@ func init() {
 	Register(builtin.InitActorCodeID, InitExtractor{})
 }
 
-func (InitExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+func (InitExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := global.Tracer("").Start(ctx, "InitExtractor")
 	defer span.End()
 

--- a/tasks/actorstate/market.go
+++ b/tasks/actorstate/market.go
@@ -31,26 +31,8 @@ func (m StorageMarketExtractor) Extract(ctx context.Context, a ActorInfo, node A
 	stop := metrics.Timer(ctx, metrics.ProcessingDuration)
 	defer stop()
 
-	proposals, err := m.marketDealProposalChanges(ctx, a, node)
-	if err != nil {
-		return nil, err
-	}
-
-	states, err := m.marketDealStateChanges(ctx, a, node)
-	if err != nil {
-		return nil, err
-	}
-
-	return &marketmodel.MarketTaskResult{
-		Proposals: proposals,
-		States:    states,
-	}, nil
-}
-
-func (m StorageMarketExtractor) marketDealStateChanges(ctx context.Context, a ActorInfo, node ActorStateAPI) (marketmodel.MarketDealStates, error) {
-	// TODO: pass in diff to avoid doing it twice
 	pred := state.NewStatePredicates(node)
-	stateDiff := pred.OnStorageMarketActorChanged(pred.OnDealStateChanged(pred.OnDealStateAmtChanged()))
+	stateDiff := pred.OnStorageMarketActorChanged(storageMarketChangesPred(pred))
 	changed, val, err := stateDiff(ctx, a.ParentTipSet, a.TipSet)
 	if err != nil {
 		return nil, err
@@ -58,12 +40,34 @@ func (m StorageMarketExtractor) marketDealStateChanges(ctx context.Context, a Ac
 	if !changed {
 		return nil, xerrors.Errorf("no state change detected")
 	}
-	changes, ok := val.(*market.DealStateChanges)
+
+	mchanges, ok := val.(*marketChanges)
 	if !ok {
-		// indicates a developer error or breaking change in lotus
-		return nil, xerrors.Errorf("Unknown type returned by Deal State AMT predicate: %T", val)
+		return nil, xerrors.Errorf("Unknown type returned by market changes predicate: %T", val)
 	}
 
+	res := &marketmodel.MarketTaskResult{}
+
+	if mchanges.ProposalChanges != nil {
+		proposals, err := m.marketDealProposalChanges(ctx, a, mchanges.ProposalChanges)
+		if err != nil {
+			return nil, err
+		}
+		res.Proposals = proposals
+	}
+
+	if mchanges.DealChanges != nil {
+		states, err := m.marketDealStateChanges(ctx, a, mchanges.DealChanges)
+		if err != nil {
+			return nil, err
+		}
+		res.States = states
+	}
+
+	return res, nil
+}
+
+func (m StorageMarketExtractor) marketDealStateChanges(ctx context.Context, a ActorInfo, changes *market.DealStateChanges) (marketmodel.MarketDealStates, error) {
 	out := make(marketmodel.MarketDealStates, len(changes.Added)+len(changes.Modified))
 	idx := 0
 	for _, add := range changes.Added {
@@ -89,23 +93,7 @@ func (m StorageMarketExtractor) marketDealStateChanges(ctx context.Context, a Ac
 	return out, nil
 }
 
-func (m StorageMarketExtractor) marketDealProposalChanges(ctx context.Context, a ActorInfo, node ActorStateAPI) (marketmodel.MarketDealProposals, error) {
-	// TODO: pass in diff to avoid doing it twice
-	pred := state.NewStatePredicates(node)
-	stateDiff := pred.OnStorageMarketActorChanged(pred.OnDealProposalChanged(pred.OnDealProposalAmtChanged()))
-	changed, val, err := stateDiff(ctx, a.ParentTipSet, a.TipSet)
-	if err != nil {
-		return nil, err
-	}
-	if !changed {
-		return nil, nil
-	}
-	changes, ok := val.(*market.DealProposalChanges)
-	if !ok {
-		// indicates a developer error or breaking change in lotus
-		return nil, xerrors.Errorf("Unknown type returned by Deal Proposal AMT predicate: %T", val)
-	}
-
+func (m StorageMarketExtractor) marketDealProposalChanges(ctx context.Context, a ActorInfo, changes *market.DealProposalChanges) (marketmodel.MarketDealProposals, error) {
 	out := make(marketmodel.MarketDealProposals, len(changes.Added))
 
 	for idx, add := range changes.Added {
@@ -127,4 +115,51 @@ func (m StorageMarketExtractor) marketDealProposalChanges(ctx context.Context, a
 		}
 	}
 	return out, nil
+}
+
+type marketChanges struct {
+	DealChanges     *market.DealStateChanges
+	ProposalChanges *market.DealProposalChanges
+}
+
+// storageMarketChangesPred returns a DiffStorageMarketStateFunc that extracts deal state and deal proposal changes from
+// a single state change.
+func storageMarketChangesPred(pred *state.StatePredicates) state.DiffStorageMarketStateFunc {
+	return func(ctx context.Context, oldState market.State, newState market.State) (changed bool, user state.UserData, err error) {
+		changes := &marketChanges{}
+
+		dealsPred := pred.OnDealStateChanged(pred.OnDealStateAmtChanged())
+		dealsChanged, dealUserData, err := dealsPred(ctx, oldState, newState)
+		if err != nil {
+			return false, nil, nil
+		}
+		if dealsChanged {
+			dealChanges, ok := dealUserData.(*market.DealStateChanges)
+			if !ok {
+				// indicates a developer error or breaking change in lotus
+				return false, nil, xerrors.Errorf("Unknown type returned by Deal State AMT predicate: %T", dealUserData)
+			}
+			changes.DealChanges = dealChanges
+		}
+
+		proposalsPred := pred.OnDealProposalChanged(pred.OnDealProposalAmtChanged())
+		proposalsChanged, proposalsUserData, err := proposalsPred(ctx, oldState, newState)
+		if err != nil {
+			return false, nil, nil
+		}
+		if proposalsChanged {
+			proposalChanges, ok := proposalsUserData.(*market.DealProposalChanges)
+			if !ok {
+				// indicates a developer error or breaking change in lotus
+				return false, nil, xerrors.Errorf("Unknown type returned by Deal Proposal AMT predicate: %T", dealUserData)
+			}
+			changes.ProposalChanges = proposalChanges
+		}
+
+		if !dealsChanged && !proposalsChanged {
+			return false, nil, nil
+		}
+
+		return true, state.UserData(changes), nil
+	}
 }

--- a/tasks/actorstate/market.go
+++ b/tasks/actorstate/market.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/events/state"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 
-	"github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 	marketmodel "github.com/filecoin-project/sentinel-visor/model/actors/market"
@@ -25,7 +24,7 @@ func init() {
 	Register(builtin.StorageMarketActorCodeID, StorageMarketExtractor{})
 }
 
-func (m StorageMarketExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+func (m StorageMarketExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := global.Tracer("").Start(ctx, "StorageMarketExtractor")
 	defer span.End()
 
@@ -48,7 +47,7 @@ func (m StorageMarketExtractor) Extract(ctx context.Context, a ActorInfo, node l
 	}, nil
 }
 
-func (m StorageMarketExtractor) marketDealStateChanges(ctx context.Context, a ActorInfo, node lens.API) (marketmodel.MarketDealStates, error) {
+func (m StorageMarketExtractor) marketDealStateChanges(ctx context.Context, a ActorInfo, node ActorStateAPI) (marketmodel.MarketDealStates, error) {
 	// TODO: pass in diff to avoid doing it twice
 	pred := state.NewStatePredicates(node)
 	stateDiff := pred.OnStorageMarketActorChanged(pred.OnDealStateChanged(pred.OnDealStateAmtChanged()))
@@ -90,7 +89,7 @@ func (m StorageMarketExtractor) marketDealStateChanges(ctx context.Context, a Ac
 	return out, nil
 }
 
-func (m StorageMarketExtractor) marketDealProposalChanges(ctx context.Context, a ActorInfo, node lens.API) (marketmodel.MarketDealProposals, error) {
+func (m StorageMarketExtractor) marketDealProposalChanges(ctx context.Context, a ActorInfo, node ActorStateAPI) (marketmodel.MarketDealProposals, error) {
 	// TODO: pass in diff to avoid doing it twice
 	pred := state.NewStatePredicates(node)
 	stateDiff := pred.OnStorageMarketActorChanged(pred.OnDealProposalChanged(pred.OnDealProposalAmtChanged()))

--- a/tasks/actorstate/market_test.go
+++ b/tasks/actorstate/market_test.go
@@ -1,0 +1,195 @@
+package actorstate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
+	"github.com/filecoin-project/lotus/chain/types"
+	marketmodel "github.com/filecoin-project/sentinel-visor/model/actors/market"
+	sabuiltin "github.com/filecoin-project/specs-actors/actors/builtin"
+	samarket "github.com/filecoin-project/specs-actors/actors/builtin/market"
+	tutils "github.com/filecoin-project/specs-actors/support/testing"
+	"github.com/kortschak/utter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/sentinel-visor/testutil"
+)
+
+type balance struct {
+	available abi.TokenAmount
+	locked    abi.TokenAmount
+}
+
+func TestMarketPredicates(t *testing.T) {
+	ctx := context.Background()
+
+	mapi := NewMockAPI()
+
+	oldDeal1 := &samarket.DealState{
+		SectorStartEpoch: 1,
+		LastUpdatedEpoch: 2,
+		SlashEpoch:       0,
+	}
+	oldDeal2 := &samarket.DealState{
+		SectorStartEpoch: 4,
+		LastUpdatedEpoch: 5,
+		SlashEpoch:       0,
+	}
+	oldDeals := map[abi.DealID]*samarket.DealState{
+		abi.DealID(1): oldDeal1,
+		abi.DealID(2): oldDeal2,
+	}
+
+	oldProp1 := &samarket.DealProposal{
+		PieceCID:             testutil.RandomCid(),
+		PieceSize:            0,
+		VerifiedDeal:         false,
+		Client:               tutils.NewIDAddr(t, 1),
+		Provider:             tutils.NewIDAddr(t, 1),
+		StartEpoch:           1,
+		EndEpoch:             2,
+		StoragePricePerEpoch: big.Zero(),
+		ProviderCollateral:   big.Zero(),
+		ClientCollateral:     big.Zero(),
+	}
+	oldProp2 := &samarket.DealProposal{
+		PieceCID:             testutil.RandomCid(),
+		PieceSize:            0,
+		VerifiedDeal:         false,
+		Client:               tutils.NewIDAddr(t, 1),
+		Provider:             tutils.NewIDAddr(t, 1),
+		StartEpoch:           2,
+		EndEpoch:             3,
+		StoragePricePerEpoch: big.Zero(),
+		ProviderCollateral:   big.Zero(),
+		ClientCollateral:     big.Zero(),
+	}
+	oldProps := map[abi.DealID]*samarket.DealProposal{
+		abi.DealID(1): oldProp1,
+		abi.DealID(2): oldProp2,
+	}
+
+	oldBalances := map[address.Address]balance{
+		tutils.NewIDAddr(t, 1): {abi.NewTokenAmount(1000), abi.NewTokenAmount(1000)},
+		tutils.NewIDAddr(t, 2): {abi.NewTokenAmount(2000), abi.NewTokenAmount(500)},
+		tutils.NewIDAddr(t, 3): {abi.NewTokenAmount(3000), abi.NewTokenAmount(2000)},
+		tutils.NewIDAddr(t, 5): {abi.NewTokenAmount(3000), abi.NewTokenAmount(1000)},
+	}
+
+	oldStateCid, err := mapi.createMarketState(ctx, oldDeals, oldProps, oldBalances)
+	require.NoError(t, err)
+
+	newDeal1 := &samarket.DealState{
+		SectorStartEpoch: 1,
+		LastUpdatedEpoch: 3,
+		SlashEpoch:       0,
+	}
+
+	// deal 2 removed
+
+	// added
+	newDeal3 := &samarket.DealState{
+		SectorStartEpoch: 1,
+		LastUpdatedEpoch: 2,
+		SlashEpoch:       3,
+	}
+	newDeals := map[abi.DealID]*samarket.DealState{
+		abi.DealID(1): newDeal1,
+		// deal 2 was removed
+		abi.DealID(3): newDeal3,
+	}
+
+	// added
+	newProp3 := &samarket.DealProposal{
+		PieceCID:             testutil.RandomCid(),
+		PieceSize:            0,
+		VerifiedDeal:         false,
+		Client:               tutils.NewIDAddr(t, 1),
+		Provider:             tutils.NewIDAddr(t, 1),
+		StartEpoch:           4,
+		EndEpoch:             4,
+		StoragePricePerEpoch: big.Zero(),
+		ProviderCollateral:   big.Zero(),
+		ClientCollateral:     big.Zero(),
+	}
+	newProps := map[abi.DealID]*samarket.DealProposal{
+		abi.DealID(1): oldProp1, // 1 was persisted
+		// prop 2 was removed
+		abi.DealID(3): newProp3, // new
+	}
+	newBalances := map[address.Address]balance{
+		tutils.NewIDAddr(t, 1): {abi.NewTokenAmount(3000), abi.NewTokenAmount(0)},
+		tutils.NewIDAddr(t, 2): {abi.NewTokenAmount(2000), abi.NewTokenAmount(500)},
+		tutils.NewIDAddr(t, 4): {abi.NewTokenAmount(5000), abi.NewTokenAmount(0)},
+		tutils.NewIDAddr(t, 5): {abi.NewTokenAmount(1000), abi.NewTokenAmount(3000)},
+	}
+
+	newStateCid, err := mapi.createMarketState(ctx, newDeals, newProps, newBalances)
+	require.NoError(t, err)
+
+	minerAddr, err := address.NewFromString("t00")
+	require.NoError(t, err)
+	oldStateTs, err := mockTipset(minerAddr, 1)
+	require.NoError(t, err)
+	newStateTs, err := mockTipset(minerAddr, 2)
+	require.NoError(t, err)
+
+	mapi.setActor(oldStateTs.Key(), market.Address, &types.Actor{Code: sabuiltin.StorageMarketActorCodeID, Head: oldStateCid})
+	mapi.setActor(newStateTs.Key(), market.Address, &types.Actor{Code: sabuiltin.StorageMarketActorCodeID, Head: newStateCid})
+
+	info := ActorInfo{
+		Actor:        types.Actor{Code: sabuiltin.StorageMarketActorCodeID, Head: newStateCid},
+		Address:      market.Address,
+		TipSet:       newStateTs.Key(),
+		ParentTipSet: oldStateTs.Key(),
+	}
+
+	ex := StorageMarketExtractor{}
+	res, err := ex.Extract(ctx, info, mapi)
+	require.NoError(t, err)
+
+	mtr, ok := res.(*marketmodel.MarketTaskResult)
+	require.True(t, ok)
+	require.NotNil(t, mtr)
+	utter.Dump(mtr)
+
+	t.Run("proposals", func(t *testing.T) {
+		require.Equal(t, 1, len(mtr.Proposals))
+
+		assert.EqualValues(t, abi.DealID(3), mtr.Proposals[0].DealID, "DealID")
+		assert.EqualValues(t, info.ParentStateRoot.String(), mtr.Proposals[0].StateRoot, "StateRoot")
+		assert.EqualValues(t, newProp3.PieceSize, mtr.Proposals[0].PaddedPieceSize, "PaddedPieceSize")
+		assert.EqualValues(t, newProp3.PieceSize.Unpadded(), mtr.Proposals[0].UnpaddedPieceSize, "UnpaddedPieceSize")
+		assert.EqualValues(t, newProp3.StartEpoch, mtr.Proposals[0].StartEpoch, "StartEpoch")
+		assert.EqualValues(t, newProp3.EndEpoch, mtr.Proposals[0].EndEpoch, "EndEpoch")
+		assert.EqualValues(t, newProp3.Client.String(), mtr.Proposals[0].ClientID, "ClientID")
+		assert.EqualValues(t, newProp3.Provider.String(), mtr.Proposals[0].ProviderID, "ProviderID")
+		assert.EqualValues(t, newProp3.ClientCollateral.String(), mtr.Proposals[0].ClientCollateral, "ClientCollateral")
+		assert.EqualValues(t, newProp3.ProviderCollateral.String(), mtr.Proposals[0].ProviderCollateral, "ProviderCollateral")
+		assert.EqualValues(t, newProp3.StoragePricePerEpoch.String(), mtr.Proposals[0].StoragePricePerEpoch, "StoragePricePerEpoch")
+		assert.EqualValues(t, newProp3.PieceCID.String(), mtr.Proposals[0].PieceCID, "PieceCID")
+		assert.EqualValues(t, newProp3.VerifiedDeal, mtr.Proposals[0].IsVerified, "IsVerified")
+		assert.EqualValues(t, newProp3.Label, mtr.Proposals[0].Label, "Label")
+	})
+
+	t.Run("states", func(t *testing.T) {
+		require.Equal(t, 2, len(mtr.States))
+
+		assert.EqualValues(t, abi.DealID(3), mtr.States[0].DealID, "DealID")
+		assert.EqualValues(t, newDeal3.SectorStartEpoch, mtr.States[0].SectorStartEpoch, "SectorStartEpoch")
+		assert.EqualValues(t, newDeal3.LastUpdatedEpoch, mtr.States[0].LastUpdateEpoch, "LastUpdateEpoch")
+		assert.EqualValues(t, newDeal3.SlashEpoch, mtr.States[0].SlashEpoch, "SlashEpoch")
+		assert.EqualValues(t, info.ParentStateRoot.String(), mtr.States[0].StateRoot, "StateRoot")
+
+		assert.EqualValues(t, abi.DealID(1), mtr.States[1].DealID, "DealID")
+		assert.EqualValues(t, newDeal1.SectorStartEpoch, mtr.States[1].SectorStartEpoch, "SectorStartEpoch")
+		assert.EqualValues(t, newDeal1.LastUpdatedEpoch, mtr.States[1].LastUpdateEpoch, "LastUpdateEpoch")
+		assert.EqualValues(t, newDeal1.SlashEpoch, mtr.States[1].SlashEpoch, "SlashEpoch")
+		assert.EqualValues(t, info.ParentStateRoot.String(), mtr.States[1].StateRoot, "StateRoot")
+	})
+}

--- a/tasks/actorstate/market_test.go
+++ b/tasks/actorstate/market_test.go
@@ -13,7 +13,6 @@ import (
 	sabuiltin "github.com/filecoin-project/specs-actors/actors/builtin"
 	samarket "github.com/filecoin-project/specs-actors/actors/builtin/market"
 	tutils "github.com/filecoin-project/specs-actors/support/testing"
-	"github.com/kortschak/utter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -156,7 +155,6 @@ func TestMarketPredicates(t *testing.T) {
 	mtr, ok := res.(*marketmodel.MarketTaskResult)
 	require.True(t, ok)
 	require.NotNil(t, mtr)
-	utter.Dump(mtr)
 
 	t.Run("proposals", func(t *testing.T) {
 		require.Equal(t, 1, len(mtr.Proposals))

--- a/tasks/actorstate/miner.go
+++ b/tasks/actorstate/miner.go
@@ -9,7 +9,6 @@ import (
 	miner "github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 
-	"github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 	minermodel "github.com/filecoin-project/sentinel-visor/model/actors/miner"
@@ -24,7 +23,7 @@ func init() {
 	Register(builtin.StorageMinerActorCodeID, StorageMinerExtractor{})
 }
 
-func (m StorageMinerExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+func (m StorageMinerExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	// TODO:
 	// - all processing below can and probably should be done in parallel.
 	// - processing is incomplete, see below TODO about sector inspection.

--- a/tasks/actorstate/power.go
+++ b/tasks/actorstate/power.go
@@ -9,7 +9,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 
-	"github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 	powermodel "github.com/filecoin-project/sentinel-visor/model/actors/power"
@@ -24,7 +23,7 @@ func init() {
 	Register(builtin.StoragePowerActorCodeID, StoragePowerExtractor{})
 }
 
-func (StoragePowerExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+func (StoragePowerExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := global.Tracer("").Start(ctx, "StoragePowerExtractor")
 	defer span.End()
 

--- a/tasks/actorstate/reward.go
+++ b/tasks/actorstate/reward.go
@@ -7,7 +7,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"go.opentelemetry.io/otel/api/global"
 
-	"github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 	rewardmodel "github.com/filecoin-project/sentinel-visor/model/actors/reward"
@@ -22,7 +21,7 @@ func init() {
 	Register(builtin.RewardActorCodeID, RewardExtractor{})
 }
 
-func (RewardExtractor) Extract(ctx context.Context, a ActorInfo, node lens.API) (model.Persistable, error) {
+func (RewardExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := global.Tracer("").Start(ctx, "RewardExtractor")
 	defer span.End()
 

--- a/testutil/ipfs.go
+++ b/testutil/ipfs.go
@@ -1,0 +1,24 @@
+package testutil
+
+import (
+	"math/rand"
+	"strconv"
+
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+)
+
+var cidPref = cid.Prefix{
+	Version:  1,
+	Codec:    cid.Raw,
+	MhType:   multihash.SHA2_256,
+	MhLength: -1,
+}
+
+func RandomCid() cid.Cid {
+	c, err := cidPref.Sum([]byte(strconv.Itoa(rand.Int())))
+	if err != nil {
+		panic("randomCid: " + err.Error())
+	}
+	return c
+}


### PR DESCRIPTION
The first commit adds a test for market actor state diffing and adds a mock API that will help with writing future unit tests for actor state extraction.

The second commit changes the implementation of market state extraction to combine the deal and proposal diffing into a single predicate so the old and new actor states are only loaded once.