### PR TITLE
Reorder migrations after merging latest master

### DIFF
--- a/storage/migrations/18_msig_transactions.go
+++ b/storage/migrations/18_msig_transactions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/go-pg/migrations/v8"
 )
 
-// Schema version 17 adds multisig transactions
+// Schema version 18 adds multisig transactions
 
 func init() {
 	up := batch(`

--- a/storage/migrations/19_remove_unused_tables.go
+++ b/storage/migrations/19_remove_unused_tables.go
@@ -8,6 +8,34 @@ import (
 
 func init() {
 	up := batch(`
+DROP VIEW IF EXISTS chain_visualizer_chain_data_view;
+CREATE VIEW chain_visualizer_chain_data_view AS
+	SELECT
+		main_block.cid AS block,
+		bp.parent AS parent,
+		main_block.miner,
+		main_block.height,
+		main_block.parent_weight AS parentweight,
+		main_block.timestamp,
+		main_block.parent_state_root AS parentstateroot,
+		parent_block.timestamp AS parenttimestamp,
+		parent_block.height AS parentheight,
+		-- was miner_power.raw_bytes_power (plural bytes)
+		pac.raw_byte_power AS parentpower,
+		-- was blocks_synced.synced_at
+		main_block.timestamp AS syncedtimestamp,
+		(SELECT COUNT(*) FROM block_messages WHERE block_messages.block = main_block.cid) AS messages
+	FROM
+		block_headers main_block
+	LEFT JOIN
+		block_parents bp ON bp.block = main_block.cid
+	LEFT JOIN
+		block_headers parent_block ON parent_block.cid = bp.parent
+	LEFT JOIN
+		-- was miner_power (singular)
+		power_actor_claims pac ON main_block.parent_state_root = pac.state_root
+;
+
 	DROP MATERIALIZED VIEW IF EXISTS public.top_miners_by_base_reward; 				-- artifact from chainwatch
 	DROP MATERIALIZED VIEW IF EXISTS public.top_miners_by_base_reward_max_height;	-- artifact from chainwatch
 

--- a/storage/migrations/19_remove_unused_tables.go
+++ b/storage/migrations/19_remove_unused_tables.go
@@ -8,7 +8,6 @@ import (
 
 func init() {
 	up := batch(`
-	DROP MATERIALIZED VIEW IF EXISTS public.chain_visualizer_chain_data_view; 		-- artifact from chainwatch
 	DROP MATERIALIZED VIEW IF EXISTS public.top_miners_by_base_reward; 				-- artifact from chainwatch
 	DROP MATERIALIZED VIEW IF EXISTS public.top_miners_by_base_reward_max_height;	-- artifact from chainwatch
 

--- a/storage/migrations/19_remove_unused_tables.go
+++ b/storage/migrations/19_remove_unused_tables.go
@@ -4,7 +4,7 @@ import (
 	"github.com/go-pg/migrations/v8"
 )
 
-// Schema version 18 drops unused tables.
+// Schema version 19 drops unused tables.
 
 func init() {
 	up := batch(`


### PR DESCRIPTION
Just want to be explicit about the changes I'm making to make latest hotfix migrations agree with what is already deployed to `master`.

NOTE: This will FBUAR anyone's visor database who has already migrated up to v17.