### PR TITLE
perf: ensure processing updates always include height in criteria

### DIFF
--- a/model/derived/gasoutputs.go
+++ b/model/derived/gasoutputs.go
@@ -65,3 +65,8 @@ func (l GasOutputsList) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
 	}
 	return nil
 }
+
+type ProcessingGasOutputs struct {
+	Height int64
+	GasOutputs
+}

--- a/storage/sql_test.go
+++ b/storage/sql_test.go
@@ -329,7 +329,7 @@ func TestMarkActorComplete(t *testing.T) {
 
 	t.Run("with error message", func(t *testing.T) {
 		completedAt := testutil.KnownTime.Add(time.Minute * 1)
-		err = d.MarkActorComplete(ctx, "head1", "codeB", completedAt, "message")
+		err = d.MarkActorComplete(ctx, 1, "head1", "codeB", completedAt, "message")
 		require.NoError(t, err)
 
 		// Check the database contains the updated row
@@ -341,7 +341,7 @@ func TestMarkActorComplete(t *testing.T) {
 
 	t.Run("without error message", func(t *testing.T) {
 		completedAt := testutil.KnownTime.Add(time.Minute * 2)
-		err = d.MarkActorComplete(ctx, "head1", "codeB", completedAt, "")
+		err = d.MarkActorComplete(ctx, 1, "head1", "codeB", completedAt, "")
 		require.NoError(t, err)
 
 		// Check the database contains the updated row with a null errors_detected column
@@ -713,7 +713,7 @@ func TestMarkGasOutputsMessagesComplete(t *testing.T) {
 
 	t.Run("with error message", func(t *testing.T) {
 		completedAt := testutil.KnownTime.Add(time.Minute * 1)
-		err = d.MarkGasOutputsMessagesComplete(ctx, "cid1", completedAt, "message")
+		err = d.MarkGasOutputsMessagesComplete(ctx, 1, "cid1", completedAt, "message")
 		require.NoError(t, err)
 
 		// Check the database contains the updated row
@@ -725,7 +725,7 @@ func TestMarkGasOutputsMessagesComplete(t *testing.T) {
 
 	t.Run("without error message", func(t *testing.T) {
 		completedAt := testutil.KnownTime.Add(time.Minute * 2)
-		err = d.MarkGasOutputsMessagesComplete(ctx, "cid1", completedAt, "")
+		err = d.MarkGasOutputsMessagesComplete(ctx, 1, "cid1", completedAt, "")
 		require.NoError(t, err)
 
 		// Check the database contains the updated row with a null errors_detected column

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -267,7 +267,7 @@ func (p *ActorStateProcessor) processBatch(ctx context.Context, node lens.API) (
 		info, err := NewActorInfo(actor)
 		if err != nil {
 			errorLog.Errorw("unmarshal actor", "error", err.Error())
-			if err := p.storage.MarkActorComplete(ctx, actor.Head, actor.Code, p.clock.Now(), err.Error()); err != nil {
+			if err := p.storage.MarkActorComplete(ctx, actor.Height, actor.Head, actor.Code, p.clock.Now(), err.Error()); err != nil {
 				errorLog.Errorw("failed to mark actor complete", "error", err.Error())
 			}
 			continue
@@ -275,14 +275,14 @@ func (p *ActorStateProcessor) processBatch(ctx context.Context, node lens.API) (
 
 		if err := p.processActor(ctx, node, info); err != nil {
 			errorLog.Errorw("process actor", "error", err.Error())
-			if err := p.storage.MarkActorComplete(ctx, actor.Head, actor.Code, p.clock.Now(), err.Error()); err != nil {
+			if err := p.storage.MarkActorComplete(ctx, actor.Height, actor.Head, actor.Code, p.clock.Now(), err.Error()); err != nil {
 				errorLog.Errorw("failed to mark actor complete", "error", err.Error())
 			}
 
 			return false, xerrors.Errorf("process actor: %w", err)
 		}
 
-		if err := p.storage.MarkActorComplete(ctx, actor.Head, actor.Code, p.clock.Now(), ""); err != nil {
+		if err := p.storage.MarkActorComplete(ctx, actor.Height, actor.Head, actor.Code, p.clock.Now(), ""); err != nil {
 			errorLog.Errorw("failed to mark actor complete", "error", err.Error())
 		}
 	}

--- a/tasks/message/gasoutputs.go
+++ b/tasks/message/gasoutputs.go
@@ -91,16 +91,16 @@ func (p *GasOutputsProcessor) processBatch(ctx context.Context, node lens.API) (
 
 		errorLog := log.With("cid", item.Cid)
 
-		if err := p.processItem(ctx, node, item); err != nil {
+		if err := p.processItem(ctx, node, &item.GasOutputs); err != nil {
 			// Any errors are likely to be problems using the lens, mark this tipset as failed and exit this batch
 			errorLog.Errorw("failed to process message", "error", err.Error())
-			if err := p.storage.MarkGasOutputsMessagesComplete(ctx, item.Cid, p.clock.Now(), err.Error()); err != nil {
+			if err := p.storage.MarkGasOutputsMessagesComplete(ctx, item.Height, item.Cid, p.clock.Now(), err.Error()); err != nil {
 				errorLog.Errorw("failed to mark message complete", "error", err.Error())
 			}
 			return false, xerrors.Errorf("process item: %w", err)
 		}
 
-		if err := p.storage.MarkGasOutputsMessagesComplete(ctx, item.Cid, p.clock.Now(), ""); err != nil {
+		if err := p.storage.MarkGasOutputsMessagesComplete(ctx, item.Height, item.Cid, p.clock.Now(), ""); err != nil {
 			errorLog.Errorw("failed to mark message complete", "error", err.Error())
 		}
 	}


### PR DESCRIPTION
Helps with https://github.com/filecoin-project/sentinel-visor/issues/188 and https://github.com/filecoin-project/sentinel-visor/issues/183

Avoids the update needing to traverse all hypertables when looking for the item to update.