### PR TITLE
feat(debug): Process actor by head without persistance

### DIFF
--- a/commands/debug.go
+++ b/commands/debug.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/tasks/actorstate"
+)
+
+var Debug = &cli.Command{
+	Name:  "debug",
+	Usage: "Execute individual tasks without persisting them to the database",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "actor-head",
+			Usage: "Process task in visor_processing_actors by head",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if err := setupLogging(cctx); err != nil {
+			return xerrors.Errorf("setup logging: %w", err)
+		}
+
+		tcloser, err := setupTracing(cctx)
+		if err != nil {
+			return xerrors.Errorf("setup tracing: %w", err)
+		}
+		defer tcloser()
+
+		ctx, rctx, err := setupStorageAndAPI(cctx)
+		if err != nil {
+			return xerrors.Errorf("setup storage and api: %w", err)
+		}
+		defer func() {
+			rctx.closer()
+			if err := rctx.db.Close(ctx); err != nil {
+				log.Errorw("close database", "error", err)
+			}
+		}()
+
+		p, err := actorstate.NewActorStateProcessor(rctx.db, rctx.api, 0, 0, 0, 0, actorstate.SupportedActorCodes())
+		if err != nil {
+			return err
+		}
+
+		return p.Debug(ctx, cctx.String("actor-head"), os.Stdout)
+	},
+}

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ func main() {
 		Commands: []*cli.Command{
 			commands.Migrate,
 			commands.Run,
+			commands.Debug,
 		},
 	}
 

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -309,6 +309,26 @@ func (d *Database) MarkStateChangeComplete(ctx context.Context, tsk string, heig
 	return nil
 }
 
+// GetActorByHead returns an actor without a lease by its CID
+func (d *Database) GetActorByHead(ctx context.Context, head string) (*visor.ProcessingActor, error) {
+	if len(head) == 0 {
+		return nil, xerrors.Errorf("lookup actor head was empty")
+	}
+
+	d.DB.AddQueryHook(pgext.DebugHook{
+		Verbose: true, // Print all queries.
+	})
+
+	a := new(visor.ProcessingActor)
+	if err := d.DB.ModelContext(ctx, a).
+		Where("head = ?", head).
+		Limit(1).
+		Select(); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
 // LeaseActors leases a set of actors to process. minHeight and maxHeight define an inclusive range of heights to process.
 func (d *Database) LeaseActors(ctx context.Context, claimUntil time.Time, batchSize int, minHeight, maxHeight int64, codes []string) (visor.ProcessingActorList, error) {
 	var actors visor.ProcessingActorList

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -2,7 +2,11 @@ package actorstate
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -119,6 +123,65 @@ type ActorStateProcessor struct {
 	actorCodes  []string                        // list of actor codes that will be requested
 	extractors  map[cid.Cid]ActorStateExtractor // list of extractors that will be used
 	clock       clock.Clock
+}
+
+func trackDuration(topic string, w io.Writer) func() {
+	t := time.Now()
+	return func() {
+		w.Write([]byte(fmt.Sprintf("** %s finished in %s\n", topic, time.Since(t))))
+	}
+}
+
+// Debug runs an individual actor and returns result
+func (p *ActorStateProcessor) Debug(ctx context.Context, head string, writer io.Writer) error {
+	defer trackDuration("debug total", writer)()
+	printActorDuration := trackDuration("get actor", writer)
+	actor, err := p.storage.GetActorByHead(ctx, head)
+	if err != nil {
+		return xerrors.Errorf("get actor by head: %w", err)
+	}
+	printActorDuration()
+
+	printNewActorDuration := trackDuration("new actor info", writer)
+	info, err := NewActorInfo(actor)
+	if err != nil {
+		return xerrors.Errorf("new actor info: %w", err)
+	}
+	printNewActorDuration()
+	defer trackDuration("debug actor", writer)()
+	if err := p.debugActor(ctx, info, writer); err != nil {
+		return xerrors.Errorf("debug actor: %w", err)
+	}
+	return nil
+}
+
+func (p *ActorStateProcessor) debugActor(ctx context.Context, info ActorInfo, writer io.Writer) error {
+	// extract actor state
+	extractor, exists := p.extractors[info.Actor.Code]
+	if !exists {
+		return xerrors.Errorf("no extractor defined for actor code %q", info.Actor.Code.String())
+	}
+
+	data, err := extractor.Extract(ctx, info, p.node)
+	if err != nil {
+		return xerrors.Errorf("extract actor state: %w", err)
+	}
+
+	dm, err := json.MarshalIndent(data, "    ", "  ")
+	if err != nil {
+		return xerrors.Errorf("marshaling actor state: %w", err)
+	}
+
+	var result strings.Builder
+	header := "** ActorProcessorResult:\n"
+	result.Grow(len(header) + len(dm))
+	if _, err := result.WriteString(header); err != nil {
+		return xerrors.Errorf("writing actor state: %w", err)
+	}
+	result.Write(dm)
+	fmt.Fprint(writer, result.String())
+
+	return nil
 }
 
 // Run starts processing batches of actors and blocks until the context is done or


### PR DESCRIPTION
Usage: `./visor debug --actor-head <head-cid>`

```
$ ./visor --log-level=debug debug --actor-head bafy2bzaceav5xqjxizyht2o7ps5zt6zsky6itsvo5hzgwbsgehrrw6zhvrw6m
2020-10-10T22:37:15.637Z        INFO    visor/lens/lotus        lotus/lotus.go:53       Lotus API version: 0.9.0+git.8f35a5c0
SELECT "processing_actor"."head", "processing_actor"."code", "processing_actor"."nonce", "processing_actor"."balance", "processing_actor"."address", "processing_actor"."parent_state_root", "processing_actor"."tip_set", "processing_actor"."parent_tip_set", "processing_acto
r"."height", "processing_actor"."added_at", "processing_actor"."claimed_until", "processing_actor"."completed_at", "processing_actor"."errors_detected" FROM "visor_processing_actors" AS "processing_actor" WHERE (head = 'bafy2bzaceav5xqjxizyht2o7ps5zt6zsky6itsvo5hzgwbsgehr
rw6zhvrw6m') LIMIT 1
** get actor finished in 1.606408ms
** new actor info finished in 21.391µs
** ActorProcessorResult:
{
      "Ts": [
        {
          "/": "bafy2bzacea6ryf7fordylzhchpkc7ww25tk7mtpj262q5nv5ruc2ghufd3et2"
        },
        {
          "/": "bafy2bzaceagbsfjuyv7bovamsjpjhlbfxvwimiudzqm7nmxh3ncjzlczhixga"
        },
        {
          "/": "bafy2bzacedvajzu2prcq6ojwre43wivlhx3tmsb2wh6oxswas3ndqnwsghwbu"
        },
        {
          "/": "bafy2bzacedylz3ltal44ixciojtuszxdui4sb6jcaxxgpch3pjdrl4zbletjo"
        },
        {
          "/": "bafy2bzaceczgiyykt425horot7khxoxfztocq34noxvcypdzgkr3dfmprlm3m"
        }
      ],
      "Pts": [
        {
          "/": "bafy2bzacedn7xwashv7u6knwz7ucwrnvjqzj362h3xi3usaux4ezx2zk3yad6"
        }
      ],
      "StateRoot": {
        "/": "bafy2bzacebagf5wjtwxt2p3tb36smp4acsai7xrbf524ccd3kkfocqd3n6ocq"
      },
      "Addr": "t09999",
      "Actor": {
        "Code": {
          "/": "bafkqaetgnfwc6mjpon2g64tbm5sw22lomvza"
        },
        "Head": {
          "/": "bafy2bzaceav5xqjxizyht2o7ps5zt6zsky6itsvo5hzgwbsgehrrw6zhvrw6m"
        },
        "Nonce": 0,
        "Balance": "0"
      },
      "State": {
        "Info": {
          "/": "bafy2bzacebvnwjnmkvjv3o4245vcjw6sr74vxexx4h4d4wqewsdfw7f43doa2"
        },
        "PreCommitDeposits": "0",
        "LockedFunds": "0",
        "VestingFunds": {
          "/": "bafy2bzacealbq6s7ptdud6gvpc2yv54opwotncjlqjxmzb2q2rnjxv753rwdc"
        },
        "InitialPledgeRequirement": "0",
        "PreCommittedSectors": {
          "/": "bafy2bzaceamp42wmmgr2g2ymg46euououzfyck7szknvfacqscohrvaikwfay"
        },
        "PreCommittedSectorsExpiry": {
          "/": "bafy2bzacedswlcz5ddgqnyo3sak3jmhmkxashisnlpq6ujgyhe4mlobzpnhs6"
        },
        "AllocatedSectors": {
          "/": "bafy2bzacea456askyutsf7uk4ta2q5aojrlcji4mhaqokbfalgvoq4ueeh4l2"
        },
        "Sectors": {
          "/": "bafy2bzacedswlcz5ddgqnyo3sak3jmhmkxashisnlpq6ujgyhe4mlobzpnhs6"
        },
        "ProvingPeriodStart": 112899,
        "CurrentDeadline": 20,
        "Deadlines": {
          "/": "bafy2bzaceakubxbluycf7ug7ve3o5yg2kwbhjaf65gtu5m4ethfrq2qxurtcy"
        },
        "EarlyTerminations": [
          0
        ]
      },
      "Info": {
        "Owner": "t09034",
        "Worker": "t09034",
        "NewWorker": "\u003cempty\u003e",
        "ControlAddresses": null,
        "WorkerChangeEpoch": -1,
        "PeerId": "12D3KooWN8AFaTHatE5dqAtZbStjsL8t1ZJv7zGT1xNZCpTPCYuz",
        "Multiaddrs": null,
        "SealProofType": 3,
        "SectorSize": 34359738368,
        "WindowPoStPartitionSectors": 2349
      },
      "Power": {
        "MinerPower": {
          "RawBytePower": "0",
          "QualityAdjPower": "0"
        },
        "TotalPower": {
          "RawBytePower": "455171391260459008",
          "QualityAdjPower": "455171391260459008"
        },
        "HasMinPower": false
      },
      "PreCommitChanges": {
        "Added": null,
        "Removed": null
      },
      "SectorChanges": {
        "Added": null,
        "Extended": null,
        "Removed": null
      },
      "PartitionDiff": null
    }** debug actor finished in 3.491511ms
** debug total finished in 5.147261ms
SELECT pg_advisory_unlock_shared(1);
```