### PR TITLE
feat: convert processing, block and message tables to hypertables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
   timescaledb:
     container_name: timescaledb
-    image: timescale/timescaledb:latest-pg10
+    image: timescale/timescaledb:latest-pg12
     ports:
       - "5432:5432"
     environment:

--- a/model/actors/common/actors.go
+++ b/model/actors/common/actors.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Actor struct {
+	Height    int64  `pg:",pk,notnull,use_zero"`
 	ID        string `pg:",pk,notnull"`
 	StateRoot string `pg:",pk,notnull"`
 	Code      string `pg:",notnull"`
@@ -28,9 +29,10 @@ func (a *Actor) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
 }
 
 type ActorState struct {
-	Head  string `pg:",pk,notnull"`
-	Code  string `pg:",pk,notnull"`
-	State string `pg:",type:jsonb,notnull"`
+	Height int64  `pg:",pk,notnull,use_zero"`
+	Head   string `pg:",pk,notnull"`
+	Code   string `pg:",pk,notnull"`
+	State  string `pg:",type:jsonb,notnull"`
 }
 
 func (s *ActorState) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
@@ -42,5 +44,4 @@ func (s *ActorState) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
 		return err
 	}
 	return nil
-
 }

--- a/model/actors/market/dealproposal.go
+++ b/model/actors/market/dealproposal.go
@@ -10,6 +10,7 @@ import (
 )
 
 type MarketDealProposal struct {
+	Height    int64  `pg:",pk,notnull,use_zero"`
 	DealID    uint64 `pg:",pk,use_zero"`
 	StateRoot string `pg:",notnull"`
 

--- a/model/actors/market/dealstate.go
+++ b/model/actors/market/dealstate.go
@@ -10,6 +10,7 @@ import (
 )
 
 type MarketDealState struct {
+	Height           int64  `pg:",pk,notnull,use_zero"`
 	DealID           uint64 `pg:",pk,use_zero"`
 	SectorStartEpoch int64  `pg:",pk,use_zero"`
 	LastUpdateEpoch  int64  `pg:",pk,use_zero"`

--- a/model/actors/miner/power.go
+++ b/model/actors/miner/power.go
@@ -10,6 +10,7 @@ import (
 
 func NewMinerPowerModel(res *MinerTaskResult) *MinerPower {
 	return &MinerPower{
+		Height:               int64(res.Height),
 		MinerID:              res.Addr.String(),
 		StateRoot:            res.StateRoot.String(),
 		RawBytePower:         res.Power.MinerPower.RawBytePower.String(),
@@ -18,6 +19,7 @@ func NewMinerPowerModel(res *MinerTaskResult) *MinerPower {
 }
 
 type MinerPower struct {
+	Height               int64  `pg:",pk,notnull,use_zero"`
 	MinerID              string `pg:",pk,notnull"`
 	StateRoot            string `pg:",pk,notnull"`
 	RawBytePower         string `pg:",notnull"`

--- a/model/actors/miner/precommit.go
+++ b/model/actors/miner/precommit.go
@@ -11,6 +11,7 @@ import (
 )
 
 type MinerPreCommitInfo struct {
+	Height    int64  `pg:",pk,notnull,use_zero"`
 	MinerID   string `pg:",pk,notnull"`
 	SectorID  uint64 `pg:",pk,use_zero"`
 	StateRoot string `pg:",pk,notnull"`
@@ -43,6 +44,7 @@ func NewMinerPreCommitInfos(res *MinerTaskResult) MinerPreCommitInfos {
 	out := make(MinerPreCommitInfos, len(res.PreCommitChanges.Added))
 	for i, added := range res.PreCommitChanges.Added {
 		pc := &MinerPreCommitInfo{
+			Height:    int64(res.Height),
 			MinerID:   res.Addr.String(),
 			SectorID:  uint64(added.Info.SectorNumber),
 			StateRoot: res.StateRoot.String(),

--- a/model/actors/miner/sector.go
+++ b/model/actors/miner/sector.go
@@ -11,6 +11,7 @@ import (
 )
 
 type MinerSectorInfo struct {
+	Height    int64  `pg:",pk,notnull,use_zero"`
 	MinerID   string `pg:",pk,notnull"`
 	SectorID  uint64 `pg:",pk,use_zero"`
 	StateRoot string `pg:",pk,notnull"`
@@ -41,6 +42,7 @@ func NewMinerSectorInfos(res *MinerTaskResult) MinerSectorInfos {
 	out := make(MinerSectorInfos, len(res.SectorChanges.Added))
 	for i, added := range res.SectorChanges.Added {
 		si := &MinerSectorInfo{
+			Height:                int64(res.Height),
 			MinerID:               res.Addr.String(),
 			SectorID:              uint64(added.SectorNumber),
 			StateRoot:             res.StateRoot.String(),

--- a/model/actors/miner/sector_events.go
+++ b/model/actors/miner/sector_events.go
@@ -27,6 +27,7 @@ const (
 )
 
 type MinerSectorEvent struct {
+	Height    int64  `pg:",pk,notnull,use_zero"`
 	MinerID   string `pg:",pk,notnull"`
 	SectorID  uint64 `pg:",pk,use_zero"`
 	StateRoot string `pg:",pk,notnull"`

--- a/model/actors/miner/sectordeals.go
+++ b/model/actors/miner/sectordeals.go
@@ -11,6 +11,7 @@ import (
 )
 
 type MinerDealSector struct {
+	Height   int64  `pg:",pk,notnull,use_zero"`
 	MinerID  string `pg:",pk,notnull"`
 	SectorID uint64 `pg:",pk,use_zero"`
 	DealID   uint64 `pg:",use_zero"`

--- a/model/actors/miner/sectorposts.go
+++ b/model/actors/miner/sectorposts.go
@@ -12,9 +12,9 @@ import (
 )
 
 type MinerSectorPost struct {
+	Height   int64  `pg:",pk,notnull,use_zero"`
 	MinerID  string `pg:",pk,notnull"`
 	SectorID uint64 `pg:",pk,notnull,use_zero"`
-	Epoch    int64  `pg:",pk,notnull"`
 
 	PostMessageCID string
 }
@@ -38,9 +38,9 @@ func NewMinerSectorPost(task *MinerTaskResult) MinerSectorPosts {
 			mid = c.String()
 		}
 		post := &MinerSectorPost{
+			Height:         int64(task.Height),
 			MinerID:        task.Addr.String(),
 			SectorID:       s,
-			Epoch:          int64(task.Height),
 			PostMessageCID: mid,
 		}
 		out = append(out, post)

--- a/model/actors/miner/state.go
+++ b/model/actors/miner/state.go
@@ -10,6 +10,7 @@ import (
 
 func NewMinerStateModel(res *MinerTaskResult) *MinerState {
 	ms := &MinerState{
+		Height:     int64(res.Height),
 		MinerID:    res.Addr.String(),
 		OwnerID:    res.Info.Owner.String(),
 		WorkerID:   res.Info.Worker.String(),
@@ -24,6 +25,7 @@ func NewMinerStateModel(res *MinerTaskResult) *MinerState {
 }
 
 type MinerState struct {
+	Height     int64  `pg:",pk,notnull,use_zero"`
 	MinerID    string `pg:",pk,notnull"`
 	OwnerID    string `pg:",notnull"`
 	WorkerID   string `pg:",notnull"`
@@ -35,7 +37,6 @@ func (ms *MinerState) Persist(ctx context.Context, db *pg.DB) error {
 	return db.RunInTransaction(ctx, func(tx *pg.Tx) error {
 		return ms.PersistWithTx(ctx, tx)
 	})
-
 }
 
 func (ms *MinerState) PersistWithTx(ctx context.Context, tx *pg.Tx) error {

--- a/model/actors/power/chainpower.go
+++ b/model/actors/power/chainpower.go
@@ -11,6 +11,7 @@ import (
 )
 
 type ChainPower struct {
+	Height    int64  `pg:",pk,notnull,use_zero"`
 	StateRoot string `pg:",pk"`
 
 	TotalRawBytesPower string `pg:",notnull"`

--- a/model/actors/reward/chainreward.go
+++ b/model/actors/reward/chainreward.go
@@ -10,6 +10,7 @@ import (
 )
 
 type ChainReward struct {
+	Height                            int64  `pg:",pk,notnull,use_zero"`
 	StateRoot                         string `pg:",pk,notnull"`
 	CumSumBaseline                    string `pg:",notnull"`
 	CumSumRealized                    string `pg:",notnull"`

--- a/model/blocks/header.go
+++ b/model/blocks/header.go
@@ -12,13 +12,13 @@ import (
 )
 
 type BlockHeader struct {
+	Height          int64  `pg:",pk,use_zero,notnull"`
 	Cid             string `pg:",pk,notnull"`
 	Miner           string `pg:",notnull"`
 	ParentWeight    string `pg:",notnull"`
 	ParentBaseFee   string `pg:",notnull"`
 	ParentStateRoot string `pg:",notnull"`
 
-	Height        int64  `pg:",use_zero"`
 	WinCount      int64  `pg:",use_zero"`
 	Timestamp     uint64 `pg:",use_zero"`
 	ForkSignaling uint64 `pg:",use_zero"`

--- a/model/blocks/parent.go
+++ b/model/blocks/parent.go
@@ -12,6 +12,7 @@ import (
 )
 
 type BlockParent struct {
+	Height int64  `pg:",pk,notnull,use_zero"`
 	Block  string `pg:",pk,notnull"`
 	Parent string `pg:",notnull"`
 }
@@ -31,6 +32,7 @@ func NewBlockParents(header *types.BlockHeader) BlockParents {
 	var out BlockParents
 	for _, p := range header.Parents {
 		out = append(out, &BlockParent{
+			Height: int64(header.Height),
 			Block:  header.Cid().String(),
 			Parent: p.String(),
 		})

--- a/model/messages/blockmessage.go
+++ b/model/messages/blockmessage.go
@@ -14,6 +14,7 @@ import (
 )
 
 type BlockMessage struct {
+	Height  int64  `pg:",pk,notnull,use_zero"`
 	Block   string `pg:",pk,notnull"`
 	Message string `pg:",pk,notnull"`
 }

--- a/model/messages/gaseconomy.go
+++ b/model/messages/gaseconomy.go
@@ -9,6 +9,7 @@ import (
 
 type MessageGasEconomy struct {
 	tableName struct{} `pg:"message_gas_economy"`
+	Height    int64    `pg:",pk,notnull,use_zero"`
 	StateRoot string   `pg:",pk,notnull"`
 
 	BaseFee          float64 `pg:",use_zero"`

--- a/model/messages/message.go
+++ b/model/messages/message.go
@@ -14,7 +14,8 @@ import (
 )
 
 type Message struct {
-	Cid string `pg:",pk,notnull"`
+	Height int64  `pg:",pk,notnull,use_zero"`
+	Cid    string `pg:",pk,notnull"`
 
 	From       string `pg:",notnull"`
 	To         string `pg:",notnull"`

--- a/model/messages/parsedmessage.go
+++ b/model/messages/parsedmessage.go
@@ -14,9 +14,8 @@ import (
 )
 
 type ParsedMessage struct {
-	Cid string `pg:",pk,notnull"`
-
-	Height int64  `pg:",use_zero"`
+	Height int64  `pg:",pk,notnull,use_zero"`
+	Cid    string `pg:",pk,notnull"`
 	From   string `pg:",notnull"`
 	To     string `pg:",notnull"`
 	Value  string `pg:",notnull"`

--- a/model/messages/receipt.go
+++ b/model/messages/receipt.go
@@ -14,6 +14,7 @@ import (
 )
 
 type Receipt struct {
+	Height    int64  `pg:",pk,notnull,use_zero"` // note this is the height of the receipt not the message
 	Message   string `pg:",pk,notnull"`
 	StateRoot string `pg:",pk,notnull"`
 

--- a/storage/migrations/14_height_partitoning.go
+++ b/storage/migrations/14_height_partitoning.go
@@ -1,0 +1,479 @@
+package migrations
+
+import (
+	"github.com/go-pg/migrations/v8"
+)
+
+// Schema version 14 paritions most tables by height as timescale hypertables
+
+func init() {
+	up := batch(`
+
+-- Ideally we want chunks to fit into memory so aim to keep them fairly small
+-- Best practise is to restrict chunk sizes so total across all active hypertables fits 25% main memory
+-- Space partitioning can also be used (i.e. hash over another column) but main benefit comes from
+-- parallelising IO by placing those chunks on separate disks which we are not planning at the moment.
+-- Space partitioning can be added at a later date via the add_dimension function.
+
+-- TimescaleDB only supports UNIQUE constraints that have the partitioning key as their prefix. This
+-- means that all out unique indexes have to include height so that timescale can place them in the
+-- correct chunk.
+
+-- ----------------------------------------------------------------
+-- visor_processing_tipsets
+-- ----------------------------------------------------------------
+
+-- Make sure height is in the primary key of visor_processing_tipsets
+ALTER TABLE visor_processing_tipsets ALTER COLUMN height SET NOT NULL;
+ALTER TABLE visor_processing_tipsets DROP CONSTRAINT IF EXISTS visor_processing_statechanges_pkey;
+ALTER TABLE visor_processing_tipsets ADD PRIMARY KEY (height, tip_set);
+
+DROP INDEX IF EXISTS visor_processing_tipsets_statechange_idx;
+DROP INDEX IF EXISTS visor_processing_tipsets_message_idx;
+DROP INDEX IF EXISTS visor_processing_tipsets_economics_idx;
+DROP INDEX IF EXISTS visor_processing_tipsets_height_idx;
+
+-- Specific indexes for selection of work by tasks
+CREATE INDEX IF NOT EXISTS "visor_processing_tipsets_message_idx" ON public.visor_processing_tipsets USING BTREE (height,message_claimed_until,message_completed_at);
+CREATE INDEX IF NOT EXISTS "visor_processing_tipsets_statechange_idx" ON public.visor_processing_tipsets USING BTREE (height,statechange_claimed_until,statechange_completed_at);
+CREATE INDEX IF NOT EXISTS "visor_processing_tipsets_economics_idx" ON public.visor_processing_tipsets USING BTREE (height,economics_claimed_until,economics_completed_at);
+
+-- Convert visor_processing_tipsets to a hypertable partitioned on height (time)
+-- Assume ~1103 bytes per row
+-- Height chunked per week so we expect ~20160 rows per chunk, ~21MiB per chunk
+SELECT create_hypertable(
+	'visor_processing_tipsets',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+
+-- ----------------------------------------------------------------
+-- visor_processing_messages
+-- ----------------------------------------------------------------
+
+-- Make sure height is in the primary key of visor_processing_messages
+ALTER TABLE visor_processing_messages ALTER COLUMN height SET NOT NULL;
+ALTER TABLE visor_processing_messages DROP CONSTRAINT IF EXISTS visor_processing_messages_pkey;
+ALTER TABLE visor_processing_messages ADD PRIMARY KEY (height, cid);
+
+DROP INDEX IF EXISTS visor_processing_messages_gas_outputs_idx;
+DROP INDEX IF EXISTS visor_processing_messages_height_idx;
+
+-- Specific index for selection of work by tasks
+CREATE INDEX IF NOT EXISTS "visor_processing_messages_gas_outputs_idx" ON public.visor_processing_messages USING BTREE (height,gas_outputs_claimed_until,gas_outputs_completed_at);
+
+-- Convert visor_processing_messages to a hypertable partitioned on height (time)
+-- Assume ~250 messages per epoch, ~280 bytes per row
+-- Height chunked per day so we expect 8640*250 = ~700000 rows per chunk, ~187MiB per chunk
+SELECT create_hypertable(
+	'visor_processing_messages',
+	'height',
+	chunk_time_interval => 2880,
+	if_not_exists => TRUE
+);
+
+
+-- ----------------------------------------------------------------
+-- visor_processing_actors
+-- ----------------------------------------------------------------
+
+-- Make sure height is in the primary key of visor_processing_actors
+ALTER TABLE visor_processing_actors ALTER COLUMN height SET NOT NULL;
+ALTER TABLE visor_processing_actors DROP CONSTRAINT IF EXISTS visor_processing_actors_pkey;
+ALTER TABLE visor_processing_actors ADD PRIMARY KEY (height, head, code);
+
+DROP INDEX IF EXISTS visor_processing_actors_completed_idx;
+DROP INDEX IF EXISTS visor_processing_actors_code_idx;
+DROP INDEX IF EXISTS visor_processing_actors_height_idx;
+
+-- Specific indexes for selection of work by tasks
+CREATE INDEX IF NOT EXISTS "visor_processing_actors_claimed_idx" ON public.visor_processing_actors USING BTREE (height,claimed_until,completed_at);
+CREATE INDEX IF NOT EXISTS "visor_processing_actors_codeclaimed_idx" ON public.visor_processing_actors USING BTREE (code,height,claimed_until,completed_at);
+
+
+-- Convert visor_processing_actors to a hypertable partitioned on height (time)
+-- Assume ~20 state changes per epoch, ~1071 bytes per table row
+-- Height chunked per 2 days so we expect 5760*20 = ~115200 rows per chunk, ~118MiB per chunk
+SELECT create_hypertable(
+	'visor_processing_actors',
+	'height',
+	chunk_time_interval => 5760,
+	if_not_exists => TRUE
+);
+
+
+
+-- block_headers table used to be called blocks
+ALTER TABLE block_headers DROP CONSTRAINT IF EXISTS blocks_pk;
+ALTER TABLE block_headers ADD PRIMARY KEY (height, cid);
+DROP INDEX IF EXISTS block_cid_uindex;
+CREATE INDEX IF NOT EXISTS "block_headers_timestamp_idx" ON public.block_headers USING BTREE (timestamp);
+
+
+-- Convert block_headers to a hypertable partitioned on height (time)
+-- Assume ~5 blocks per epoch, ~432 bytes per table row
+-- Height chunked per week so we expect 20160*5 = ~100800 rows per chunk, ~42MiB per chunk
+SELECT create_hypertable(
+	'block_headers',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+-- this will fail if block_parents is populated since new height column is not null
+ALTER TABLE public.block_parents ADD COLUMN height bigint NOT NULL;
+DROP INDEX IF EXISTS block_parents_block_parent_uindex;
+ALTER TABLE block_parents ADD PRIMARY KEY (height, block, parent);
+
+-- Convert block_parents to a hypertable partitioned on height (time)
+-- Assume ~5 blocks per epoch with ~4 parents, ~150 bytes per table row
+-- Height chunked per week so we expect 20160*5*4 = ~403200 rows per chunk, ~58MiB per chunk
+SELECT create_hypertable(
+	'block_parents',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+
+-- this will fail if block_messages is populated since new height column is not null
+ALTER TABLE public.block_messages ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.block_messages DROP CONSTRAINT IF EXISTS block_messages_pk;
+ALTER TABLE public.block_messages ADD PRIMARY KEY (height, block, message);
+
+-- Convert block_messages to a hypertable partitioned on height (time)
+-- Assume ~250 messages per epoch, ~200 bytes per table row
+-- Height chunked per day so we expect 2880*250 = ~720000 rows per chunk, ~137MiB per chunk
+SELECT create_hypertable(
+	'block_messages',
+	'height',
+	chunk_time_interval => 2880,
+	if_not_exists => TRUE
+);
+
+-- this will fail if messages is populated since new height column is not null
+ALTER TABLE public.messages ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.messages DROP CONSTRAINT IF EXISTS messages_pk;
+ALTER TABLE public.messages ADD PRIMARY KEY (height, cid);
+DROP INDEX IF EXISTS messages_cid_uindex;
+
+-- Convert messages to a hypertable partitioned on height (time)
+-- Assume ~250 messages per epoch, ~373 bytes per table row (not including toast)
+-- Height chunked per day so we expect 2880*250 = ~720000 rows per chunk, ~256MiB per chunk
+SELECT create_hypertable(
+	'messages',
+	'height',
+	chunk_time_interval => 2880,
+	if_not_exists => TRUE
+);
+
+ALTER TABLE public.parsed_messages DROP CONSTRAINT IF EXISTS parsed_messages_pkey;
+ALTER TABLE public.parsed_messages ADD PRIMARY KEY (height, cid);
+
+-- Convert messages to a hypertable partitioned on height (time)
+-- Assume ~250 messages per epoch, ~373 bytes per table row (not including toast for jsonb)
+-- Height chunked per day so we expect 2880*250 = ~720000 rows per chunk, ~256MiB per chunk
+SELECT create_hypertable(
+	'parsed_messages',
+	'height',
+	chunk_time_interval => 2880,
+	if_not_exists => TRUE
+);
+
+
+-- this will fail if receipts is populated since new height column is not null
+ALTER TABLE public.receipts ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.receipts DROP CONSTRAINT IF EXISTS receipts_pk;
+ALTER TABLE public.receipts ADD PRIMARY KEY (height, message, state_root);
+DROP INDEX IF EXISTS receipts_msg_state_index;
+
+-- Convert receipts to a hypertable partitioned on height (time)
+-- Assume ~250 receipts per epoch, ~215 bytes per table row
+-- Height chunked per day so we expect 2880*250 = ~720000 rows per chunk, ~148MiB per chunk
+SELECT create_hypertable(
+	'receipts',
+	'height',
+	chunk_time_interval => 2880,
+	if_not_exists => TRUE
+);
+
+
+-- this will fail if message_gas_economy is populated since new height column is not null
+ALTER TABLE public.message_gas_economy ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.message_gas_economy DROP CONSTRAINT IF EXISTS message_gas_economy_pkey;
+ALTER TABLE public.message_gas_economy ADD PRIMARY KEY (height, state_root);
+
+-- Convert message_gas_economy to a hypertable partitioned on height (time)
+-- Assume ~1 row per epoch, ~800 bytes per table row
+-- Height chunked per week so we expect 20160*800 = ~15MiB per chunk
+SELECT create_hypertable(
+	'message_gas_economy',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+
+-- ----------------------------------------------------------------
+-- actors
+-- ----------------------------------------------------------------
+
+ALTER TABLE public.actors ADD COLUMN height bigint NOT NULL;
+DROP INDEX IF EXISTS actors_id_index;
+ALTER TABLE public.actors ADD PRIMARY KEY (height, id, state_root);
+
+-- Convert actors to a hypertable partitioned on height (time)
+-- Assume ~20 state changes per epoch, ~250 bytes per table row
+-- Height chunked per 7 days so we expect 20160*20 = ~403200 rows per chunk, ~96MiB per chunk
+SELECT create_hypertable(
+	'actors',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+-- ----------------------------------------------------------------
+-- actor_states
+-- ----------------------------------------------------------------
+
+ALTER TABLE public.actor_states ADD COLUMN height bigint NOT NULL;
+DROP INDEX IF EXISTS actor_states_head_code_uindex;
+DROP INDEX IF EXISTS actor_states_code_head_index;
+DROP INDEX IF EXISTS actor_states_head_index;
+ALTER TABLE public.actor_states ADD PRIMARY KEY (height, head, code);
+
+-- Convert actor_states to a hypertable partitioned on height (time)
+-- Assume ~20 state changes per epoch, ~850 bytes per table row
+-- Height chunked per 4 days so we expect 11520*20 = ~230400 rows per chunk, ~186MiB per chunk
+SELECT create_hypertable(
+	'actor_states',
+	'height',
+	chunk_time_interval => 11520,
+	if_not_exists => TRUE
+);
+
+-- ----------------------------------------------------------------
+-- chain_rewards
+-- ----------------------------------------------------------------
+
+ALTER TABLE public.chain_rewards ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.chain_rewards DROP CONSTRAINT IF EXISTS chain_rewards_pkey;
+ALTER TABLE public.chain_rewards ADD PRIMARY KEY (height, state_root);
+
+-- Convert chain_rewards to a hypertable partitioned on height (time)
+-- Assume ~1  per epoch, ~400 bytes per table row
+-- Height chunked per 28 days so we expect ~80640 rows per chunk, ~28MiB per chunk
+SELECT create_hypertable(
+	'chain_rewards',
+	'height',
+	chunk_time_interval => 80640,
+	if_not_exists => TRUE
+);
+
+-- ----------------------------------------------------------------
+-- chain_powers
+-- ----------------------------------------------------------------
+
+ALTER TABLE public.chain_powers ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.chain_powers DROP CONSTRAINT IF EXISTS chain_powers_pkey;
+ALTER TABLE public.chain_powers ADD PRIMARY KEY (height, state_root);
+
+-- Convert chain_powers to a hypertable partitioned on height (time)
+-- Assume ~1  per epoch, ~400 bytes per table row
+-- Height chunked per 28 days so we expect ~80640 rows per chunk, ~28MiB per chunk
+SELECT create_hypertable(
+	'chain_powers',
+	'height',
+	chunk_time_interval => 80640,
+	if_not_exists => TRUE
+);
+
+-- ----------------------------------------------------------------
+-- miner_powers
+-- ----------------------------------------------------------------
+
+ALTER TABLE public.miner_powers ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.miner_powers DROP CONSTRAINT IF EXISTS miner_powers_pkey;
+ALTER TABLE public.miner_powers ADD PRIMARY KEY (height, miner_id, state_root);
+
+-- Convert miner_powers to a hypertable partitioned on height (time)
+-- Assume ~5  per epoch, ~150 bytes per table row
+-- Height chunked per 7 days so we expect 20160*5 = ~100800 rows per chunk, ~14MiB per chunk
+SELECT create_hypertable(
+	'miner_powers',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+
+-- ----------------------------------------------------------------
+-- miner_pre_commit_infos
+-- ----------------------------------------------------------------
+
+-- sector_id was an autoincrement serial type by mistake
+ALTER TABLE public.miner_pre_commit_infos ALTER COLUMN sector_id DROP DEFAULT;
+DROP SEQUENCE IF EXISTS miner_pre_commit_infos_sector_id_seq;
+
+
+ALTER TABLE public.miner_pre_commit_infos ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.miner_pre_commit_infos DROP CONSTRAINT IF EXISTS miner_pre_commit_infos_pkey;
+ALTER TABLE public.miner_pre_commit_infos ADD PRIMARY KEY (height, miner_id, sector_id, state_root);
+
+-- Convert miner_pre_commit_infos to a hypertable partitioned on height (time)
+-- Assume ~5  per epoch, ~300 bytes per table row
+-- Height chunked per 7 days so we expect 20160*5 = ~100800 rows per chunk, ~28MiB per chunk
+SELECT create_hypertable(
+	'miner_pre_commit_infos',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+
+-- ----------------------------------------------------------------
+-- miner_sector_infos
+-- ----------------------------------------------------------------
+
+-- sector_id was an autoincrement serial type by mistake
+ALTER TABLE public.miner_sector_infos ALTER COLUMN sector_id DROP DEFAULT;
+DROP SEQUENCE IF EXISTS miner_sector_infos_sector_id_seq;
+
+ALTER TABLE public.miner_sector_infos ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.miner_sector_infos DROP CONSTRAINT IF EXISTS miner_sector_infos_pkey;
+ALTER TABLE public.miner_sector_infos ADD PRIMARY KEY (height, miner_id, sector_id, state_root);
+
+-- Convert miner_sector_infos to a hypertable partitioned on height (time)
+-- Assume ~5  per epoch, ~300 bytes per table row
+-- Height chunked per 7 days so we expect 20160*5 = ~100800 rows per chunk, ~28MiB per chunk
+SELECT create_hypertable(
+	'miner_sector_infos',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+-- ----------------------------------------------------------------
+-- miner_sector_events
+-- ----------------------------------------------------------------
+
+ALTER TABLE public.miner_sector_events ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.miner_sector_events DROP CONSTRAINT IF EXISTS miner_sector_events_pk;
+ALTER TABLE public.miner_sector_events ADD PRIMARY KEY (height, sector_id, event, miner_id, state_root);
+
+-- Convert miner_sector_events to a hypertable partitioned on height (time)
+-- Assume ~5  per epoch, ~300 bytes per table row
+-- Height chunked per 7 days so we expect 20160*5 = ~100800 rows per chunk, ~28MiB per chunk
+SELECT create_hypertable(
+	'miner_sector_events',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+-- ----------------------------------------------------------------
+-- miner_deal_sectors
+-- ----------------------------------------------------------------
+
+-- sector_id was an autoincrement serial type by mistake
+ALTER TABLE public.miner_deal_sectors ALTER COLUMN sector_id DROP DEFAULT;
+DROP SEQUENCE IF EXISTS miner_deal_sectors_sector_id_seq;
+
+ALTER TABLE public.miner_deal_sectors ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.miner_deal_sectors DROP CONSTRAINT IF EXISTS miner_deal_sectors_pkey;
+ALTER TABLE public.miner_deal_sectors ADD PRIMARY KEY (height, miner_id, sector_id);
+
+-- Convert miner_deal_sectors to a hypertable partitioned on height (time)
+-- Assume ~5  per epoch, ~150 bytes per table row
+-- Height chunked per 7 days so we expect 20160*5 = ~100800 rows per chunk, ~14MiB per chunk
+SELECT create_hypertable(
+	'miner_deal_sectors',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+-- ----------------------------------------------------------------
+-- miner_sector_posts
+-- ----------------------------------------------------------------
+
+ALTER TABLE public.miner_sector_posts RENAME COLUMN epoch TO height;
+ALTER TABLE public.miner_sector_posts DROP CONSTRAINT IF EXISTS miner_sector_posts_pkey;
+ALTER TABLE public.miner_sector_posts ADD PRIMARY KEY (height, miner_id, sector_id);
+
+-- Convert miner_sector_posts to a hypertable partitioned on height (time)
+-- Assume ~5  per epoch, ~150 bytes per table row
+-- Height chunked per 7 days so we expect 20160*5 = ~100800 rows per chunk, ~14MiB per chunk
+SELECT create_hypertable(
+	'miner_sector_posts',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+-- ----------------------------------------------------------------
+-- miner_states
+-- ----------------------------------------------------------------
+
+ALTER TABLE public.miner_states ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.miner_states DROP CONSTRAINT IF EXISTS miner_states_pkey;
+ALTER TABLE public.miner_states ADD PRIMARY KEY (height, miner_id);
+
+-- Convert miner_states to a hypertable partitioned on height (time)
+-- Assume ~5  per epoch, ~150 bytes per table row
+-- Height chunked per 7 days so we expect 20160*5 = ~100800 rows per chunk, ~14MiB per chunk
+SELECT create_hypertable(
+	'miner_states',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+
+-- ----------------------------------------------------------------
+-- market_deal_states
+-- ----------------------------------------------------------------
+
+ALTER TABLE public.market_deal_states ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.market_deal_states DROP CONSTRAINT IF EXISTS market_deal_states_pk;
+ALTER TABLE public.market_deal_states ADD PRIMARY KEY (height, deal_id, state_root);
+ALTER TABLE public.market_deal_states DROP CONSTRAINT IF EXISTS market_deal_states_deal_id_sector_start_epoch_last_update_e_key;
+
+-- Convert market_deal_states to a hypertable partitioned on height (time)
+-- Assume ~5  per epoch, ~150 bytes per table row
+-- Height chunked per 7 days so we expect 20160*5 = ~100800 rows per chunk, ~14MiB per chunk
+SELECT create_hypertable(
+	'market_deal_states',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+
+-- ----------------------------------------------------------------
+-- market_deal_proposals
+-- ----------------------------------------------------------------
+
+ALTER TABLE public.market_deal_proposals ADD COLUMN height bigint NOT NULL;
+ALTER TABLE public.market_deal_proposals DROP CONSTRAINT IF EXISTS market_deal_proposal_pk;
+ALTER TABLE public.market_deal_proposals ADD PRIMARY KEY (height, deal_id);
+
+-- Convert market_deal_proposals to a hypertable partitioned on height (time)
+-- Assume ~5  per epoch, ~350 bytes per table row
+-- Height chunked per 7 days so we expect 20160*5 = ~100800 rows per chunk, 34MiB per chunk
+SELECT create_hypertable(
+	'market_deal_proposals',
+	'height',
+	chunk_time_interval => 20160,
+	if_not_exists => TRUE
+);
+
+
+`)
+	// there is no simple way to convert a hypertable back to a normal table
+	down := batch(`SELECT 1`)
+
+	migrations.MustRegisterTx(up, down)
+}

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -485,10 +485,10 @@ WITH leased AS (
 			   m.gas_fee_cap, m.gas_premium, m.gas_limit, m.method,
 			   r.state_root, r.exit_code,r.gas_used, bh.parent_base_fee
 		FROM visor_processing_messages pm
-		JOIN receipts r ON pm.cid = r.message
-		JOIN messages m ON pm.cid = m.cid
-		JOIN block_messages bm on pm.cid = bm.message
-		JOIN block_headers bh on bm.block = bh.cid
+		JOIN receipts r ON pm.cid = r.message -- don't join receipts on height since it's the height of the receipt
+		JOIN messages m ON pm.cid = m.cid AND pm.height = m.height
+		JOIN block_messages bm on pm.cid = bm.message AND pm.height = bm.height
+		JOIN block_headers bh on bm.block = bh.cid AND bm.height = bh.height
 		WHERE pm.gas_outputs_completed_at IS null AND
 		      (pm.gas_outputs_claimed_until IS null OR pm.gas_outputs_claimed_until < ?) AND
 		      pm.height >= ? AND pm.height <= ?

--- a/storage/sql_test.go
+++ b/storage/sql_test.go
@@ -520,8 +520,9 @@ func TestLeaseGasOutputsMessages(t *testing.T) {
 		},
 	}
 
-	dummyMessage := func(cid string) *messages.Message {
+	dummyMessage := func(height int64, cid string) *messages.Message {
 		return &messages.Message{
+			Height:     height,
 			Cid:        cid,
 			From:       "from",
 			To:         "to",
@@ -532,34 +533,37 @@ func TestLeaseGasOutputsMessages(t *testing.T) {
 	}
 
 	msgs := messages.Messages{
-		dummyMessage("cid0"),
-		dummyMessage("cid1"),
-		dummyMessage("cid2"),
-		dummyMessage("cid3"),
-		dummyMessage("cid4"),
-		dummyMessage("cid5"),
-		dummyMessage("cid6"),
+		dummyMessage(0, "cid0"),
+		dummyMessage(1, "cid1"),
+		dummyMessage(2, "cid2"),
+		dummyMessage(3, "cid3"),
+		dummyMessage(4, "cid4"),
+		dummyMessage(5, "cid5"),
+		dummyMessage(6, "cid6"),
 	}
 
-	dummyReceipt := func(cid string) *messages.Receipt {
+	dummyReceipt := func(height int64, cid string) *messages.Receipt {
 		return &messages.Receipt{
+			Height:    height,
 			Message:   cid,
 			StateRoot: "stateroot",
 		}
 	}
 
 	receipts := messages.Receipts{
-		dummyReceipt("cid0"),
-		dummyReceipt("cid1"),
-		dummyReceipt("cid2"),
+		// Receipt height is later than the messages
+		dummyReceipt(7, "cid0"),
+		dummyReceipt(7, "cid1"),
+		dummyReceipt(7, "cid2"),
 		// no receipt for cid3
-		dummyReceipt("cid4"),
-		dummyReceipt("cid5"),
-		dummyReceipt("cid6"),
+		dummyReceipt(7, "cid4"),
+		dummyReceipt(7, "cid5"),
+		dummyReceipt(7, "cid6"),
 	}
 
-	dummyBlockHeader := func(cid string) *blocks.BlockHeader {
+	dummyBlockHeader := func(height int64, cid string) *blocks.BlockHeader {
 		return &blocks.BlockHeader{
+			Height:          height,
 			Cid:             cid,
 			Miner:           "miner",
 			ParentWeight:    "parentweight",
@@ -570,37 +574,49 @@ func TestLeaseGasOutputsMessages(t *testing.T) {
 	}
 
 	blockHeaders := blocks.BlockHeaders{
-		dummyBlockHeader("blocka"),
-		dummyBlockHeader("blockb"),
+		dummyBlockHeader(0, "blocka"),
+		dummyBlockHeader(1, "blockb"),
+		dummyBlockHeader(2, "blockc"),
+		dummyBlockHeader(3, "blockd"),
+		dummyBlockHeader(4, "blocke"),
+		dummyBlockHeader(5, "blockf"),
+		dummyBlockHeader(6, "blockg"),
 	}
 
 	blockMessages := messages.BlockMessages{
 		{
+			Height:  0,
 			Block:   "blocka",
 			Message: "cid0",
 		},
 		{
-			Block:   "blocka",
+			Height:  1,
+			Block:   "blockb",
 			Message: "cid1",
 		},
 		{
-			Block:   "blocka",
+			Height:  2,
+			Block:   "blockc",
 			Message: "cid2",
 		},
 		{
-			Block:   "blockb",
+			Height:  3,
+			Block:   "blockd",
 			Message: "cid3",
 		},
 		{
-			Block:   "blockb",
+			Height:  4,
+			Block:   "blocke",
 			Message: "cid4",
 		},
 		{
-			Block:   "blockb",
+			Height:  5,
+			Block:   "blockf",
 			Message: "cid5",
 		},
 		{
-			Block:   "blockb",
+			Height:  6,
+			Block:   "blockg",
 			Message: "cid6",
 		},
 	}

--- a/tasks/actorstate/actor.go
+++ b/tasks/actorstate/actor.go
@@ -36,6 +36,7 @@ func (ActorExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateA
 
 	return &commonmodel.ActorTaskResult{
 		Actor: &commonmodel.Actor{
+			Height:    int64(a.Epoch),
 			ID:        a.Address.String(),
 			StateRoot: a.ParentStateRoot.String(),
 			Code:      ActorNameByCode(a.Actor.Code),
@@ -44,9 +45,10 @@ func (ActorExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateA
 			Nonce:     a.Actor.Nonce,
 		},
 		State: &commonmodel.ActorState{
-			Head:  a.Actor.Head.String(),
-			Code:  a.Actor.Code.String(),
-			State: string(state),
+			Height: int64(a.Epoch),
+			Head:   a.Actor.Head.String(),
+			Code:   a.Actor.Code.String(),
+			State:  string(state),
 		},
 	}, nil
 }

--- a/tasks/actorstate/genesis.go
+++ b/tasks/actorstate/genesis.go
@@ -120,6 +120,7 @@ func (p *GenesisProcessor) storageMinerState(ctx context.Context, gen *types.Tip
 	}
 
 	powerModel := &minermodel.MinerPower{
+		Height:               int64(gen.Height()),
 		MinerID:              addr.String(),
 		StateRoot:            gen.ParentState().String(),
 		RawBytePower:         mpower.MinerPower.RawBytePower.String(),
@@ -127,6 +128,7 @@ func (p *GenesisProcessor) storageMinerState(ctx context.Context, gen *types.Tip
 	}
 
 	stateModel := &minermodel.MinerState{
+		Height:     int64(gen.Height()),
 		MinerID:    addr.String(),
 		OwnerID:    minfo.Owner.String(),
 		WorkerID:   minfo.Worker.String(),
@@ -138,6 +140,7 @@ func (p *GenesisProcessor) storageMinerState(ctx context.Context, gen *types.Tip
 	dealsModel := minermodel.MinerDealSectors{}
 	for idx, sector := range msectors {
 		sectorsModel[idx] = &minermodel.MinerSectorInfo{
+			Height:                int64(gen.Height()),
 			MinerID:               addr.String(),
 			SectorID:              uint64(sector.SectorNumber),
 			StateRoot:             gen.ParentState().String(),
@@ -152,6 +155,7 @@ func (p *GenesisProcessor) storageMinerState(ctx context.Context, gen *types.Tip
 		}
 		for _, dealID := range sector.DealIDs {
 			dealsModel = append(dealsModel, &minermodel.MinerDealSector{
+				Height:   int64(gen.Height()),
 				MinerID:  addr.String(),
 				SectorID: uint64(sector.SectorNumber),
 				DealID:   uint64(dealID),
@@ -201,6 +205,7 @@ func (p *GenesisProcessor) storageMarketState(ctx context.Context, gen *types.Ti
 			return nil, err
 		}
 		states[idx] = &marketmodel.MarketDealState{
+			Height:           int64(gen.Height()),
 			DealID:           dealID,
 			SectorStartEpoch: int64(deal.State.SectorStartEpoch),
 			LastUpdateEpoch:  int64(deal.State.LastUpdatedEpoch),
@@ -208,6 +213,7 @@ func (p *GenesisProcessor) storageMarketState(ctx context.Context, gen *types.Ti
 			StateRoot:        gen.ParentState().String(),
 		}
 		proposals[idx] = &marketmodel.MarketDealProposal{
+			Height:               int64(gen.Height()),
 			DealID:               dealID,
 			StateRoot:            gen.ParentState().String(),
 			PaddedPieceSize:      uint64(deal.Proposal.PieceSize),

--- a/tasks/actorstate/market.go
+++ b/tasks/actorstate/market.go
@@ -74,6 +74,7 @@ func (m StorageMarketExtractor) marketDealStateChanges(ctx context.Context, a Ac
 	idx := 0
 	for _, add := range changes.Added {
 		out[idx] = &marketmodel.MarketDealState{
+			Height:           int64(a.Epoch),
 			DealID:           uint64(add.ID),
 			StateRoot:        a.ParentStateRoot.String(),
 			SectorStartEpoch: int64(add.Deal.SectorStartEpoch),
@@ -84,6 +85,7 @@ func (m StorageMarketExtractor) marketDealStateChanges(ctx context.Context, a Ac
 	}
 	for _, mod := range changes.Modified {
 		out[idx] = &marketmodel.MarketDealState{
+			Height:           int64(a.Epoch),
 			DealID:           uint64(mod.ID),
 			SectorStartEpoch: int64(mod.To.SectorStartEpoch),
 			LastUpdateEpoch:  int64(mod.To.LastUpdatedEpoch),
@@ -100,6 +102,7 @@ func (m StorageMarketExtractor) marketDealProposalChanges(ctx context.Context, a
 
 	for idx, add := range changes.Added {
 		out[idx] = &marketmodel.MarketDealProposal{
+			Height:               int64(a.Epoch),
 			DealID:               uint64(add.ID),
 			StateRoot:            a.ParentStateRoot.String(),
 			PaddedPieceSize:      uint64(add.Proposal.PieceSize),

--- a/tasks/actorstate/miner.go
+++ b/tasks/actorstate/miner.go
@@ -150,6 +150,7 @@ func (m StorageMinerExtractor) computeSectorEvents(ctx context.Context, node Act
 				event = minermodel.SectorExpired
 			}
 			out = append(out, &minermodel.MinerSectorEvent{
+				Height:    int64(a.Epoch),
 				MinerID:   a.Address.String(),
 				StateRoot: a.ParentStateRoot.String(),
 				SectorID:  u,
@@ -163,6 +164,7 @@ func (m StorageMinerExtractor) computeSectorEvents(ctx context.Context, node Act
 		// track recovering sectors
 		if err := ps.Recovering.ForEach(func(u uint64) error {
 			out = append(out, &minermodel.MinerSectorEvent{
+				Height:    int64(a.Epoch),
 				MinerID:   a.Address.String(),
 				StateRoot: a.ParentStateRoot.String(),
 				SectorID:  u,
@@ -176,6 +178,7 @@ func (m StorageMinerExtractor) computeSectorEvents(ctx context.Context, node Act
 		// track faulted sectors
 		if err := ps.Faulted.ForEach(func(u uint64) error {
 			out = append(out, &minermodel.MinerSectorEvent{
+				Height:    int64(a.Epoch),
 				MinerID:   a.Address.String(),
 				StateRoot: a.ParentStateRoot.String(),
 				SectorID:  u,
@@ -189,6 +192,7 @@ func (m StorageMinerExtractor) computeSectorEvents(ctx context.Context, node Act
 		// track recovered sectors
 		if err := ps.Recovered.ForEach(func(u uint64) error {
 			out = append(out, &minermodel.MinerSectorEvent{
+				Height:    int64(a.Epoch),
 				MinerID:   a.Address.String(),
 				StateRoot: a.ParentStateRoot.String(),
 				SectorID:  u,
@@ -209,6 +213,7 @@ func (m StorageMinerExtractor) computeSectorEvents(ctx context.Context, node Act
 				event = minermodel.CommitCapacityAdded
 			}
 			out = append(out, &minermodel.MinerSectorEvent{
+				Height:    int64(a.Epoch),
 				MinerID:   a.Address.String(),
 				StateRoot: a.ParentStateRoot.String(),
 				SectorID:  uint64(add.SectorNumber),
@@ -220,6 +225,7 @@ func (m StorageMinerExtractor) computeSectorEvents(ctx context.Context, node Act
 		// track sector extensions
 		for _, mod := range sc.Extended {
 			out = append(out, &minermodel.MinerSectorEvent{
+				Height:    int64(a.Epoch),
 				MinerID:   a.Address.String(),
 				StateRoot: a.ParentStateRoot.String(),
 				SectorID:  uint64(mod.To.SectorNumber),
@@ -234,6 +240,7 @@ func (m StorageMinerExtractor) computeSectorEvents(ctx context.Context, node Act
 		// track precommit addition
 		for _, add := range pc.Added {
 			out = append(out, &minermodel.MinerSectorEvent{
+				Height:    int64(a.Epoch),
 				MinerID:   a.Address.String(),
 				StateRoot: a.ParentStateRoot.String(),
 				SectorID:  uint64(add.Info.SectorNumber),

--- a/tasks/actorstate/reward.go
+++ b/tasks/actorstate/reward.go
@@ -80,6 +80,7 @@ func (RewardExtractor) Extract(ctx context.Context, a ActorInfo, node ActorState
 	}
 
 	return &rewardmodel.ChainReward{
+		Height:                            int64(a.Epoch),
 		StateRoot:                         a.ParentStateRoot.String(),
 		CumSumBaseline:                    csbaseline.String(),
 		CumSumRealized:                    csrealized.String(),

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -238,6 +238,7 @@ func (p *MessageProcessor) extractMessageModels(ctx context.Context, ts *types.T
 		for _, message := range vmm {
 			// record which blocks had which messages
 			result.BlockMessages = append(result.BlockMessages, &messagemodel.BlockMessage{
+				Height:  int64(ts.Height()),
 				Block:   blk.String(),
 				Message: message.Cid().String(),
 			})
@@ -260,6 +261,7 @@ func (p *MessageProcessor) extractMessageModels(ctx context.Context, ts *types.T
 
 			// record all unique messages
 			msg := &messagemodel.Message{
+				Height:     int64(ts.Height()),
 				Cid:        message.Cid().String(),
 				From:       message.From.String(),
 				To:         message.To.String(),
@@ -307,6 +309,7 @@ func (p *MessageProcessor) extractMessageModels(ctx context.Context, ts *types.T
 	baseFeeChangeF, _ := baseFeeChange.Float64()
 
 	result.MessageGasEconomy = &messagemodel.MessageGasEconomy{
+		Height:              int64(ts.Height()),
 		StateRoot:           ts.ParentState().String(),
 		GasLimitTotal:       totalGasLimit,
 		GasLimitUniqueTotal: totalUniqGasLimit,
@@ -389,6 +392,7 @@ func (p *MessageProcessor) fetchReceipts(ctx context.Context, ts *types.TipSet) 
 
 		for i, r := range recs {
 			out = append(out, &messagemodel.Receipt{
+				Height:    int64(ts.Height()),
 				Message:   msgs[i].Cid.String(),
 				StateRoot: ts.ParentState().String(),
 				Idx:       i,


### PR DESCRIPTION
This is a major rework of the database schema and may only be applied
to an empty database. It is not reversible without dropping the schema
and restating.

This change adds a height column to processing, message and actor
tables as part of the primary key and uses it
to partition the table as a timescale hypertable. Rough calculations of
expected number of rows per epoch and row widths are included to estimate
the potential chunk sizes of each hypertable. Timescale recommend that chunks
are small enough that the most recent can fit into 25% of main memory, summed
over all tables.

Additionally the indexes on the visor_processing tables have been analysed to
give the best performance for the work selection queries used by visor. The
tipsets and message processing table indexes fully cover the query so only an
index scan is performed. The actors processing table requires two indexes to
cover the cases where all codes are specified vs zero codes.

Also fixes the sector_id columns for miner_pre_commit_infos, miner_sector_infos and
miner_deal_sectors which were created as autoincrement serials by the go-pg
orm package.