### PR TITLE
perf(db): reduce batch size for chain history indexer

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -59,7 +59,7 @@ var Run = &cli.Command{
 			Aliases: []string{"ihb"},
 			Value:   25,
 			Usage:   "Batch size for the chain history indexer",
-			EnvVars: []string{"VISOR_indexhistory_BATCH"},
+			EnvVars: []string{"VISOR_INDEXHISTORY_BATCH"},
 		},
 
 		&cli.DurationFlag{

--- a/commands/run.go
+++ b/commands/run.go
@@ -54,6 +54,13 @@ var Run = &cli.Command{
 			Usage:   "Start indexing tipsets by walking the chain history",
 			EnvVars: []string{"VISOR_INDEXHISTORY"},
 		},
+		&cli.IntFlag{
+			Name:    "indexhistory-batch",
+			Aliases: []string{"ihb"},
+			Value:   25,
+			Usage:   "Batch size for the chain history indexer",
+			EnvVars: []string{"VISOR_indexhistory_BATCH"},
+		},
 
 		&cli.DurationFlag{
 			Name:    "statechange-lease",
@@ -237,7 +244,7 @@ var Run = &cli.Command{
 		if cctx.Bool("indexhistory") {
 			scheduler.Add(schedule.TaskConfig{
 				Name:                "ChainHistoryIndexer",
-				Task:                indexer.NewChainHistoryIndexer(rctx.db, rctx.api),
+				Task:                indexer.NewChainHistoryIndexer(rctx.db, rctx.api, cctx.Int("indexhistory-batch")),
 				Locker:              NewGlobalSingleton(ChainHistoryIndexerLockID, rctx.db), // only want one history indexer anywhere to be running
 				RestartOnFailure:    true,
 				RestartOnCompletion: true,

--- a/tasks/indexer/chainhistoryindexer.go
+++ b/tasks/indexer/chainhistoryindexer.go
@@ -15,12 +15,12 @@ import (
 	"github.com/filecoin-project/sentinel-visor/storage"
 )
 
-func NewChainHistoryIndexer(d *storage.Database, node lens.API) *ChainHistoryIndexer {
+func NewChainHistoryIndexer(d *storage.Database, node lens.API, batchSize int) *ChainHistoryIndexer {
 	return &ChainHistoryIndexer{
 		node:      node,
 		storage:   d,
 		finality:  900,
-		batchSize: 500,
+		batchSize: batchSize,
 	}
 }
 


### PR DESCRIPTION
Makes batch size configurable. The high batch size was causing enormous insert queries
to be sent to postgres which were always taking > 10s to process, holding locks in the
process.