### PR TITLE
feat: add power actor claim extraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/filecoin-project/go-fil-markets v1.0.0
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-state-types v0.0.0-20201013222834-41ea465f274f
-	github.com/filecoin-project/lotus v1.1.3-0.20201027132752-3d02dba5dc9b
+	github.com/filecoin-project/lotus v1.1.3-0.20201031000550-a5c05f87f15f
 	github.com/filecoin-project/specs-actors v0.9.12
 	github.com/filecoin-project/specs-actors/v2 v2.2.0
 	github.com/filecoin-project/statediff v0.0.8-0.20201027195725-7eaa5391a639

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,7 @@ github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -289,8 +290,8 @@ github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZO
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
 github.com/filecoin-project/lotus v0.9.0/go.mod h1:8Qg5wmvHgCvxq2gCq9iziPlcNHl58dtzozf4StZ68Kk=
-github.com/filecoin-project/lotus v1.1.3-0.20201027132752-3d02dba5dc9b h1:A5xJDE9tJPHzMYz5Gqh+Jue1Tbs0VNXv18hZEbMdVgk=
-github.com/filecoin-project/lotus v1.1.3-0.20201027132752-3d02dba5dc9b/go.mod h1:41z5qos7adeegSp1SjylE85hu7Zey1h0SV0vpMPv2G0=
+github.com/filecoin-project/lotus v1.1.3-0.20201031000550-a5c05f87f15f h1:7mTCv5I/7kJ8sfwRjUKlTLFCa7LQYroLDkL9ekURPek=
+github.com/filecoin-project/lotus v1.1.3-0.20201031000550-a5c05f87f15f/go.mod h1:41z5qos7adeegSp1SjylE85hu7Zey1h0SV0vpMPv2G0=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/filecoin-project/specs-actors v0.9.7/go.mod h1:wM2z+kwqYgXn5Z7scV1YHLyd1Q1cy0R8HfTIWQ0BFGU=
 github.com/filecoin-project/specs-actors v0.9.12 h1:iIvk58tuMtmloFNHhAOQHG+4Gci6Lui0n7DYQGi3cJk=
@@ -700,6 +701,7 @@ github.com/ipld/go-ipld-prime-proto v0.0.0-20200922192210-9a2bfd4440a6 h1:6Mq+tZ
 github.com/ipld/go-ipld-prime-proto v0.0.0-20200922192210-9a2bfd4440a6/go.mod h1:3pHYooM9Ea65jewRwrb2u5uHZCNkNTe9ABsVB+SrkH0=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
+github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -718,6 +720,7 @@ github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye47
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=
@@ -1395,6 +1398,7 @@ github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -1504,6 +1508,7 @@ github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=

--- a/model/actors/power/claimedpower.go
+++ b/model/actors/power/claimedpower.go
@@ -1,0 +1,45 @@
+package power
+
+import (
+	"context"
+
+	"github.com/go-pg/pg/v10"
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+)
+
+type PowerActorClaim struct {
+	Height          int64  `pg:",pk,notnull,use_zero"`
+	MinerID         string `pg:",pk,notnull"`
+	StateRoot       string `pg:",pk,notnull"`
+	RawBytePower    string `pg:",notnull"`
+	QualityAdjPower string `pg:",notnull"`
+}
+
+func (p *PowerActorClaim) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	ctx, span := global.Tracer("").Start(ctx, "PowerActorClaim.PersistWithTx")
+	defer span.End()
+	if _, err := tx.ModelContext(ctx, p).
+		OnConflict("do nothing").
+		Insert(); err != nil {
+		return xerrors.Errorf("persisting power actors claim: %w", err)
+	}
+	return nil
+}
+
+type PowerActorClaimList []*PowerActorClaim
+
+func (pl PowerActorClaimList) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	ctx, span := global.Tracer("").Start(ctx, "PowerActorClaimList.PersistWithTx")
+	defer span.End()
+	if len(pl) == 0 {
+		return nil
+	}
+	if _, err := tx.ModelContext(ctx, &pl).
+		OnConflict("do nothing").
+		Insert(); err != nil {
+		return xerrors.Errorf("persisting power actor claim list: %w")
+	}
+	return nil
+
+}

--- a/model/actors/power/task.go
+++ b/model/actors/power/task.go
@@ -1,0 +1,41 @@
+package power
+
+import (
+	"context"
+
+	"github.com/go-pg/pg/v10"
+	"go.opentelemetry.io/otel/api/global"
+
+	"github.com/filecoin-project/sentinel-visor/metrics"
+)
+
+type PowerTaskResult struct {
+	ChainPowerModel *ChainPower
+	ClaimStateModel PowerActorClaimList
+}
+
+func (p *PowerTaskResult) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	if p.ChainPowerModel != nil {
+		if err := p.ChainPowerModel.PersistWithTx(ctx, tx); err != nil {
+			return err
+		}
+	}
+	if p.ClaimStateModel != nil {
+		if err := p.ClaimStateModel.PersistWithTx(ctx, tx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *PowerTaskResult) Persist(ctx context.Context, db *pg.DB) error {
+	ctx, span := global.Tracer("").Start(ctx, "PowerTaskResult.Persist")
+	defer span.End()
+
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
+	return db.RunInTransaction(ctx, func(tx *pg.Tx) error {
+		return p.PersistWithTx(ctx, tx)
+	})
+}

--- a/storage/migrations/16_power_actor_claims.go
+++ b/storage/migrations/16_power_actor_claims.go
@@ -1,0 +1,26 @@
+package migrations
+
+import (
+	"github.com/go-pg/migrations/v8"
+)
+
+// Schema version 16 adds power actor claims table
+
+func init() {
+	up := batch(`
+	CREATE TABLE IF NOT EXISTS "power_actor_claims" (
+		"height" bigint not null,
+		"miner_id" text not null,
+		"state_root" text not null,
+		"raw_byte_power" text not null,
+		"quality_adj_power" text not null,
+		PRIMARY KEY ("height", "miner_id", "state_root")
+	);
+`)
+
+	down := batch(`
+	DROP TABLE IF EXISTS public.power_actor_claims;
+`)
+
+	migrations.MustRegisterTx(up, down)
+}

--- a/tasks/actorstate/genesis_test.go
+++ b/tasks/actorstate/genesis_test.go
@@ -74,7 +74,7 @@ func TestGenesisProcessor(t *testing.T) {
 
 	t.Run("miner_deal_sectors", func(t *testing.T) {
 		var count int
-		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM miner_deal_sectors`)
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM miner_sector_deals`)
 		require.NoError(t, err)
 		assert.NotEqual(t, 0, count)
 	})
@@ -128,7 +128,7 @@ func truncateGenesisTables(tb testing.TB, db *pg.DB) error {
 		"miner_states",
 		"miner_powers",
 		"miner_sector_infos",
-		"miner_deal_sectors",
+		"miner_sector_deals",
 		"market_deal_states",
 		"market_deal_proposals",
 		"id_addresses",

--- a/tasks/actorstate/miner.go
+++ b/tasks/actorstate/miner.go
@@ -45,15 +45,6 @@ func (m StorageMinerExtractor) Extract(ctx context.Context, a ActorInfo, node Ac
 		return nil, err
 	}
 
-	// TODO add this to the power actor processing.
-	// remove when #171 closes.
-	/*
-		minerPower, err := node.StateMinerPower(ctx, a.Address, a.TipSet)
-		if err != nil {
-			return nil, xerrors.Errorf("loading miner power: %w", err)
-		}
-	*/
-
 	minerInfoModel, err := ExtractMinerInfo(a, ec)
 	if err != nil {
 		return nil, xerrors.Errorf("extracting miner info: %w", err)
@@ -289,13 +280,7 @@ func ExtractMinerSectorData(ctx context.Context, ec *MinerStateExtractionContext
 
 	sectorDealsModel := minermodel.MinerSectorDealList{}
 	if ec.IsGenesis() {
-		// load genesis miners sectors
-		mstate, err := miner.Load(node.Store(), ec.CurrActor)
-		if err != nil {
-			return nil, nil, nil, nil, err
-		}
-
-		msectors, err := mstate.LoadSectors(nil)
+		msectors, err := ec.CurrState.LoadSectors(nil)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}

--- a/tasks/actorstate/power.go
+++ b/tasks/actorstate/power.go
@@ -3,6 +3,8 @@ package actorstate
 import (
 	"context"
 
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/chain/types"
 	"go.opentelemetry.io/otel/api/global"
 	"golang.org/x/xerrors"
 
@@ -25,6 +27,51 @@ func init() {
 	Register(sa2builtin.StoragePowerActorCodeID, StoragePowerExtractor{})
 }
 
+func NewPowerStateExtractionContext(ctx context.Context, a ActorInfo, node ActorStateAPI) (*PowerStateExtractionContext, error) {
+	curActor, err := node.StateGetActor(ctx, a.Address, a.TipSet)
+	if err != nil {
+		return nil, xerrors.Errorf("loading current power actor: %w", err)
+	}
+
+	curTipset, err := node.ChainGetTipSet(ctx, a.TipSet)
+	if err != nil {
+		return nil, xerrors.Errorf("loading current tipset: %w", err)
+	}
+
+	curState, err := power.Load(node.Store(), curActor)
+	if err != nil {
+		return nil, xerrors.Errorf("loading current power state: %w", err)
+	}
+
+	prevState := curState
+	if a.Epoch != 0 {
+		prevActor, err := node.StateGetActor(ctx, a.Address, a.ParentTipSet)
+		if err != nil {
+			return nil, xerrors.Errorf("loading previous power actor at tipset %s epoch %d: %w", a.ParentTipSet, a.Epoch)
+		}
+
+		prevState, err = power.Load(node.Store(), prevActor)
+		if err != nil {
+			return nil, xerrors.Errorf("loading previous power actor state: %w", err)
+		}
+	}
+	return &PowerStateExtractionContext{
+		PrevState: prevState,
+		CurrState: curState,
+		CurrTs:    curTipset,
+	}, nil
+}
+
+type PowerStateExtractionContext struct {
+	PrevState power.State
+	CurrState power.State
+	CurrTs    *types.TipSet
+}
+
+func (p *PowerStateExtractionContext) IsGenesis() bool {
+	return 0 == p.CurrTs.Height()
+}
+
 func (StoragePowerExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := global.Tracer("").Start(ctx, "StoragePowerExtractor")
 	defer span.End()
@@ -32,39 +79,50 @@ func (StoragePowerExtractor) Extract(ctx context.Context, a ActorInfo, node Acto
 	stop := metrics.Timer(ctx, metrics.ProcessingDuration)
 	defer stop()
 
-	powerActor, err := node.StateGetActor(ctx, power.Address, a.TipSet)
+	ec, err := NewPowerStateExtractionContext(ctx, a, node)
 	if err != nil {
-		return nil, xerrors.Errorf("loading power actor: %w", err)
+		return nil, err
 	}
 
-	pstate, err := power.Load(node.Store(), powerActor)
+	chainPowerModel, err := ExtractChainPower(ec)
 	if err != nil {
-		return nil, xerrors.Errorf("loading power actor state: %w", err)
+		return nil, err
 	}
 
-	locked, err := pstate.TotalLocked()
+	claimedPowerModel, err := ExtractClaimedPower(ec)
 	if err != nil {
 		return nil, err
 	}
-	pow, err := pstate.TotalPower()
+	return &powermodel.PowerTaskResult{
+		ChainPowerModel: chainPowerModel,
+		ClaimStateModel: claimedPowerModel,
+	}, nil
+}
+
+func ExtractChainPower(ec *PowerStateExtractionContext) (*powermodel.ChainPower, error) {
+	locked, err := ec.CurrState.TotalLocked()
 	if err != nil {
 		return nil, err
 	}
-	commit, err := pstate.TotalCommitted()
+	pow, err := ec.CurrState.TotalPower()
 	if err != nil {
 		return nil, err
 	}
-	smoothed, err := pstate.TotalPowerSmoothed()
+	commit, err := ec.CurrState.TotalCommitted()
 	if err != nil {
 		return nil, err
 	}
-	participating, total, err := pstate.MinerCounts()
+	smoothed, err := ec.CurrState.TotalPowerSmoothed()
+	if err != nil {
+		return nil, err
+	}
+	participating, total, err := ec.CurrState.MinerCounts()
 	if err != nil {
 		return nil, err
 	}
 
 	return &powermodel.ChainPower{
-		StateRoot:                  a.ParentStateRoot.String(),
+		StateRoot:                  ec.CurrTs.ParentState().String(),
 		TotalRawBytesPower:         pow.RawBytePower.String(),
 		TotalQABytesPower:          pow.QualityAdjPower.String(),
 		TotalRawBytesCommitted:     commit.RawBytePower.String(),
@@ -75,4 +133,48 @@ func (StoragePowerExtractor) Extract(ctx context.Context, a ActorInfo, node Acto
 		MinerCount:                 total,
 		ParticipatingMinerCount:    participating,
 	}, nil
+}
+
+func ExtractClaimedPower(ec *PowerStateExtractionContext) (powermodel.PowerActorClaimList, error) {
+	claimModel := powermodel.PowerActorClaimList{}
+	if ec.IsGenesis() {
+		if err := ec.CurrState.ForEachClaim(func(miner address.Address, claim power.Claim) error {
+			claimModel = append(claimModel, &powermodel.PowerActorClaim{
+				Height:          int64(ec.CurrTs.Height()),
+				StateRoot:       ec.CurrTs.ParentState().String(),
+				MinerID:         miner.String(),
+				RawBytePower:    claim.RawBytePower.String(),
+				QualityAdjPower: claim.QualityAdjPower.String(),
+			})
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		return claimModel, nil
+	}
+	// normal case.
+	claimChanges, err := power.DiffClaims(ec.PrevState, ec.CurrState)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, newClaim := range claimChanges.Added {
+		claimModel = append(claimModel, &powermodel.PowerActorClaim{
+			Height:          int64(ec.CurrTs.Height()),
+			StateRoot:       ec.CurrTs.ParentState().String(),
+			MinerID:         newClaim.Miner.String(),
+			RawBytePower:    newClaim.Claim.RawBytePower.String(),
+			QualityAdjPower: newClaim.Claim.QualityAdjPower.String(),
+		})
+	}
+	for _, modClaim := range claimChanges.Modified {
+		claimModel = append(claimModel, &powermodel.PowerActorClaim{
+			Height:          int64(ec.CurrTs.Height()),
+			StateRoot:       ec.CurrTs.ParentState().String(),
+			MinerID:         modClaim.Miner.String(),
+			RawBytePower:    modClaim.To.RawBytePower.String(),
+			QualityAdjPower: modClaim.To.QualityAdjPower.String(),
+		})
+	}
+	return claimModel, nil
 }

--- a/tasks/actorstate/power_test.go
+++ b/tasks/actorstate/power_test.go
@@ -47,31 +47,33 @@ func TestPowerExtractV0(t *testing.T) {
 	require.NoError(t, err)
 
 	info := ActorInfo{
-		Actor:   types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: stateCid},
-		Address: power.Address,
-		TipSet:  stateTs.Key(),
+		Actor:           types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: stateCid},
+		Address:         power.Address,
+		TipSet:          stateTs.Key(),
+		ParentStateRoot: stateTs.ParentState(),
 	}
 
 	mapi.setActor(stateTs.Key(), power.Address, &types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: stateCid})
+	mapi.putTipSet(stateTs)
 
 	ex := StoragePowerExtractor{}
 	res, err := ex.Extract(ctx, info, mapi)
 	require.NoError(t, err)
 
-	cp, ok := res.(*powermodel.ChainPower)
+	cp, ok := res.(*powermodel.PowerTaskResult)
 	require.True(t, ok)
 	require.NotNil(t, cp)
 
-	assert.EqualValues(t, info.ParentStateRoot.String(), cp.StateRoot, "StateRoot")
-	assert.EqualValues(t, state.TotalRawBytePower.String(), cp.TotalRawBytesPower, "TotalRawBytesPower")
-	assert.EqualValues(t, state.TotalQualityAdjPower.String(), cp.TotalQABytesPower, "TotalQABytesPower")
-	assert.EqualValues(t, state.TotalBytesCommitted.String(), cp.TotalRawBytesCommitted, "TotalRawBytesCommitted")
-	assert.EqualValues(t, state.TotalQABytesCommitted.String(), cp.TotalQABytesCommitted, "TotalQABytesCommitted")
-	assert.EqualValues(t, state.TotalPledgeCollateral.String(), cp.TotalPledgeCollateral, "TotalPledgeCollateral")
-	assert.EqualValues(t, state.ThisEpochQAPowerSmoothed.PositionEstimate.String(), cp.QASmoothedPositionEstimate, "QASmoothedPositionEstimate")
-	assert.EqualValues(t, state.ThisEpochQAPowerSmoothed.VelocityEstimate.String(), cp.QASmoothedVelocityEstimate, "QASmoothedVelocityEstimate")
-	assert.EqualValues(t, state.MinerCount, cp.MinerCount, "MinerCount")
-	assert.EqualValues(t, state.MinerAboveMinPowerCount, cp.ParticipatingMinerCount, "ParticipatingMinerCount")
+	assert.EqualValues(t, info.ParentStateRoot.String(), cp.ChainPowerModel.StateRoot, "StateRoot")
+	assert.EqualValues(t, state.TotalRawBytePower.String(), cp.ChainPowerModel.TotalRawBytesPower, "TotalRawBytesPower")
+	assert.EqualValues(t, state.TotalQualityAdjPower.String(), cp.ChainPowerModel.TotalQABytesPower, "TotalQABytesPower")
+	assert.EqualValues(t, state.TotalBytesCommitted.String(), cp.ChainPowerModel.TotalRawBytesCommitted, "TotalRawBytesCommitted")
+	assert.EqualValues(t, state.TotalQABytesCommitted.String(), cp.ChainPowerModel.TotalQABytesCommitted, "TotalQABytesCommitted")
+	assert.EqualValues(t, state.TotalPledgeCollateral.String(), cp.ChainPowerModel.TotalPledgeCollateral, "TotalPledgeCollateral")
+	assert.EqualValues(t, state.ThisEpochQAPowerSmoothed.PositionEstimate.String(), cp.ChainPowerModel.QASmoothedPositionEstimate, "QASmoothedPositionEstimate")
+	assert.EqualValues(t, state.ThisEpochQAPowerSmoothed.VelocityEstimate.String(), cp.ChainPowerModel.QASmoothedVelocityEstimate, "QASmoothedVelocityEstimate")
+	assert.EqualValues(t, state.MinerCount, cp.ChainPowerModel.MinerCount, "MinerCount")
+	assert.EqualValues(t, state.MinerAboveMinPowerCount, cp.ChainPowerModel.ParticipatingMinerCount, "ParticipatingMinerCount")
 }
 
 func TestPowerExtractV2(t *testing.T) {
@@ -103,29 +105,31 @@ func TestPowerExtractV2(t *testing.T) {
 	require.NoError(t, err)
 
 	info := ActorInfo{
-		Actor:   types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: stateCid},
-		Address: power.Address,
-		TipSet:  stateTs.Key(),
+		Actor:           types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: stateCid},
+		Address:         power.Address,
+		TipSet:          stateTs.Key(),
+		ParentStateRoot: stateTs.ParentState(),
 	}
 
 	mapi.setActor(stateTs.Key(), power.Address, &types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: stateCid})
+	mapi.putTipSet(stateTs)
 
 	ex := StoragePowerExtractor{}
 	res, err := ex.Extract(ctx, info, mapi)
 	require.NoError(t, err)
 
-	cp, ok := res.(*powermodel.ChainPower)
+	cp, ok := res.(*powermodel.PowerTaskResult)
 	require.True(t, ok)
 	require.NotNil(t, cp)
 
-	assert.EqualValues(t, info.ParentStateRoot.String(), cp.StateRoot, "StateRoot")
-	assert.EqualValues(t, state.TotalRawBytePower.String(), cp.TotalRawBytesPower, "TotalRawBytesPower")
-	assert.EqualValues(t, state.TotalQualityAdjPower.String(), cp.TotalQABytesPower, "TotalQABytesPower")
-	assert.EqualValues(t, state.TotalBytesCommitted.String(), cp.TotalRawBytesCommitted, "TotalRawBytesCommitted")
-	assert.EqualValues(t, state.TotalQABytesCommitted.String(), cp.TotalQABytesCommitted, "TotalQABytesCommitted")
-	assert.EqualValues(t, state.TotalPledgeCollateral.String(), cp.TotalPledgeCollateral, "TotalPledgeCollateral")
-	assert.EqualValues(t, state.ThisEpochQAPowerSmoothed.PositionEstimate.String(), cp.QASmoothedPositionEstimate, "QASmoothedPositionEstimate")
-	assert.EqualValues(t, state.ThisEpochQAPowerSmoothed.VelocityEstimate.String(), cp.QASmoothedVelocityEstimate, "QASmoothedVelocityEstimate")
-	assert.EqualValues(t, state.MinerCount, cp.MinerCount, "MinerCount")
-	assert.EqualValues(t, state.MinerAboveMinPowerCount, cp.ParticipatingMinerCount, "ParticipatingMinerCount")
+	assert.EqualValues(t, info.ParentStateRoot.String(), cp.ChainPowerModel.StateRoot, "StateRoot")
+	assert.EqualValues(t, state.TotalRawBytePower.String(), cp.ChainPowerModel.TotalRawBytesPower, "TotalRawBytesPower")
+	assert.EqualValues(t, state.TotalQualityAdjPower.String(), cp.ChainPowerModel.TotalQABytesPower, "TotalQABytesPower")
+	assert.EqualValues(t, state.TotalBytesCommitted.String(), cp.ChainPowerModel.TotalRawBytesCommitted, "TotalRawBytesCommitted")
+	assert.EqualValues(t, state.TotalQABytesCommitted.String(), cp.ChainPowerModel.TotalQABytesCommitted, "TotalQABytesCommitted")
+	assert.EqualValues(t, state.TotalPledgeCollateral.String(), cp.ChainPowerModel.TotalPledgeCollateral, "TotalPledgeCollateral")
+	assert.EqualValues(t, state.ThisEpochQAPowerSmoothed.PositionEstimate.String(), cp.ChainPowerModel.QASmoothedPositionEstimate, "QASmoothedPositionEstimate")
+	assert.EqualValues(t, state.ThisEpochQAPowerSmoothed.VelocityEstimate.String(), cp.ChainPowerModel.QASmoothedVelocityEstimate, "QASmoothedVelocityEstimate")
+	assert.EqualValues(t, state.MinerCount, cp.ChainPowerModel.MinerCount, "MinerCount")
+	assert.EqualValues(t, state.MinerAboveMinPowerCount, cp.ChainPowerModel.ParticipatingMinerCount, "ParticipatingMinerCount")
 }


### PR DESCRIPTION
### What
This PR does the following:
- adds a `power_actor_claims` table to track claimed power by all miners in the power actor's state.
- updates `power_test.go` and mock api to work with power actor changes.
- shares power actor extractor logic with genesis task

closes #171
~blocked on https://github.com/filecoin-project/lotus/pull/4628~