### PR TITLE
feat: functions to convert unix epoch to fil epoch

### DIFF
--- a/storage/migrations/19_height_functions.go
+++ b/storage/migrations/19_height_functions.go
@@ -8,13 +8,13 @@ import (
 
 func init() {
 	up := batch(`
-CREATE OR REPLACE FUNCTION public.unix_to_height(unix_epoch bigint) RETURNS bigint AS $$
-	SELECT ((unix_epoch - 1598306400) / 30)::bigint;
-$$ LANGUAGE SQL;
+	CREATE OR REPLACE FUNCTION public.unix_to_height(unix_epoch bigint) RETURNS bigint AS $$
+		SELECT ((unix_epoch - 1598306400) / 30)::bigint;
+	$$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION public.height_to_unix(fil_epoch bigint) RETURNS bigint AS $$
-	SELECT ((fil_epoch * 30) + 1598306400)::bigint;
-$$ LANGUAGE SQL;
+	CREATE OR REPLACE FUNCTION public.height_to_unix(fil_epoch bigint) RETURNS bigint AS $$
+		SELECT ((fil_epoch * 30) + 1598306400)::bigint;
+	$$ LANGUAGE SQL;
 `)
 
 	down := batch(`

--- a/storage/migrations/19_height_functions.go
+++ b/storage/migrations/19_height_functions.go
@@ -1,0 +1,25 @@
+package migrations
+
+import (
+	"github.com/go-pg/migrations/v8"
+)
+
+// Schema version 19 adds helper functions to convert from unix epoch to fil epoch
+
+func init() {
+	up := batch(`
+CREATE OR REPLACE FUNCTION public.unix_to_height(unix_epoch bigint) RETURNS bigint AS $$
+	SELECT ((unix_epoch - 1598306400) / 30)::bigint;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION public.height_to_unix(fil_epoch bigint) RETURNS bigint AS $$
+	SELECT ((fil_epoch * 30) + 1598306400)::bigint;
+$$ LANGUAGE SQL;
+`)
+
+	down := batch(`
+	DROP FUNCTION IF EXISTS public.actor_tips;
+`)
+
+	migrations.MustRegisterTx(up, down)
+}

--- a/storage/migrations/19_height_functions.go
+++ b/storage/migrations/19_height_functions.go
@@ -18,7 +18,8 @@ $$ LANGUAGE SQL;
 `)
 
 	down := batch(`
-	DROP FUNCTION IF EXISTS public.actor_tips;
+	DROP FUNCTION IF EXISTS public.unix_to_height;
+	DROP FUNCTION IF EXISTS public.height_to_unix;
 `)
 
 	migrations.MustRegisterTx(up, down)

--- a/storage/migrations/21_height_functions.go
+++ b/storage/migrations/21_height_functions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/go-pg/migrations/v8"
 )
 
-// Schema version 19 adds helper functions to convert from unix epoch to fil epoch
+// Schema version 21 adds helper functions to convert from unix epoch to fil epoch
 
 func init() {
 	up := batch(`


### PR DESCRIPTION
adds `unix_to_height` and `height_and_unix` to translate a unix epoch in seconds to a fil epoch. Makes searching the messages tables more fun.

This is mainnet specific, so this may not be the right approach. I'd need to be able to programmatically set the initial unix epoch time to suport other networks.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>