### PR TITLE
fix(schema): Add index on visor_processing_actors.height

### DIFF
--- a/storage/migrations/9_processing_actor_height_index.go
+++ b/storage/migrations/9_processing_actor_height_index.go
@@ -1,0 +1,17 @@
+package migrations
+
+import (
+	"github.com/go-pg/migrations/v8"
+)
+
+// Schema version 9 adds a height index to the visor_processing_actors tables
+
+func init() {
+	up := batch(`
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "visor_processing_actors_height" ON "public"."visor_processing_actors" USING BTREE (height DESC);
+`)
+	down := batch(`
+DROP INDEX IF EXISTS "visor_processing_actors_height";
+	`)
+	migrations.MustRegisterTx(up, down)
+}


### PR DESCRIPTION
Note: This depends on https://github.com/filecoin-project/sentinel-visor/pull/74/files being merged to maintain sequential migrations.

Improve the storage.LeaseActors method which was taking a bit long to select over height.