### PR TITLE
fix(migrations): CREATE EXTENSION deadlocks inside migrations global lock

### DIFF
--- a/storage/migrate.go
+++ b/storage/migrate.go
@@ -95,9 +95,12 @@ func (d *Database) MigrateSchemaTo(ctx context.Context, target int) error {
 	}
 
 	// CREATE EXTENSION cannot run inside a transaction (as part of
-	// migration), so we run it explicitally here. (#179).
-	if _, err := d.DB.Exec(`CREATE EXTENSION IF NOT EXISTS timescaledb WITH SCHEMA public`); err != nil {
-		return xerrors.Errorf("creating timescaledb extension: %w", err)
+	// migration), so we run it explicitally here and only when setting
+	// things up for the first time (#179).
+	if dbVersion == 0 {
+		if _, err := d.DB.Exec(`CREATE EXTENSION IF NOT EXISTS timescaledb WITH SCHEMA public`); err != nil {
+			return xerrors.Errorf("creating timescaledb extension: %w", err)
+		}
 	}
 
 	// Remember to release the lock

--- a/storage/migrate.go
+++ b/storage/migrate.go
@@ -94,6 +94,12 @@ func (d *Database) MigrateSchemaTo(ctx context.Context, target int) error {
 		return xerrors.Errorf("acquiring schema lock: %w", err)
 	}
 
+	// CREATE EXTENSION cannot run inside a transaction (as part of
+	// migration), so we run it explicitally here. (#179).
+	if _, err := d.DB.Exec(`CREATE EXTENSION IF NOT EXISTS timescaledb WITH SCHEMA public`); err != nil {
+		return xerrors.Errorf("creating timescaledb extension: %w", err)
+	}
+
 	// Remember to release the lock
 	defer func() {
 		err := SchemaLock.UnlockExclusive(ctx, db)

--- a/storage/migrations/1_chainwatch.go
+++ b/storage/migrations/1_chainwatch.go
@@ -10,12 +10,6 @@ func init() {
 
 	up := batch(`
 --
--- Name: timescaledb; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS timescaledb WITH SCHEMA public;
-
---
 -- Name: miner_sector_event_type; Type: TYPE; Schema: public; Owner: postgres
 --
 


### PR DESCRIPTION
Instead, run this statement before obtaining the global lock for migrations.

Fixes #179 .