### PR TITLE
feat: add repo-read-only flag to enable read or write on lotus repo

### DIFF
--- a/lens/lotusrepo/repo.go
+++ b/lens/lotusrepo/repo.go
@@ -56,7 +56,12 @@ func NewAPIOpener(c *cli.Context) (*APIOpener, lens.APICloser, error) {
 		return nil, nil, fmt.Errorf("lotus repo doesn't exist")
 	}
 
-	lr, err := r.LockRO(repo.FullNode)
+	var lr repo.LockedRepo
+	if c.Bool("repo-read-only") {
+		lr, err = r.LockRO(repo.FullNode)
+	} else {
+		lr, err = r.Lock(repo.FullNode)
+	}
 	if err != nil {
 		return nil, nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,12 @@ func main() {
 				EnvVars: []string{"LOTUS_PATH"},
 				Value:   "~/.lotus", // TODO: Consider XDG_DATA_HOME
 			},
+			&cli.BoolFlag{
+				Name:    "repo-read-only",
+				EnvVars: []string{"VISOR_REPO_READ_ONLY"},
+				Value:   true,
+				Usage:   "Open the repo in read only mode",
+			},
 			&cli.StringFlag{
 				Name:    "api",
 				EnvVars: []string{"FULLNODE_API_INFO"},


### PR DESCRIPTION
Extracted from iand/beefy

Sometimes we need to open the lotus repo as writeable when using the lotusrepo lens. This adds a new `repo-read-only` flag that defaults to true. Set to false to open a writeable repo.