### PR TITLE
feat: add deferred migrations

### DIFF
--- a/storage/migrate.go
+++ b/storage/migrate.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"strconv"
 
-	_ "github.com/filecoin-project/sentinel-visor/storage/migrations"
 	"github.com/go-pg/migrations/v8"
 	"github.com/go-pg/pg/v10"
 	"golang.org/x/xerrors"
+
+	sm "github.com/filecoin-project/sentinel-visor/storage/migrations"
 )
 
 // GetSchemaVersions returns the schema version in the database and the latest schema version defined by the available
@@ -145,6 +146,153 @@ func checkMigrationSequence(ctx context.Context, from, to int) error {
 		if !versions[int64(i)] {
 			return xerrors.Errorf("missing migration for schema version %d", i)
 		}
+	}
+
+	return nil
+}
+
+// GetDeferredSchemaVersions returns the version of the last deferred schema migration in the database and the
+// highest available deferred migration less than or equal maxVersion
+func (d *Database) GetDeferredSchemaVersions(ctx context.Context, maxVersion int) (int, int, error) {
+	// If we're already connected then use that connection
+	if d.DB != nil {
+		return getDeferredSchemaVersions(ctx, d.DB, maxVersion)
+	}
+
+	// Temporarily connect
+	db, err := connect(ctx, d.opt)
+	if err != nil {
+		return 0, 0, xerrors.Errorf("connect: %w", err)
+	}
+	defer db.Close()
+	return getDeferredSchemaVersions(ctx, db, maxVersion)
+}
+
+func getDeferredSchemaVersions(ctx context.Context, db *pg.DB, maxVersion int) (int, int, error) {
+	if err := createDeferredSchemaTable(ctx, db); err != nil {
+		return 0, 0, xerrors.Errorf("deferred migration table init: %w", err)
+	}
+
+	var dbVersion int64
+	_, err := db.QueryOne(pg.Scan(&dbVersion), `SELECT version FROM public.visor_deferred_schema_migrations ORDER BY id DESC LIMIT 1`)
+	if err != nil && err != pg.ErrNoRows {
+		return 0, 0, xerrors.Errorf("query migration table: %w", err)
+	}
+
+	return int(dbVersion), getLatestDeferredSchemaVersion(maxVersion), nil
+}
+
+func createDeferredSchemaTable(ctx context.Context, db *pg.DB) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS public.visor_deferred_schema_migrations (
+			id serial,
+			version bigint,
+			created_at timestamptz
+		)
+	`)
+	return err
+}
+
+func getLatestDeferredSchemaVersion(maxVersion int) int {
+	var latestVersion int64
+	dms := sm.DeferredMigrations()
+	for _, m := range dms {
+		if m.Version > latestVersion && m.Version <= int64(maxVersion) {
+			latestVersion = m.Version
+		}
+	}
+	return int(latestVersion)
+}
+
+func (d *Database) RunDeferredMigrations(ctx context.Context) error {
+	dbVersion, _, err := d.GetSchemaVersions(ctx)
+	if err != nil {
+		return xerrors.Errorf("get schema versions: %w", err)
+	}
+
+	return d.RunDeferredMigrationsTo(ctx, dbVersion)
+}
+
+// RunDeferredMigrationsTo runs deferred migrations up to target version.
+func (d *Database) RunDeferredMigrationsTo(ctx context.Context, target int) error {
+	db, err := connect(ctx, d.opt)
+	if err != nil {
+		return xerrors.Errorf("connect: %w", err)
+	}
+	defer db.Close()
+
+	dbVersion, latestVersion, err := getSchemaVersions(ctx, db)
+	if err != nil {
+		return xerrors.Errorf("get schema versions: %w", err)
+	}
+	if target > dbVersion {
+		return xerrors.Errorf("target %d cannot be greater than current database schema %d", target, dbVersion)
+	}
+	if target > latestVersion {
+		return xerrors.Errorf("target %d cannot be greater than latest available schema %d", target, latestVersion)
+	}
+
+	dbDeferredVersion, deferredLatestVersion, err := getDeferredSchemaVersions(ctx, db, target)
+	if err != nil {
+		return xerrors.Errorf("get deferred schema versions: %w", err)
+	}
+
+	if deferredLatestVersion > target {
+		return xerrors.Errorf("latest deferred migration version is %d", deferredLatestVersion)
+	}
+
+	dms := sm.DeferredMigrations()
+
+	// Do we need to rollback deferred migrations?
+	if dbDeferredVersion > target {
+		for dbDeferredVersion > target {
+			dm, ok := dms[int64(dbDeferredVersion)]
+			if !ok {
+				log.Infof("skipping version %d, no deferred migration", dbDeferredVersion)
+				dbDeferredVersion--
+				continue
+			}
+
+			log.Warnf("running destructive schema migration from version %d to version %d", dbDeferredVersion, dbDeferredVersion-1)
+			err := runDeferredMigration(ctx, db, dbDeferredVersion-1, dm.Down)
+			if err != nil {
+				return xerrors.Errorf("run migration: %w", err)
+			}
+			dbDeferredVersion--
+			log.Infof("current deferred migration version is now %d", dbDeferredVersion)
+		}
+		return nil
+	}
+
+	// Need to apply deferred migrations
+	for dbDeferredVersion < target {
+		dm, ok := dms[int64(dbDeferredVersion)]
+		if !ok {
+			log.Infof("skipping version %d, no deferred migration", dbDeferredVersion)
+			dbDeferredVersion++
+			continue
+		}
+
+		log.Infof("running schema migration from version %d to version %d", dbDeferredVersion, dbDeferredVersion+1)
+		err := runDeferredMigration(ctx, db, dbDeferredVersion, dm.Up) // note we pass current version
+		if err != nil {
+			return xerrors.Errorf("run migration: %w", err)
+		}
+		dbDeferredVersion++
+		log.Infof("current deferred migration version is now %d", dbDeferredVersion)
+	}
+	return nil
+}
+
+func runDeferredMigration(ctx context.Context, db *pg.DB, newVersion int, fn func(migrations.DB) error) error {
+	// Can't run in a transaction since deferred migrations often include concurrent index creation
+	err := fn(db)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(`INSERT INTO public.visor_deferred_schema_migrations (version, created_at) VALUES (?,NOW())`, newVersion)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/storage/migrations/9_processing_stats.go
+++ b/storage/migrations/9_processing_stats.go
@@ -14,23 +14,28 @@ CREATE TABLE IF NOT EXISTS public.visor_processing_stats (
 	"value" bigint NOT NULL,
 	PRIMARY KEY ("recorded_at","measure")
 );
-
-CREATE INDEX IF NOT EXISTS "visor_processing_tipsets_statechange_idx" ON public.visor_processing_tipsets USING BTREE (statechange_completed_at, statechange_claimed_until);
-CREATE INDEX IF NOT EXISTS "visor_processing_tipsets_message_idx"     ON public.visor_processing_tipsets USING BTREE (message_completed_at, message_claimed_until);
-CREATE INDEX IF NOT EXISTS "visor_processing_tipsets_economics_idx"   ON public.visor_processing_tipsets USING BTREE (economics_completed_at, economics_claimed_until);
-CREATE INDEX IF NOT EXISTS "visor_processing_tipsets_height_idx"      ON public.visor_processing_tipsets USING BTREE (height DESC);
-
-CREATE INDEX IF NOT EXISTS "visor_processing_messages_gas_outputs_idx" ON public.visor_processing_messages USING BTREE (gas_outputs_completed_at, gas_outputs_claimed_until);
-CREATE INDEX IF NOT EXISTS "visor_processing_messages_height_idx"      ON public.visor_processing_messages USING BTREE (height DESC);
-
-CREATE INDEX IF NOT EXISTS "visor_processing_actors_completed_idx" ON public.visor_processing_actors USING BTREE (completed_at, claimed_until);
-CREATE INDEX IF NOT EXISTS "visor_processing_actors_code_idx"      ON public.visor_processing_actors USING HASH (code);
-CREATE INDEX IF NOT EXISTS "visor_processing_actors_height_idx"    ON public.visor_processing_actors USING BTREE (height DESC);
 `)
 
 	down := batch(`
 DROP TABLE IF EXISTS public.visor_processing_stats;
+`)
+	migrations.MustRegisterTx(up, down)
 
+	deferredUp := batch(`
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "visor_processing_tipsets_statechange_idx" ON public.visor_processing_tipsets USING BTREE (statechange_completed_at, statechange_claimed_until);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "visor_processing_tipsets_message_idx"     ON public.visor_processing_tipsets USING BTREE (message_completed_at, message_claimed_until);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "visor_processing_tipsets_economics_idx"   ON public.visor_processing_tipsets USING BTREE (economics_completed_at, economics_claimed_until);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "visor_processing_tipsets_height_idx"      ON public.visor_processing_tipsets USING BTREE (height DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "visor_processing_messages_gas_outputs_idx" ON public.visor_processing_messages USING BTREE (gas_outputs_completed_at, gas_outputs_claimed_until);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "visor_processing_messages_height_idx"      ON public.visor_processing_messages USING BTREE (height DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "visor_processing_actors_completed_idx" ON public.visor_processing_actors USING BTREE (completed_at, claimed_until);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "visor_processing_actors_code_idx"      ON public.visor_processing_actors USING HASH (code);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "visor_processing_actors_height_idx"    ON public.visor_processing_actors USING BTREE (height DESC);
+`)
+
+	deferredDown := batch(`
 DROP INDEX IF EXISTS visor_processing_tipsets_statechange_idx;
 DROP INDEX IF EXISTS visor_processing_tipsets_message_idx;
 DROP INDEX IF EXISTS visor_processing_tipsets_economics_idx;
@@ -43,5 +48,6 @@ DROP INDEX IF EXISTS visor_processing_actors_completed_idx;
 DROP INDEX IF EXISTS visor_processing_actors_code_idx;
 DROP INDEX IF EXISTS visor_processing_actors_height_idx;
 `)
-	migrations.MustRegisterTx(up, down)
+
+	MustRegisterDeferred(deferredUp, deferredDown)
 }

--- a/storage/migrations/deferred.go
+++ b/storage/migrations/deferred.go
@@ -1,0 +1,94 @@
+package migrations
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/go-pg/migrations/v8"
+)
+
+var (
+	deferredMu sync.Mutex
+	deferred   = map[int64]Migration{}
+)
+
+type Migration struct {
+	Version  int64
+	Up, Down func(migrations.DB) error
+}
+
+// MustRegisterDeferred registers a deferred migration. The up and down functions should be idempotent.
+// Only one deferred migration may be registered for each schema version.
+func MustRegisterDeferred(up, down func(migrations.DB) error) {
+	deferredMu.Lock()
+	defer deferredMu.Unlock()
+
+	version, err := extractVersionGo(migrationFile())
+	if err != nil {
+		panic(err.Error())
+	}
+
+	if _, ok := deferred[version]; ok {
+		panic(fmt.Errorf("Attempt to register a second deferred migration for schema version %d", version))
+	}
+
+	deferred[version] = Migration{
+		Version: version,
+		Up:      up,
+		Down:    down,
+	}
+}
+
+// DeferredMigrations returns a map of deferred migrations by schema version.
+func DeferredMigrations() map[int64]Migration {
+	dms := make(map[int64]Migration, len(deferred))
+	for v, m := range deferred {
+		dms[v] = m
+	}
+	return dms
+}
+
+func migrationFile() string {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:]) // skip current and caller frames
+	frames := runtime.CallersFrames(pcs[:n])
+
+	for {
+		f, ok := frames.Next()
+		if !ok {
+			break
+		}
+		if !strings.Contains(f.Function, "RegisterDeferred") {
+			return f.File
+		}
+	}
+
+	return ""
+}
+
+func extractVersionGo(name string) (int64, error) {
+	base := filepath.Base(name)
+	if !strings.HasSuffix(name, ".go") {
+		return 0, fmt.Errorf("file=%q must have extension .go", base)
+	}
+
+	idx := strings.IndexByte(base, '_')
+	if idx == -1 {
+		err := fmt.Errorf(
+			"file=%q must have name in format version_comment, e.g. 1_initial",
+			base)
+		return 0, err
+	}
+
+	n, err := strconv.ParseInt(base[:idx], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return n, nil
+}


### PR DESCRIPTION
Deferred migrations are migrations that do not need to be applied immediately and may be
slow to execute. An example would be adding a new index to an existing large table.
A normal migration would lock the entire database until the indexing has completed which
may be unacceptably long.

All pending deferred migrations may be applied at a later date using `visor migrate --deferred`
or a up a specific schema version by using `visor migrate --deferred-to=VERSION`

Schema migration 9 is modified to use deferred migrations for the new indexes.