### PR TITLE
fix(migration): message gas economy uses bigint

### DIFF
--- a/storage/migrations/10_message_gas_economy.go
+++ b/storage/migrations/10_message_gas_economy.go
@@ -8,8 +8,8 @@ func init() {
 	up := batch(`
 CREATE TABLE IF NOT EXISTS public.message_gas_economy (
 	"state_root" text NOT NULL,
-	"gas_limit_total" double precision NOT NULL,
-	"gas_limit_unique_total "double precision NULL,
+	"gas_limit_total" bigint NOT NULL,
+	"gas_limit_unique_total" bigint NULL,
 	"base_fee" double precision NOT NULL,
 	"base_fee_change_log" double precision NOT NULL,
 	"gas_fill_ratio" double precision NULL,


### PR DESCRIPTION
I don't think we have deployed a version of visor beyond this, given that I feel comfortable modifying the migration. If there are strong feelings against this I will modify it by adding another migration instead of altering this one.