### PR TITLE
Limit cases where message parsing fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/filecoin-project/lotus v1.1.0
 	github.com/filecoin-project/specs-actors v0.9.12
 	github.com/filecoin-project/specs-actors/v2 v2.2.0
-	github.com/filecoin-project/statediff v0.0.7
+	github.com/filecoin-project/statediff v0.0.8-0.20201027195725-7eaa5391a639
 	github.com/go-pg/migrations/v8 v8.0.1
 	github.com/go-pg/pg/v10 v10.3.1
 	github.com/go-pg/pgext v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -307,6 +307,8 @@ github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
 github.com/filecoin-project/statediff v0.0.7 h1:zCvfrqGrWGet5LoGV+iTJ3S81HsM+cuNrupY+b17dYg=
 github.com/filecoin-project/statediff v0.0.7/go.mod h1:D89c9tc5Svbf/ofX+pOzduoKBtM0PpFxO+mo9qT04XU=
+github.com/filecoin-project/statediff v0.0.8-0.20201027195725-7eaa5391a639 h1:iuv1IGNCsqwmvvfdsBjbfpZBgAKMhsnxq3jOr275HMA=
+github.com/filecoin-project/statediff v0.0.8-0.20201027195725-7eaa5391a639/go.mod h1:D89c9tc5Svbf/ofX+pOzduoKBtM0PpFxO+mo9qT04XU=
 github.com/filecoin-project/test-vectors/schema v0.0.3/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
 github.com/filecoin-project/test-vectors/schema v0.0.5/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -291,7 +291,7 @@ func (p *MessageProcessor) extractMessageModels(ctx context.Context, ts *types.T
 				if err != nil {
 					// If we aren't finalized, we fail for now, because a child tipset may occur
 					if head, err := p.node.ChainGetTipSet(ctx, types.NewTipSetKey()); err == nil && head.Height()-ts.Height() < 900 {
-						log.Warn("Failing derivation for messate that does not yet have children, but might get them later")
+						log.Warn("Delaying derivation for message which is not yet finalized")
 						return nil, nil, xerrors.Errorf("Failed to load child tipset: %w", err)
 					}
 					log.Info("Skipping derivation of message parameters for message with no children blocks after derivation.")

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -290,7 +290,7 @@ func (p *MessageProcessor) extractMessageModels(ctx context.Context, ts *types.T
 				child, err := p.node.ChainGetTipSetByHeight(ctx, ts.Height()+1, types.NewTipSetKey())
 				if err != nil {
 					// If we aren't finalized, we fail for now, because a child tipset may occur
-					if head, err := p.node.ChainGetTipSet(ctx, types.NewTipSetKey()); err == nil && head.Height()-ts.Height() < 900 {
+					if head, err := p.node.ChainGetTipSet(ctx, types.NewTipSetKey()); err == nil && head.Height()-ts.Height() < build.Finality {
 						log.Warn("Delaying derivation for message which is not yet finalized")
 						return nil, nil, xerrors.Errorf("Failed to load child tipset: %w", err)
 					}

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -290,7 +290,7 @@ func (p *MessageProcessor) extractMessageModels(ctx context.Context, ts *types.T
 				child, err := p.node.ChainGetTipSetByHeight(ctx, ts.Height()+1, types.NewTipSetKey())
 				if err != nil {
 					// If we aren't finalized, we fail for now, because a child tipset may occur
-					if head, err := p.node.ChainGetTipSet(ctx, types.NewTipSetKey()); err == nil && head.Height()-ts.Height() < build.Finality {
+					if head, err := p.node.ChainHead(ctx); err == nil && head.Height()-ts.Height() < build.Finality {
 						log.Warn("Delaying derivation for message which is not yet finalized")
 						return nil, nil, xerrors.Errorf("Failed to load child tipset: %w", err)
 					}

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -3,6 +3,7 @@ package message
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math"
 	"math/big"
 	"time"
@@ -389,6 +390,9 @@ func parseMsg(m *messagemodel.Message, ts *types.TipSet, destCode string) (*mess
 	}
 	if err != nil {
 		return nil, xerrors.Errorf("parse params: %w", err)
+	}
+	if name == "Unknown" {
+		name = fmt.Sprintf("%s.%d", actor, m.Method)
 	}
 	pm.Method = name
 	if params != nil {

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -290,7 +290,7 @@ func (p *MessageProcessor) extractMessageModels(ctx context.Context, ts *types.T
 				child, err := p.node.ChainGetTipSetByHeight(ctx, ts.Height()+1, types.NewTipSetKey())
 				if err != nil {
 					// If we aren't finalized, we fail for now, because a child tipset may occur
-					if head, err := p.node.ChainHead(ctx); err == nil && head.Height()-ts.Height() < build.Finality {
+					if head, headErr := p.node.ChainHead(ctx); headErr == nil && head.Height()-ts.Height() < build.Finality {
 						log.Warn("Delaying derivation for message which is not yet finalized")
 						return nil, nil, xerrors.Errorf("Failed to load child tipset: %w", err)
 					}


### PR DESCRIPTION
* use a child tipset when available to learn type of destination actor for message parsing