### PR TITLE
remove null bytes from message params

### DIFF
--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -433,7 +433,7 @@ func parseMsg(m *messagemodel.Message, ts *types.TipSet, destCode string) (*mess
 		if err := fcjson.Encoder(params, buf); err != nil {
 			return nil, xerrors.Errorf("json encode: %w", err)
 		}
-		pm.Params = string(buf.Bytes())
+		pm.Params = string(bytes.ToValidUTF8(buf.Bytes(), []byte{}))
 	}
 
 	return pm, nil

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -424,6 +424,7 @@ func parseMsg(m *messagemodel.Message, ts *types.TipSet, destCode string) (*mess
 	}
 	pm.Method = name
 	if err != nil {
+		log.Warnf("failed to parse parameters of message %s: %v", m.Cid, err)
 		// this can occur when the message is not valid cbor
 		pm.Params = ""
 		return pm, nil

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -419,13 +419,15 @@ func parseMsg(m *messagemodel.Message, ts *types.TipSet, destCode string) (*mess
 		actor = statediff.LotusTypeUnknown
 		params, name, err = statediff.ParseParams(m.Params, int(m.Method), actor)
 	}
-	if err != nil {
-		return nil, xerrors.Errorf("parse params: %w", err)
-	}
 	if name == "Unknown" {
 		name = fmt.Sprintf("%s.%d", actor, m.Method)
 	}
 	pm.Method = name
+	if err != nil {
+		// this can occur when the message is not valid cbor
+		pm.Params = ""
+		return pm, nil
+	}
 	if params != nil {
 		buf := bytes.NewBuffer(nil)
 		if err := fcjson.Encoder(params, buf); err != nil {

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -434,7 +434,7 @@ func parseMsg(m *messagemodel.Message, ts *types.TipSet, destCode string) (*mess
 		if err := fcjson.Encoder(params, buf); err != nil {
 			return nil, xerrors.Errorf("json encode: %w", err)
 		}
-		pm.Params = string(bytes.ToValidUTF8(buf.Bytes(), []byte{}))
+		pm.Params = string(bytes.ReplaceAll(bytes.ToValidUTF8(buf.Bytes(), []byte{}), []byte{0x00}, []byte{}))
 	}
 
 	return pm, nil


### PR DESCRIPTION
this is a bit unfortunate because for some binary fields this could lead to corruption, but we probably won't be dealing with those fields meaningfully in this table.