### PR TITLE
feat: rpc reconnection on failure

### DIFF
--- a/commands/debug.go
+++ b/commands/debug.go
@@ -40,7 +40,7 @@ var Debug = &cli.Command{
 			}
 		}()
 
-		p, err := actorstate.NewActorStateProcessor(rctx.db, rctx.api, 0, 0, 0, 0, actorstate.SupportedActorCodes())
+		p, err := actorstate.NewActorStateProcessor(rctx.db, rctx.opener, 0, 0, 0, 0, actorstate.SupportedActorCodes())
 		if err != nil {
 			return err
 		}

--- a/commands/setup.go
+++ b/commands/setup.go
@@ -41,19 +41,20 @@ type RunContext struct {
 }
 
 func setupStorageAndAPI(cctx *cli.Context) (context.Context, *RunContext, error) {
-	var ctx context.Context
 	var opener lens.APIOpener // the api opener that is used by tasks
 	var closer lens.APICloser // a closer that cleans up the opener when exiting the application
 	var err error
 
+	ctx := cctx.Context
+
 	if cctx.String("lens") == "lotus" {
-		ctx, opener, closer, err = vapi.NewAPIOpener(cctx, 10_000)
+		opener, closer, err = vapi.NewAPIOpener(cctx, 10_000)
 	} else if cctx.String("lens") == "lotusrepo" {
-		ctx, opener, closer, err = repoapi.NewAPIOpener(cctx)
+		opener, closer, err = repoapi.NewAPIOpener(cctx)
 	} else if cctx.String("lens") == "carrepo" {
-		ctx, opener, closer, err = carapi.NewAPIOpener(cctx)
+		opener, closer, err = carapi.NewAPIOpener(cctx)
 	} else if cctx.String("lens") == "sql" {
-		ctx, opener, closer, err = sqlapi.NewAPIOpener(cctx)
+		opener, closer, err = sqlapi.NewAPIOpener(cctx)
 	}
 	if err != nil {
 		return nil, nil, xerrors.Errorf("get node api: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/filecoin-project/go-address v0.0.4
 	github.com/filecoin-project/go-bitfield v0.2.1
 	github.com/filecoin-project/go-fil-markets v1.0.0
-	github.com/filecoin-project/go-jsonrpc v0.1.2-0.20201008195726-68c6a2704e49
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f
 	github.com/filecoin-project/lotus v1.1.3-0.20201027132752-3d02dba5dc9b
@@ -29,6 +28,7 @@ require (
 	github.com/jackc/pgx/v4 v4.9.0
 	github.com/lib/pq v1.8.0
 	github.com/libp2p/go-libp2p-peer v0.2.0
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multibase v0.0.3
 	github.com/multiformats/go-multihash v0.0.14

--- a/go.sum
+++ b/go.sum
@@ -68,7 +68,6 @@ github.com/Stebalien/go-bitfield v0.0.0-20180330043415-076a62f9ce6e/go.mod h1:3o
 github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cBLhbQBo=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
-github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
@@ -121,7 +120,6 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
-github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129 h1:gfAMKE626QEuKG3si0pdTRcr/YEbBoxY+3GOH3gWvl4=
 github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129/go.mod h1:u9UyCz2eTrSGy6fbupqJ54eY5c4IC8gREQ1053dK12U=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
@@ -134,11 +132,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
 github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
-github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
-github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
-github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -475,7 +470,6 @@ github.com/gxed/go-shellwords v1.0.3/go.mod h1:N7paucT91ByIjmVJHhvoarjoQnmsi3Jd3
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/gxed/pubsub v0.0.0-20180201040156-26ebdf44f824/go.mod h1:OiEWyHgK+CWrmOlVquHaIK1vhpUJydC9m0Je6mhaiNE=
-github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 h1:BpJ2o0OR5FV7vrkDYfXYVJQeMNWa8RhklZOpW2ITAIQ=
 github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026/go.mod h1:5Scbynm8dF1XAPwIwkGPqzkM/shndPm79Jd1003hTjE=
 github.com/hannahhoward/cbor-gen-for v0.0.0-20200817222906-ea96cece81f1 h1:F9k+7wv5OIk1zcq23QpdiL0hfDuXPjuOmMNaC6fgQ0Q=
 github.com/hannahhoward/cbor-gen-for v0.0.0-20200817222906-ea96cece81f1/go.mod h1:jvfsLIxk0fY/2BKSQ1xf2406AKA5dwMmKKv0ADcOfN8=

--- a/go.sum
+++ b/go.sum
@@ -166,7 +166,6 @@ github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -206,19 +205,15 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/drand/bls12-381 v0.3.2 h1:RImU8Wckmx8XQx1tp1q04OV73J9Tj6mmpQLYDP7V1XE=
 github.com/drand/bls12-381 v0.3.2/go.mod h1:dtcLgPtYT38L3NO6mPDYH0nbpc5tjPassDqiniuAt4Y=
-github.com/drand/drand v1.1.2-0.20200905144319-79c957281b32 h1:sU+51aQRaDxg0KnjQg19KuYRIxDBEUHffBAICSnBys8=
 github.com/drand/drand v1.1.2-0.20200905144319-79c957281b32/go.mod h1:0sQEVg+ngs1jaDPVIiEgY0lbENWJPaUlWxGHEaSmKVM=
 github.com/drand/drand v1.2.1 h1:KB7z+69YbnQ5z22AH/LMi0ObDR8DzYmrkS6vZXTR9jI=
 github.com/drand/drand v1.2.1/go.mod h1:j0P7RGmVaY7E/OuO2yQOcQj7OgeZCuhgu2gdv0JAm+g=
 github.com/drand/kyber v1.0.1-0.20200110225416-8de27ed8c0e2/go.mod h1:UpXoA0Upd1N9l4TvRPHr1qAUBBERj6JQ/mnKI3BPEmw=
 github.com/drand/kyber v1.0.2/go.mod h1:x6KOpK7avKj0GJ4emhXFP5n7M7W7ChAPmnQh/OL6vRw=
-github.com/drand/kyber v1.1.2 h1:faemqlaFyLrbBSjZGRzzu5SG/do+uTYpHlnrJIHbAhQ=
 github.com/drand/kyber v1.1.2/go.mod h1:x6KOpK7avKj0GJ4emhXFP5n7M7W7ChAPmnQh/OL6vRw=
 github.com/drand/kyber v1.1.4 h1:YvKM03QWGvLrdTnYmxxP5iURAX+Gdb6qRDUOgg8i60Q=
 github.com/drand/kyber v1.1.4/go.mod h1:9+IgTq7kadePhZg7eRwSD7+bA+bmvqRK+8DtmoV5a3U=
-github.com/drand/kyber-bls12381 v0.1.0 h1:/P4C65VnyEwxzR5ZYYVMNzY1If+aYBrdUU5ukwh7LQw=
 github.com/drand/kyber-bls12381 v0.1.0/go.mod h1:N1emiHpm+jj7kMlxEbu3MUyOiooTgNySln564cgD9mk=
 github.com/drand/kyber-bls12381 v0.2.0/go.mod h1:zQip/bHdeEB6HFZSU3v+d3cQE0GaBVQw9aR2E7AdoeI=
 github.com/drand/kyber-bls12381 v0.2.1 h1:/d5/YAdaCmHpYjF1NZevOEcKGaq6LBbyvkCTIdGqDjs=
@@ -711,7 +706,6 @@ github.com/ipld/go-ipld-prime-proto v0.0.0-20200922192210-9a2bfd4440a6 h1:6Mq+tZ
 github.com/ipld/go-ipld-prime-proto v0.0.0-20200922192210-9a2bfd4440a6/go.mod h1:3pHYooM9Ea65jewRwrb2u5uHZCNkNTe9ABsVB+SrkH0=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
-github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -730,7 +724,6 @@ github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye47
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=
@@ -814,7 +807,6 @@ github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3/go.mod h1:BYpt4
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/kilic/bls12-381 v0.0.0-20200607163746-32e1441c8a9f h1:qET3Wx0v8tMtoTOQnsJXVvqvCopSf48qobR6tcJuDHo=
 github.com/kilic/bls12-381 v0.0.0-20200607163746-32e1441c8a9f/go.mod h1:XXfR6YFCRSrkEXbNlIyDsgXVNJWVUV30m/ebkVy9n6s=
 github.com/kilic/bls12-381 v0.0.0-20200731194930-64c428e1bff5/go.mod h1:XXfR6YFCRSrkEXbNlIyDsgXVNJWVUV30m/ebkVy9n6s=
 github.com/kilic/bls12-381 v0.0.0-20200820230200-6b2c19996391 h1:51kHw7l/dUDdOdW06AlUGT5jnpj6nqQSILebcsikSjA=
@@ -1409,7 +1401,6 @@ github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -1519,7 +1510,6 @@ github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
@@ -1894,7 +1884,6 @@ golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200908134130-d2e65c121b96/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d h1:L/IKR6COd7ubZrs2oTnTi73IhgqJ71c9s80WsQnh0Es=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200926100807-9d91bd62050c h1:38q6VNPWR010vN82/SB121GujZNIfAUb4YttE2rhGuc=
 golang.org/x/sys v0.0.0-20200926100807-9d91bd62050c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/lens/interface.go
+++ b/lens/interface.go
@@ -1,6 +1,8 @@
 package lens
 
 import (
+	"context"
+
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/vm"
@@ -14,3 +16,7 @@ type API interface {
 }
 
 type APICloser func()
+
+type APIOpener interface {
+	Open(context.Context) (API, APICloser, error)
+}

--- a/lens/lotus/cachestore.go
+++ b/lens/lotus/cachestore.go
@@ -19,14 +19,9 @@ type CacheCtxStore struct {
 	api   api.FullNode
 }
 
-func NewCacheCtxStore(ctx context.Context, api api.FullNode, size int) (*CacheCtxStore, error) {
-	ac, err := lru.NewARC(size)
-	if err != nil {
-		return nil, xerrors.Errorf("new arc cache: %w", err)
-	}
-
+func NewCacheCtxStore(ctx context.Context, api api.FullNode, cache *lru.ARCCache) (*CacheCtxStore, error) {
 	return &CacheCtxStore{
-		cache: ac,
+		cache: cache,
 		ctx:   ctx,
 		api:   api,
 	}, nil

--- a/lens/lotus/lotus.go
+++ b/lens/lotus/lotus.go
@@ -28,12 +28,10 @@ type APIOpener struct {
 	cache *lru.ARCCache // cache shared across all instances of the api
 }
 
-func NewAPIOpener(cctx *cli.Context, cacheSize int) (context.Context, *APIOpener, lens.APICloser, error) {
-	ctx := lcli.ReqContext(cctx)
-
+func NewAPIOpener(cctx *cli.Context, cacheSize int) (*APIOpener, lens.APICloser, error) {
 	ac, err := lru.NewARC(cacheSize)
 	if err != nil {
-		return ctx, nil, nil, xerrors.Errorf("new arc cache: %w", err)
+		return nil, nil, xerrors.Errorf("new arc cache: %w", err)
 	}
 
 	o := &APIOpener{
@@ -41,7 +39,7 @@ func NewAPIOpener(cctx *cli.Context, cacheSize int) (context.Context, *APIOpener
 		cache: ac,
 	}
 
-	return ctx, o, lens.APICloser(func() {}), nil
+	return o, lens.APICloser(func() {}), nil
 }
 
 func (o *APIOpener) Open(ctx context.Context) (lens.API, lens.APICloser, error) {

--- a/lens/sqlrepo/repo.go
+++ b/lens/sqlrepo/repo.go
@@ -30,6 +30,71 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+type APIOpener struct {
+	// shared instance of the repo since the opener holds an exclusive lock on it
+	rapi *SQLAPI
+}
+
+func NewAPIOpener(c *cli.Context) (context.Context, *APIOpener, lens.APICloser, error) {
+	rapi := SQLAPI{}
+
+	if _, _, err := ulimit.ManageFdLimit(); err != nil {
+		return c.Context, nil, nil, fmt.Errorf("setting file descriptor limit: %s", err)
+	}
+
+	bs, err := NewBlockStore(c.String("repo"))
+	if err != nil {
+		return c.Context, nil, nil, err
+	}
+
+	r := repo.NewMemory(nil)
+
+	lr, err := r.Lock(repo.FullNode)
+	if err != nil {
+		return c.Context, nil, nil, err
+	}
+
+	mds, err := lr.Datastore("/metadata")
+	if err != nil {
+		return c.Context, nil, nil, err
+	}
+
+	cs := store.NewChainStore(bs, mds, vm.Syscalls(&fakeVerifier{}), journal.NilJournal())
+
+	headKey, err := bs.(*SqlBlockstore).getMasterTsKey(c.Context, safetyLookBack)
+	if err != nil {
+		return c.Context, nil, nil, err
+	}
+
+	headTs, err := cs.LoadTipSet(*headKey)
+	if err != nil {
+		return c.Context, nil, nil, fmt.Errorf("failed to load our own chainhead: %w", err)
+	}
+	if err := cs.SetHead(headTs); err != nil {
+		return c.Context, nil, nil, fmt.Errorf("failed to set our own chainhead: %w", err)
+	}
+
+	sm := stmgr.NewStateManager(cs)
+
+	rapi.FullNodeAPI.ChainAPI.Chain = cs
+	rapi.FullNodeAPI.ChainAPI.ChainModuleAPI = &full.ChainModule{Chain: cs}
+	rapi.FullNodeAPI.StateAPI.Chain = cs
+	rapi.FullNodeAPI.StateAPI.StateManager = sm
+	rapi.FullNodeAPI.StateAPI.StateModuleAPI = &full.StateModule{Chain: cs, StateManager: sm}
+
+	sf := func() {
+		lr.Close()
+	}
+
+	rapi.Context = c.Context
+	rapi.cacheSize = c.Int("lens-cache-hint")
+	return c.Context, &APIOpener{rapi: &rapi}, sf, nil
+}
+
+func (o *APIOpener) Open(ctx context.Context) (lens.API, lens.APICloser, error) {
+	return o.rapi, lens.APICloser(func() {}), nil
+}
+
 type SQLAPI struct {
 	impl.FullNodeAPI
 	context.Context
@@ -83,97 +148,52 @@ func (ra *SQLAPI) ClientImport(ctx context.Context, ref api.FileRef) (*api.Impor
 func (ra *SQLAPI) ClientRemoveImport(ctx context.Context, importID multistore.StoreID) error {
 	return fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientImportLocal(ctx context.Context, f io.Reader) (cid.Cid, error) {
 	return cid.Undef, fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientListImports(ctx context.Context) ([]api.Import, error) {
 	return nil, fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientRetrieve(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) error {
 	return fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientRetrieveWithEvents(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) (<-chan marketevents.RetrievalEvent, error) {
 	return nil, fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientQueryAsk(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.StorageAsk, error) {
 	return nil, fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientCalcCommP(ctx context.Context, inpath string) (*api.CommPRet, error) {
 	return nil, fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientDealSize(ctx context.Context, root cid.Cid) (api.DataSize, error) {
 	return api.DataSize{}, fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientGenCar(ctx context.Context, ref api.FileRef, outputPath string) error {
 	return fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientListDataTransfers(ctx context.Context) ([]api.DataTransferChannel, error) {
 	return nil, fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientDataTransferUpdates(ctx context.Context) (<-chan api.DataTransferChannel, error) {
 	return nil, fmt.Errorf("unsupported")
 }
+
 func (ra *SQLAPI) ClientRetrieveTryRestartInsufficientFunds(ctx context.Context, paymentChannel address.Address) error {
 	return fmt.Errorf("unsupported")
 }
 
 const safetyLookBack = 5
-
-func GetAPI(c *cli.Context) (context.Context, lens.API, lens.APICloser, error) {
-	rapi := SQLAPI{}
-
-	if _, _, err := ulimit.ManageFdLimit(); err != nil {
-		return nil, nil, nil, fmt.Errorf("setting file descriptor limit: %s", err)
-	}
-
-	bs, err := NewBlockStore(c.String("repo"))
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	r := repo.NewMemory(nil)
-
-	lr, err := r.Lock(repo.FullNode)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	mds, err := lr.Datastore("/metadata")
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	cs := store.NewChainStore(bs, mds, vm.Syscalls(&fakeVerifier{}), journal.NilJournal())
-
-	headKey, err := bs.(*SqlBlockstore).getMasterTsKey(c.Context, safetyLookBack)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	headTs, err := cs.LoadTipSet(*headKey)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to load our own chainhead: %w", err)
-	}
-	if err := cs.SetHead(headTs); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to set our own chainhead: %w", err)
-	}
-
-	sm := stmgr.NewStateManager(cs)
-
-	rapi.FullNodeAPI.ChainAPI.Chain = cs
-	rapi.FullNodeAPI.ChainAPI.ChainModuleAPI = &full.ChainModule{Chain: cs}
-	rapi.FullNodeAPI.StateAPI.Chain = cs
-	rapi.FullNodeAPI.StateAPI.StateManager = sm
-	rapi.FullNodeAPI.StateAPI.StateModuleAPI = &full.StateModule{Chain: cs, StateManager: sm}
-
-	sf := func() {
-		lr.Close()
-	}
-
-	rapi.Context = c.Context
-	rapi.cacheSize = c.Int("lens-cache-hint")
-	return c.Context, &rapi, sf, nil
-}
 
 // From https://github.com/ribasushi/ltsh/blob/5b0211033020570217b0ae37b50ee304566ac218/cmd/lotus-shed/deallifecycles.go#L41-L171
 type fakeVerifier struct{}

--- a/tasks/actorstate/actorstatechange.go
+++ b/tasks/actorstate/actorstatechange.go
@@ -25,9 +25,9 @@ import (
 
 const idleSleepInterval = 60 * time.Second // time to wait if the processor runs out of blocks to process
 
-func NewActorStateChangeProcessor(d *storage.Database, node lens.API, leaseLength time.Duration, batchSize int, minHeight, maxHeight int64) *ActorStateChangeProcessor {
+func NewActorStateChangeProcessor(d *storage.Database, opener lens.APIOpener, leaseLength time.Duration, batchSize int, minHeight, maxHeight int64) *ActorStateChangeProcessor {
 	return &ActorStateChangeProcessor{
-		node:        node,
+		opener:      opener,
 		storage:     d,
 		leaseLength: leaseLength,
 		batchSize:   batchSize,
@@ -40,7 +40,7 @@ func NewActorStateChangeProcessor(d *storage.Database, node lens.API, leaseLengt
 // ActorStateChangeProcessor is a task that processes blocks to detect actors whose states have changed and persists
 // their details to the database.
 type ActorStateChangeProcessor struct {
-	node        lens.API
+	opener      lens.APIOpener
 	storage     *storage.Database
 	leaseLength time.Duration // length of time to lease work for
 	batchSize   int           // number of blocks to lease in a batch
@@ -52,11 +52,19 @@ type ActorStateChangeProcessor struct {
 // Run starts processing batches of blocks and blocks until the context is done or
 // an error occurs.
 func (p *ActorStateChangeProcessor) Run(ctx context.Context) error {
+	node, closer, err := p.opener.Open(ctx)
+	if err != nil {
+		return xerrors.Errorf("open lens: %w", err)
+	}
+	defer closer()
+
 	// Loop until context is done or processing encounters a fatal error
-	return wait.RepeatUntil(ctx, batchInterval, p.processBatch)
+	return wait.RepeatUntil(ctx, batchInterval, func(ctx context.Context) (bool, error) {
+		return p.processBatch(ctx, node)
+	})
 }
 
-func (p *ActorStateChangeProcessor) processBatch(ctx context.Context) (bool, error) {
+func (p *ActorStateChangeProcessor) processBatch(ctx context.Context, node lens.API) (bool, error) {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, "statechange"))
 	ctx, span := global.Tracer("").Start(ctx, "ActorStateChangeProcessor.processBatch")
 	defer span.End()
@@ -91,12 +99,12 @@ func (p *ActorStateChangeProcessor) processBatch(ctx context.Context) (bool, err
 
 		errorLog := log.With("height", item.Height, "tipset", item.TipSet)
 
-		if err := p.processItem(ctx, item); err != nil {
+		if err := p.processItem(ctx, node, item); err != nil {
 			errorLog.Errorw("failed to process tipset", "error", err.Error())
 			if err := p.storage.MarkStateChangeComplete(ctx, item.TipSet, item.Height, p.clock.Now(), err.Error()); err != nil {
 				errorLog.Errorw("failed to mark tipset complete", "error", err.Error())
 			}
-			continue
+			return false, xerrors.Errorf("process item: %w", err)
 		}
 
 		if err := p.storage.MarkStateChangeComplete(ctx, item.TipSet, item.Height, p.clock.Now(), ""); err != nil {
@@ -107,7 +115,7 @@ func (p *ActorStateChangeProcessor) processBatch(ctx context.Context) (bool, err
 	return false, nil
 }
 
-func (p *ActorStateChangeProcessor) processItem(ctx context.Context, item *visor.ProcessingTipSet) error {
+func (p *ActorStateChangeProcessor) processItem(ctx context.Context, node lens.API, item *visor.ProcessingTipSet) error {
 	ctx, span := global.Tracer("").Start(ctx, "ActorStateChangeProcessor.processItem")
 	defer span.End()
 	span.SetAttributes(label.Any("height", item.Height), label.Any("tipset", item.TipSet))
@@ -121,17 +129,17 @@ func (p *ActorStateChangeProcessor) processItem(ctx context.Context, item *visor
 		return xerrors.Errorf("get tipsetkey: %w", err)
 	}
 
-	ts, err := p.node.ChainGetTipSet(ctx, tsk)
+	ts, err := node.ChainGetTipSet(ctx, tsk)
 	if err != nil {
 		return xerrors.Errorf("get tipset: %w", err)
 	}
 
 	if item.Height > 0 {
-		if err := p.processTipSet(ctx, ts); err != nil {
+		if err := p.processTipSet(ctx, node, ts); err != nil {
 			return xerrors.Errorf("process tipset: %w", err)
 		}
 	} else {
-		gp := NewGenesisProcessor(p.storage, p.node)
+		gp := NewGenesisProcessor(p.storage, node)
 		if err := gp.ProcessGenesis(ctx, ts); err != nil {
 			return xerrors.Errorf("process genesis: %w", err)
 		}
@@ -140,19 +148,19 @@ func (p *ActorStateChangeProcessor) processItem(ctx context.Context, item *visor
 	return nil
 }
 
-func (p *ActorStateChangeProcessor) processTipSet(ctx context.Context, ts *types.TipSet) error {
+func (p *ActorStateChangeProcessor) processTipSet(ctx context.Context, node lens.API, ts *types.TipSet) error {
 	ctx, span := global.Tracer("").Start(ctx, "ActorStateChangeProcessor.processTipSet")
 	defer span.End()
 	ll := log.With("height", int64(ts.Height()))
 
 	ll.Debugw("processing tipset")
 
-	pts, err := p.node.ChainGetTipSet(ctx, ts.Parents())
+	pts, err := node.ChainGetTipSet(ctx, ts.Parents())
 	if err != nil {
 		return xerrors.Errorf("get parent tipset: %w", err)
 	}
 
-	changes, err := p.node.StateChangedActors(ctx, pts.ParentState(), ts.ParentState())
+	changes, err := node.StateChangedActors(ctx, pts.ParentState(), ts.ParentState())
 	if err != nil {
 		return xerrors.Errorf("get actor changes: %w", err)
 	}
@@ -174,7 +182,7 @@ func (p *ActorStateChangeProcessor) processTipSet(ctx context.Context, ts *types
 			return xerrors.Errorf("parse address: %w", err)
 		}
 
-		_, err = p.node.StateGetActor(ctx, addr, pts.Key())
+		_, err = node.StateGetActor(ctx, addr, pts.Key())
 		if err != nil {
 			if strings.Contains(err.Error(), "actor not found") {
 				ll.Debugw("actor not found", "addr", str)
@@ -184,7 +192,7 @@ func (p *ActorStateChangeProcessor) processTipSet(ctx context.Context, ts *types
 			return xerrors.Errorf("get actor: %w", err)
 		}
 
-		_, err = p.node.StateGetActor(ctx, addr, pts.Parents())
+		_, err = node.StateGetActor(ctx, addr, pts.Parents())
 		if err != nil {
 			if strings.Contains(err.Error(), "actor not found") {
 				ll.Debugw("parent actor not found", "addr", str)
@@ -216,5 +224,4 @@ func (p *ActorStateChangeProcessor) processTipSet(ctx context.Context, ts *types
 	}
 
 	return nil
-
 }

--- a/tasks/indexer/chainheadindexer_test.go
+++ b/tasks/indexer/chainheadindexer_test.go
@@ -15,13 +15,11 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
-
 	"github.com/go-pg/pg/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/sentinel-visor/lens"
-	"github.com/filecoin-project/sentinel-visor/lens/lotus"
 	"github.com/filecoin-project/sentinel-visor/model/blocks"
 	"github.com/filecoin-project/sentinel-visor/model/visor"
 	"github.com/filecoin-project/sentinel-visor/storage"
@@ -59,15 +57,15 @@ func TestChainHeadIndexer(t *testing.T) {
 
 	t.Logf("preparing chain")
 	nodes, sn := nodetest.Builder(t, apitest.DefaultFullOpts(1), apitest.OneMiner)
-	cs, err := lotus.NewCacheCtxStore(ctx, nodes[0], 5)
-	require.NoError(t, err, "cache store")
-	node := lotus.NewAPIWrapper(nodes[0], cs)
 
-	apitest.MineUntilBlock(ctx, t, nodes[0], sn[0], nil)
+	node := nodes[0]
+	opener := testutil.NewAPIOpener(node)
+
+	apitest.MineUntilBlock(ctx, t, node, sn[0], nil)
 
 	d := &storage.Database{DB: db}
 	t.Logf("initializing indexer")
-	idx := NewChainHeadIndexer(d, node, 0)
+	idx := NewChainHeadIndexer(d, opener, 0)
 
 	newHeads, err := node.ChainNotify(ctx)
 	require.NoError(t, err, "chain notify")

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -41,8 +41,10 @@ const (
 	batchInterval     = 100 * time.Millisecond // time to wait between batches
 )
 
-var accountActorCodeID string
-var log = logging.Logger("message")
+var (
+	accountActorCodeID string
+	log                = logging.Logger("message")
+)
 
 func init() {
 	for code, actor := range statediff.LotusActorCodes {
@@ -53,9 +55,9 @@ func init() {
 	}
 }
 
-func NewMessageProcessor(d *storage.Database, node lens.API, leaseLength time.Duration, batchSize int, parseMessages bool, minHeight, maxHeight int64) *MessageProcessor {
+func NewMessageProcessor(d *storage.Database, opener lens.APIOpener, leaseLength time.Duration, batchSize int, parseMessages bool, minHeight, maxHeight int64) *MessageProcessor {
 	return &MessageProcessor{
-		node:          node,
+		opener:        opener,
 		storage:       d,
 		leaseLength:   leaseLength,
 		batchSize:     batchSize,
@@ -69,7 +71,7 @@ func NewMessageProcessor(d *storage.Database, node lens.API, leaseLength time.Du
 // MessageProcessor is a task that processes blocks to detect messages and persists
 // their details to the database.
 type MessageProcessor struct {
-	node          lens.API
+	opener        lens.APIOpener
 	storage       *storage.Database
 	leaseLength   time.Duration // length of time to lease work for
 	batchSize     int           // number of tipsets to lease in a batch
@@ -82,11 +84,21 @@ type MessageProcessor struct {
 // Run starts processing batches of tipsets and blocks until the context is done or
 // an error occurs.
 func (p *MessageProcessor) Run(ctx context.Context) error {
+	node, closer, err := p.opener.Open(ctx)
+	if err != nil {
+		return xerrors.Errorf("open lens: %w", err)
+	}
+	defer closer()
+
+	// TODO: restart delay when error returned
+
 	// Loop until context is done or processing encounters a fatal error
-	return wait.RepeatUntil(ctx, batchInterval, p.processBatch)
+	return wait.RepeatUntil(ctx, batchInterval, func(ctx context.Context) (bool, error) {
+		return p.processBatch(ctx, node)
+	})
 }
 
-func (p *MessageProcessor) processBatch(ctx context.Context) (bool, error) {
+func (p *MessageProcessor) processBatch(ctx context.Context, node lens.API) (bool, error) {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, "message"))
 	ctx, span := global.Tracer("").Start(ctx, "MessageProcessor.processBatch")
 	defer span.End()
@@ -96,7 +108,7 @@ func (p *MessageProcessor) processBatch(ctx context.Context) (bool, error) {
 	// Lease some blocks to work on
 	batch, err := p.storage.LeaseTipSetMessages(ctx, claimUntil, p.batchSize, p.minHeight, p.maxHeight)
 	if err != nil {
-		return true, xerrors.Errorf("lease tipset messages: %w", err)
+		return false, xerrors.Errorf("lease tipset messages: %w", err)
 	}
 
 	// If we have no tipsets to work on then wait before trying again
@@ -119,12 +131,14 @@ func (p *MessageProcessor) processBatch(ctx context.Context) (bool, error) {
 		default:
 		}
 
-		if err := p.processItem(ctx, item); err != nil {
+		if err := p.processItem(ctx, node, item); err != nil {
+			// Any errors are likely to be problems using the lens, mark this tipset as failed and exit this batch
 			log.Errorw("failed to process tipset", "error", err.Error(), "height", item.Height)
 			if err := p.storage.MarkTipSetMessagesComplete(ctx, item.TipSet, item.Height, p.clock.Now(), err.Error()); err != nil {
 				log.Errorw("failed to mark tipset messages complete", "error", err.Error(), "height", item.Height)
 			}
-			continue
+
+			return false, xerrors.Errorf("process item: %w", err)
 		}
 
 		if err := p.storage.MarkTipSetMessagesComplete(ctx, item.TipSet, item.Height, p.clock.Now(), ""); err != nil {
@@ -135,7 +149,7 @@ func (p *MessageProcessor) processBatch(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func (p *MessageProcessor) processItem(ctx context.Context, item *visor.ProcessingTipSet) error {
+func (p *MessageProcessor) processItem(ctx context.Context, node lens.API, item *visor.ProcessingTipSet) error {
 	ctx, span := global.Tracer("").Start(ctx, "MessageProcessor.processItem")
 	defer span.End()
 	span.SetAttributes(label.Any("height", item.Height), label.Any("tipset", item.TipSet))
@@ -149,35 +163,35 @@ func (p *MessageProcessor) processItem(ctx context.Context, item *visor.Processi
 		return xerrors.Errorf("get tipsetkey: %w", err)
 	}
 
-	ts, err := p.node.ChainGetTipSet(ctx, tsk)
+	ts, err := node.ChainGetTipSet(ctx, tsk)
 	if err != nil {
 		return xerrors.Errorf("get tipset: %w", err)
 	}
 
-	if err := p.processTipSet(ctx, ts); err != nil {
+	if err := p.processTipSet(ctx, node, ts); err != nil {
 		return xerrors.Errorf("process tipset: %w", err)
 	}
 
 	return nil
 }
 
-func (p *MessageProcessor) processTipSet(ctx context.Context, ts *types.TipSet) error {
+func (p *MessageProcessor) processTipSet(ctx context.Context, node lens.API, ts *types.TipSet) error {
 	ctx, span := global.Tracer("").Start(ctx, "MessageProcessor.processTipSet")
 	defer span.End()
 
 	ll := log.With("height", int64(ts.Height()))
 
-	blkMsgs, err := p.fetchMessages(ctx, ts)
+	blkMsgs, err := p.fetchMessages(ctx, node, ts)
 	if err != nil {
 		return xerrors.Errorf("fetch messages: %w", err)
 	}
 
-	rcts, err := p.fetchReceipts(ctx, ts)
+	rcts, err := p.fetchReceipts(ctx, node, ts)
 	if err != nil {
 		return xerrors.Errorf("fetch receipts: %w", err)
 	}
 
-	result, processingMsgs, err := p.extractMessageModels(ctx, ts, blkMsgs)
+	result, processingMsgs, err := p.extractMessageModels(ctx, node, ts, blkMsgs)
 	if err != nil {
 		return xerrors.Errorf("extract message models: %w", err)
 	}
@@ -200,7 +214,7 @@ func (p *MessageProcessor) processTipSet(ctx context.Context, ts *types.TipSet) 
 	return nil
 }
 
-func (p *MessageProcessor) fetchMessages(ctx context.Context, ts *types.TipSet) (map[cid.Cid]*api.BlockMessages, error) {
+func (p *MessageProcessor) fetchMessages(ctx context.Context, node lens.API, ts *types.TipSet) (map[cid.Cid]*api.BlockMessages, error) {
 	out := make(map[cid.Cid]*api.BlockMessages)
 	for _, blk := range ts.Cids() {
 		// Stop processing if we have somehow passed our own lease time
@@ -209,7 +223,7 @@ func (p *MessageProcessor) fetchMessages(ctx context.Context, ts *types.TipSet) 
 			return nil, xerrors.Errorf("context done: %w", ctx.Err())
 		default:
 		}
-		blkMsgs, err := p.node.ChainGetBlockMessages(ctx, blk)
+		blkMsgs, err := node.ChainGetBlockMessages(ctx, blk)
 		if err != nil {
 			return nil, xerrors.Errorf("get block messages: %w", err)
 		}
@@ -218,7 +232,7 @@ func (p *MessageProcessor) fetchMessages(ctx context.Context, ts *types.TipSet) 
 	return out, nil
 }
 
-func (p *MessageProcessor) extractMessageModels(ctx context.Context, ts *types.TipSet, blkMsgs map[cid.Cid]*api.BlockMessages) (*messagemodel.MessageTaskResult, visor.ProcessingMessageList, error) {
+func (p *MessageProcessor) extractMessageModels(ctx context.Context, node lens.API, ts *types.TipSet, blkMsgs map[cid.Cid]*api.BlockMessages) (*messagemodel.MessageTaskResult, visor.ProcessingMessageList, error) {
 	result := &messagemodel.MessageTaskResult{
 		Messages:          messagemodel.Messages{},
 		BlockMessages:     messagemodel.BlockMessages{},
@@ -298,10 +312,10 @@ func (p *MessageProcessor) extractMessageModels(ctx context.Context, ts *types.T
 					return nil, nil, xerrors.Errorf("parse to address failed for %s: %w", message.Cid().String(), err)
 				}
 
-				child, err := p.node.ChainGetTipSetByHeight(ctx, ts.Height()+1, types.NewTipSetKey())
+				child, err := node.ChainGetTipSetByHeight(ctx, ts.Height()+1, types.NewTipSetKey())
 				if err != nil {
 					// If we aren't finalized, we fail for now, because a child tipset may occur
-					if head, headErr := p.node.ChainHead(ctx); headErr == nil && head.Height()-ts.Height() < build.Finality {
+					if head, headErr := node.ChainHead(ctx); headErr == nil && head.Height()-ts.Height() < build.Finality {
 						log.Warnf("Delaying derivation for message %s which is not yet finalized", message.Cid().String())
 						return nil, nil, xerrors.Errorf("Failed to load child tipset: %w", err)
 					}
@@ -314,7 +328,7 @@ func (p *MessageProcessor) extractMessageModels(ctx context.Context, ts *types.T
 					continue
 				}
 
-				st, err := state.LoadStateTree(p.node.Store(), child.ParentState())
+				st, err := state.LoadStateTree(node.Store(), child.ParentState())
 				if err != nil {
 					return nil, nil, xerrors.Errorf("load state tree when considering message %s: %w", message.Cid().String(), err)
 				}
@@ -423,7 +437,7 @@ func parseMsg(m *messagemodel.Message, ts *types.TipSet, destCode string) (*mess
 	return pm, nil
 }
 
-func (p *MessageProcessor) fetchReceipts(ctx context.Context, ts *types.TipSet) (messagemodel.Receipts, error) {
+func (p *MessageProcessor) fetchReceipts(ctx context.Context, node lens.API, ts *types.TipSet) (messagemodel.Receipts, error) {
 	out := messagemodel.Receipts{}
 
 	for _, blk := range ts.Cids() {
@@ -434,11 +448,11 @@ func (p *MessageProcessor) fetchReceipts(ctx context.Context, ts *types.TipSet) 
 		default:
 		}
 
-		recs, err := p.node.ChainGetParentReceipts(ctx, blk)
+		recs, err := node.ChainGetParentReceipts(ctx, blk)
 		if err != nil {
 			return nil, xerrors.Errorf("get parent receipts: %w", err)
 		}
-		msgs, err := p.node.ChainGetParentMessages(ctx, blk)
+		msgs, err := node.ChainGetParentMessages(ctx, blk)
 		if err != nil {
 			return nil, xerrors.Errorf("get parent messages: %w", err)
 		}

--- a/testutil/db.go
+++ b/testutil/db.go
@@ -21,7 +21,7 @@ func DatabaseAvailable() bool {
 }
 
 // Database returns the connection string for connecting to the test database
-func Database() string {
+func DatabaseOptions() string {
 	return testDatabase
 }
 

--- a/testutil/lens.go
+++ b/testutil/lens.go
@@ -1,0 +1,71 @@
+package testutil
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	apitest "github.com/filecoin-project/lotus/api/test"
+	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	cid "github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+)
+
+type APIOpener struct {
+	node apitest.TestNode
+}
+
+func NewAPIOpener(node apitest.TestNode) *APIOpener {
+	return &APIOpener{node: node}
+}
+
+func (o *APIOpener) Open(ctx context.Context) (lens.API, lens.APICloser, error) {
+	return &APIWrapper{
+		TestNode: o.node,
+		ctx:      ctx,
+	}, lens.APICloser(func() {}), nil
+}
+
+type APIWrapper struct {
+	apitest.TestNode
+	ctx context.Context
+}
+
+func (aw *APIWrapper) Store() adt.Store {
+	return aw
+}
+
+func (aw *APIWrapper) ComputeGasOutputs(gasUsed, gasLimit int64, baseFee, feeCap, gasPremium abi.TokenAmount) vm.GasOutputs {
+	return vm.ComputeGasOutputs(gasUsed, gasLimit, baseFee, feeCap, gasPremium)
+}
+
+func (aw *APIWrapper) Get(ctx context.Context, c cid.Cid, out interface{}) error {
+	cu, ok := out.(cbg.CBORUnmarshaler)
+	if !ok {
+		return xerrors.Errorf("out parameter does not implement CBORUnmarshaler")
+	}
+
+	// miss :(
+	raw, err := aw.ChainReadObj(ctx, c)
+	if err != nil {
+		return xerrors.Errorf("read obj: %w", err)
+	}
+
+	if err := cu.UnmarshalCBOR(bytes.NewReader(raw)); err != nil {
+		return xerrors.Errorf("unmarshal obj: %w", err)
+	}
+
+	return nil
+}
+
+func (aw *APIWrapper) Put(ctx context.Context, v interface{}) (cid.Cid, error) {
+	return cid.Undef, xerrors.Errorf("put is not implemented")
+}
+
+func (aw *APIWrapper) Context() context.Context {
+	return aw.ctx
+}


### PR DESCRIPTION
Tasks are now passed an APIOpener which they use to acquire a lens. On
encountering a fatal error the task exits and closes the lens. The scheduler
restarts the task after a delay allowing the task to attempt a new connection
to the lens.

The lotus lens opener returns a new rpc connection. The lotusrepo and carrepo
openers return a shared instance of their repo since they hold exclusive locks
over the store.

Fixes #98 