### PR TITLE
fix: include height with chain power results

### DIFF
--- a/tasks/actorstate/power.go
+++ b/tasks/actorstate/power.go
@@ -122,6 +122,7 @@ func ExtractChainPower(ec *PowerStateExtractionContext) (*powermodel.ChainPower,
 	}
 
 	return &powermodel.ChainPower{
+		Height:                     int64(ec.CurrTs.Height()),
 		StateRoot:                  ec.CurrTs.ParentState().String(),
 		TotalRawBytesPower:         pow.RawBytePower.String(),
 		TotalQABytesPower:          pow.QualityAdjPower.String(),


### PR DESCRIPTION
Extractions were working but stored with height 0

Closes #224 