### PR TITLE
feat: allow application name to be passed in postgres connection url

### DIFF
--- a/storage/sql.go
+++ b/storage/sql.go
@@ -93,7 +93,9 @@ func NewDatabase(ctx context.Context, url string, poolSize int) (*Database, erro
 		return nil, xerrors.Errorf("parse database URL: %w", err)
 	}
 	opt.PoolSize = poolSize
-	opt.ApplicationName = "visor-" + version.String()
+	if opt.ApplicationName == "" {
+		opt.ApplicationName = "visor-" + version.String()
+	}
 
 	return &Database{
 		opt:   opt,


### PR DESCRIPTION
This change sets the application name to the current version only if a name has not already been specified. This allows us to assign names to instances by including `application_name=foo` as part of the the postgres connection url, e.g. `postgres://user:password@server/database?application_name=headindexer'

The application name is shown in the `pg_stat_activity` table.
