### PR TITLE
fix: don't update go modules when running make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ build/.update-modules:
 
 .PHONY: deps
 deps: build/.update-modules
-	go get -u github.com/git-chglog/git-chglog/cmd/git-chglog
 
 # test starts dependencies and runs all tests
 .PHONY: test
@@ -85,4 +84,4 @@ dist-clean:
 
 .PHONY: changelog
 changelog:
-	git-chglog -o CHANGELOG.md
+	go run github.com/git-chglog/git-chglog/cmd/git-chglog -o CHANGELOG.md


### PR DESCRIPTION
I'd like to avoid fetching `git-chnglg` when I run make (also the `-u` in the `go get` was cauing go modules to be updated on calls to `make`). Instead `make changelog` runs the binary using:
```
go run go run github.com/git-chglog/git-chglog/cmd/git-chglog ...
```