### PR TITLE
feat: add dashboard for process completion

### DIFF
--- a/build/grafana/provisioning/dashboards/dashboard-visor-processing.json
+++ b/build/grafana/provisioning/dashboards/dashboard-visor-processing.json
@@ -1,0 +1,988 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "PostgreSQL",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "decimals": 2,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-orange",
+                "value": 50
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "measure",
+          "rawQuery": true,
+          "rawSql": "with tipset_total as (select\n                                  value as todo,\n                               recorded_at,\n                                  measure\n                    from visor_processing_stats\n                    where measure = 'tipsets_statechange_count'\n                    order by recorded_at desc\n),\ntipset_complete as (\n    select\n           value as complete,\n        recorded_at,\n           measure\n    from visor_processing_stats\n    where measure = 'tipsets_statechange_completed_count'\n    order by recorded_at desc\n)\nselect\n       distinct on (tipset_complete.recorded_at)\n       tipset_complete.recorded_at as \"time\",\n       complete::decimal/todo as value\nfrom tipset_complete, tipset_total\nWHERE $__timeFilter(tipset_complete.recorded_at)\norder by tipset_complete.recorded_at",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "visor_processing_stats",
+          "timeColumn": "recorded_at",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "",
+              "params": [
+                "value",
+                "=",
+                "'tipsets_economics_completed_height_max'"
+              ],
+              "type": "expression"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TipSet State Changes Completion",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "PostgreSQL",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "decimals": 2,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-orange",
+                "value": 50
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "measure",
+          "rawQuery": true,
+          "rawSql": "with tipset_total as (select\n                                  value as todo,\n                               recorded_at,\n                                  measure\n                    from visor_processing_stats\n                    where measure = 'tipsets_message_count'\n                    order by recorded_at desc\n),\ntipset_complete as (\n    select\n           value as complete,\n        recorded_at,\n           measure\n    from visor_processing_stats\n    where measure = 'tipsets_message_completed_count'\n    order by recorded_at desc\n)\nselect\n       distinct on (tipset_complete.recorded_at)\n       tipset_complete.recorded_at as \"time\",\n       complete::decimal/todo as value\nfrom tipset_complete, tipset_total\nWHERE $__timeFilter(tipset_complete.recorded_at)\norder by tipset_complete.recorded_at",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "visor_processing_stats",
+          "timeColumn": "recorded_at",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "",
+              "params": [
+                "value",
+                "=",
+                "'tipsets_economics_completed_height_max'"
+              ],
+              "type": "expression"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TipSet Message Completion",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "PostgreSQL",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "decimals": 2,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-orange",
+                "value": 50
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "measure",
+          "rawQuery": true,
+          "rawSql": "with tipset_total as (select\n                                  value as todo,\n                               recorded_at,\n                                  measure\n                    from visor_processing_stats\n                    where measure = 'tipsets_economics_count'\n                    order by recorded_at desc\n),\ntipset_complete as (\n    select\n           value as complete,\n        recorded_at,\n           measure\n    from visor_processing_stats\n    where measure = 'tipsets_economics_completed_count'\n    order by recorded_at desc\n)\nselect\n       distinct on (tipset_complete.recorded_at)\n       tipset_complete.recorded_at as \"time\",\n       complete::decimal/todo as value\nfrom tipset_complete, tipset_total\nWHERE $__timeFilter(tipset_complete.recorded_at)\norder by tipset_complete.recorded_at",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "visor_processing_stats",
+          "timeColumn": "recorded_at",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "",
+              "params": [
+                "value",
+                "=",
+                "'tipsets_economics_completed_height_max'"
+              ],
+              "type": "expression"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TipSet Economics Completion",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "PostgreSQL",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "decimals": 2,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-orange",
+                "value": 50
+              },
+              {
+                "color": "dark-yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "measure",
+          "rawQuery": true,
+          "rawSql": "with tipset_total as (select\n                                  value as todo,\n                               recorded_at,\n                                  measure\n                    from visor_processing_stats\n                    where measure = 'messages_gas_outputs_count'\n                    order by recorded_at desc\n),\ntipset_complete as (\n    select\n           value as complete,\n        recorded_at,\n           measure\n    from visor_processing_stats\n    where measure = 'messages_gas_outputs_completed_count'\n    order by recorded_at desc\n)\nselect\n       distinct on (tipset_complete.recorded_at)\n       tipset_complete.recorded_at as \"time\",\n       complete::decimal/todo as value\nfrom tipset_complete, tipset_total\nWHERE $__timeFilter(tipset_complete.recorded_at)\norder by tipset_complete.recorded_at",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "visor_processing_stats",
+          "timeColumn": "recorded_at",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "",
+              "params": [
+                "value",
+                "=",
+                "'tipsets_economics_completed_height_max'"
+              ],
+              "type": "expression"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Message Gas Output Completion",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PostgreSQL",
+      "description": "The number of tipset state changes left to process",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pluginVersion": "7.0.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "measure",
+          "rawQuery": true,
+          "rawSql": "with tipset_total as (select\n                                  value as todo,\n                               recorded_at,\n                                  measure\n                    from visor_processing_stats\n                    where measure = 'tipsets_statechange_count'\n                    order by recorded_at desc\n),\ntipset_complete as (\n    select\n           value as complete,\n        recorded_at,\n           measure\n    from visor_processing_stats\n    where measure = 'tipsets_statechange_completed_count'\n    order by recorded_at desc\n)\nselect\n       distinct on (tipset_complete.recorded_at)\n       tipset_complete.recorded_at as \"time\",\n       todo-complete as value\nfrom tipset_complete, tipset_total\nWHERE $__timeFilter(tipset_complete.recorded_at)\norder by tipset_complete.recorded_at",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "visor_processing_stats",
+          "timeColumn": "recorded_at",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "",
+              "params": [
+                "value",
+                "=",
+                "'tipsets_economics_completed_height_max'"
+              ],
+              "type": "expression"
+            }
+          ]
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": null,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "TipSet State Changes to Process",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "TipSets",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PostgreSQL",
+      "description": "The number of tipset messages left to process",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pluginVersion": "7.0.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "measure",
+          "rawQuery": true,
+          "rawSql": "with tipset_total as (select\n                                  value as todo,\n                               recorded_at,\n                                  measure\n                    from visor_processing_stats\n                    where measure = 'tipsets_message_count'\n                    order by recorded_at desc\n),\ntipset_complete as (\n    select\n           value as complete,\n        recorded_at,\n           measure\n    from visor_processing_stats\n    where measure = 'tipsets_message_completed_count'\n    order by recorded_at desc\n)\nselect\n       distinct on (tipset_complete.recorded_at)\n       tipset_complete.recorded_at as \"time\",\n       todo-complete as value\nfrom tipset_complete, tipset_total\nWHERE $__timeFilter(tipset_complete.recorded_at)\norder by tipset_complete.recorded_at",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "visor_processing_stats",
+          "timeColumn": "recorded_at",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "",
+              "params": [
+                "value",
+                "=",
+                "'tipsets_economics_completed_height_max'"
+              ],
+              "type": "expression"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "TipSet Messages to Process",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PostgreSQL",
+      "description": "The number of tipset economics left to process",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pluginVersion": "7.0.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "measure",
+          "rawQuery": true,
+          "rawSql": "with tipset_total as (select\n                                  value as todo,\n                               recorded_at,\n                                  measure\n                    from visor_processing_stats\n                    where measure = 'tipsets_economics_count'\n                    order by recorded_at desc\n),\ntipset_complete as (\n    select\n           value as complete,\n        recorded_at,\n           measure\n    from visor_processing_stats\n    where measure = 'tipsets_economics_completed_count'\n    order by recorded_at desc\n)\nselect\n       distinct on (tipset_complete.recorded_at)\n       tipset_complete.recorded_at as \"time\",\n       todo-complete as value\nfrom tipset_complete, tipset_total\nWHERE $__timeFilter(tipset_complete.recorded_at)\norder by tipset_complete.recorded_at",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "visor_processing_stats",
+          "timeColumn": "recorded_at",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "",
+              "params": [
+                "value",
+                "=",
+                "'tipsets_economics_completed_height_max'"
+              ],
+              "type": "expression"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "TipSet Economics to Process",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PostgreSQL",
+      "description": "The number of message gas outputs left to process",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pluginVersion": "7.0.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "measure",
+          "rawQuery": true,
+          "rawSql": "with tipset_total as (select\n                                  value as todo,\n                               recorded_at,\n                                  measure\n                    from visor_processing_stats\n                    where measure = 'messages_gas_outputs_count'\n                    order by recorded_at desc\n),\ntipset_complete as (\n    select\n           value as complete,\n        recorded_at,\n           measure\n    from visor_processing_stats\n    where measure = 'messages_gas_outputs_completed_count'\n    order by recorded_at desc\n)\nselect\n       distinct on (tipset_complete.recorded_at)\n       tipset_complete.recorded_at as \"time\",\n       todo-complete as value\nfrom tipset_complete, tipset_total\nWHERE $__timeFilter(tipset_complete.recorded_at)\norder by tipset_complete.recorded_at",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "visor_processing_stats",
+          "timeColumn": "recorded_at",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "",
+              "params": [
+                "value",
+                "=",
+                "'tipsets_economics_completed_height_max'"
+              ],
+              "type": "expression"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Messages Gas Outputs to Process",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Process Completion",
+  "uid": "Yjj06w5Mk",
+  "version": 6
+}


### PR DESCRIPTION
Add a dashboard to track processing completion using the visor_processing_stats table
![Selection_051](https://user-images.githubusercontent.com/6546409/96293666-f9cb5080-0f9f-11eb-9aa4-dc2668386396.png)
