### PR TITLE
polish(mockapi): accepts testing.TB and produces less errors

### DIFF
--- a/tasks/actorstate/init_test.go
+++ b/tasks/actorstate/init_test.go
@@ -22,10 +22,9 @@ import (
 func TestInitExtractorV0(t *testing.T) {
 	ctx := context.Background()
 
-	mapi := NewMockAPI()
+	mapi := NewMockAPI(t)
 
-	state, err := mapi.newEmptyInitStateV0()
-	require.NoError(t, err)
+	state := mapi.newEmptyInitStateV0()
 	minerAddr := tutils.NewIDAddr(t, 1234)
 
 	t.Run("genesis init state extraction", func(t *testing.T) {
@@ -135,10 +134,9 @@ func TestInitExtractorV0(t *testing.T) {
 func TestInitExtractorV2(t *testing.T) {
 	ctx := context.Background()
 
-	mapi := NewMockAPI()
+	mapi := NewMockAPI(t)
 
-	state, err := mapi.newEmptyInitStateV2()
-	require.NoError(t, err)
+	state := mapi.newEmptyInitStateV2()
 	minerAddr := tutils.NewIDAddr(t, 1234)
 
 	t.Run("genesis init state extraction", func(t *testing.T) {

--- a/tasks/actorstate/init_test.go
+++ b/tasks/actorstate/init_test.go
@@ -45,10 +45,8 @@ func TestInitExtractorV0(t *testing.T) {
 		// persist state
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		stateTs, err := mockTipset(minerAddr, 1, WithHeight(0)) // genesis
-		require.NoError(t, err)
+		stateTs := mapi.mockTipset(minerAddr, 1, WithHeight(0)) // genesis
 		mapi.setActor(stateTs.Key(), init_.Address, &types.Actor{Code: sa0builtin.InitActorCodeID, Head: stateCid})
-		mapi.putTipSet(stateTs)
 
 		info := actorstate.ActorInfo{
 			Epoch:           0, // genesis
@@ -81,10 +79,8 @@ func TestInitExtractorV0(t *testing.T) {
 		// persist base state.
 		baseStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		baseTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		baseTs := mapi.mockTipset(minerAddr, 1)
 		mapi.setActor(baseTs.Key(), init_.Address, &types.Actor{Code: sa0builtin.InitActorCodeID, Head: baseStateCid})
-		mapi.putTipSet(baseTs)
 
 		// setup following state.
 		// add a new address.
@@ -101,10 +97,8 @@ func TestInitExtractorV0(t *testing.T) {
 		// persist new state.
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		stateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		stateTs := mapi.mockTipset(minerAddr, 1)
 		mapi.setActor(stateTs.Key(), init_.Address, &types.Actor{Code: sa0builtin.InitActorCodeID, Head: stateCid})
-		mapi.putTipSet(stateTs)
 
 		info := actorstate.ActorInfo{
 			Epoch:           1,
@@ -157,10 +151,8 @@ func TestInitExtractorV2(t *testing.T) {
 		// persist state
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		stateTs, err := mockTipset(minerAddr, 1, WithHeight(0)) // genesis
-		require.NoError(t, err)
+		stateTs := mapi.mockTipset(minerAddr, 1, WithHeight(0)) // genesis
 		mapi.setActor(stateTs.Key(), init_.Address, &types.Actor{Code: sa2builtin.InitActorCodeID, Head: stateCid})
-		mapi.putTipSet(stateTs)
 
 		info := actorstate.ActorInfo{
 			Epoch:           0, // genesis
@@ -193,10 +185,8 @@ func TestInitExtractorV2(t *testing.T) {
 		// persist base state.
 		baseStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		baseTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		baseTs := mapi.mockTipset(minerAddr, 1)
 		mapi.setActor(baseTs.Key(), init_.Address, &types.Actor{Code: sa2builtin.InitActorCodeID, Head: baseStateCid})
-		mapi.putTipSet(baseTs)
 
 		// setup following state.
 		// add a new address.
@@ -213,10 +203,8 @@ func TestInitExtractorV2(t *testing.T) {
 		// persist new state.
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		stateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		stateTs := mapi.mockTipset(minerAddr, 1)
 		mapi.setActor(stateTs.Key(), init_.Address, &types.Actor{Code: sa2builtin.InitActorCodeID, Head: stateCid})
-		mapi.putTipSet(stateTs)
 
 		info := actorstate.ActorInfo{
 			Epoch:           1,

--- a/tasks/actorstate/init_test.go
+++ b/tasks/actorstate/init_test.go
@@ -24,7 +24,7 @@ func TestInitExtractorV0(t *testing.T) {
 
 	mapi := NewMockAPI(t)
 
-	state := mapi.newEmptyInitStateV0()
+	state := mapi.mustCreateEmptyInitStateV0()
 	minerAddr := tutils.NewIDAddr(t, 1234)
 
 	t.Run("genesis init state extraction", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestInitExtractorV0(t *testing.T) {
 		// persist state
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		stateTs := mapi.mockTipset(minerAddr, 1, WithHeight(0)) // genesis
+		stateTs := mapi.fakeTipset(minerAddr, 1, WithHeight(0)) // genesis
 		mapi.setActor(stateTs.Key(), init_.Address, &types.Actor{Code: sa0builtin.InitActorCodeID, Head: stateCid})
 
 		info := actorstate.ActorInfo{
@@ -79,7 +79,7 @@ func TestInitExtractorV0(t *testing.T) {
 		// persist base state.
 		baseStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		baseTs := mapi.mockTipset(minerAddr, 1)
+		baseTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(baseTs.Key(), init_.Address, &types.Actor{Code: sa0builtin.InitActorCodeID, Head: baseStateCid})
 
 		// setup following state.
@@ -97,7 +97,7 @@ func TestInitExtractorV0(t *testing.T) {
 		// persist new state.
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		stateTs := mapi.mockTipset(minerAddr, 1)
+		stateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(stateTs.Key(), init_.Address, &types.Actor{Code: sa0builtin.InitActorCodeID, Head: stateCid})
 
 		info := actorstate.ActorInfo{
@@ -130,7 +130,7 @@ func TestInitExtractorV2(t *testing.T) {
 
 	mapi := NewMockAPI(t)
 
-	state := mapi.newEmptyInitStateV2()
+	state := mapi.mustCreateEmptyInitStateV2()
 	minerAddr := tutils.NewIDAddr(t, 1234)
 
 	t.Run("genesis init state extraction", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestInitExtractorV2(t *testing.T) {
 		// persist state
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		stateTs := mapi.mockTipset(minerAddr, 1, WithHeight(0)) // genesis
+		stateTs := mapi.fakeTipset(minerAddr, 1, WithHeight(0)) // genesis
 		mapi.setActor(stateTs.Key(), init_.Address, &types.Actor{Code: sa2builtin.InitActorCodeID, Head: stateCid})
 
 		info := actorstate.ActorInfo{
@@ -185,7 +185,7 @@ func TestInitExtractorV2(t *testing.T) {
 		// persist base state.
 		baseStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		baseTs := mapi.mockTipset(minerAddr, 1)
+		baseTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(baseTs.Key(), init_.Address, &types.Actor{Code: sa2builtin.InitActorCodeID, Head: baseStateCid})
 
 		// setup following state.
@@ -203,7 +203,7 @@ func TestInitExtractorV2(t *testing.T) {
 		// persist new state.
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
-		stateTs := mapi.mockTipset(minerAddr, 1)
+		stateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(stateTs.Key(), init_.Address, &types.Actor{Code: sa2builtin.InitActorCodeID, Head: stateCid})
 
 		info := actorstate.ActorInfo{

--- a/tasks/actorstate/market_test.go
+++ b/tasks/actorstate/market_test.go
@@ -29,7 +29,7 @@ type balance struct {
 func TestMarketPredicates(t *testing.T) {
 	ctx := context.Background()
 
-	mapi := NewMockAPI()
+	mapi := NewMockAPI(t)
 
 	oldDeal1 := &samarket.DealState{
 		SectorStartEpoch: 1,
@@ -82,8 +82,7 @@ func TestMarketPredicates(t *testing.T) {
 		tutils.NewIDAddr(t, 5): {abi.NewTokenAmount(3000), abi.NewTokenAmount(1000)},
 	}
 
-	oldStateCid, err := mapi.createMarketState(ctx, oldDeals, oldProps, oldBalances)
-	require.NoError(t, err)
+	oldStateCid := mapi.createMarketState(ctx, oldDeals, oldProps, oldBalances)
 
 	newDeal1 := &samarket.DealState{
 		SectorStartEpoch: 1,
@@ -130,8 +129,7 @@ func TestMarketPredicates(t *testing.T) {
 		tutils.NewIDAddr(t, 5): {abi.NewTokenAmount(1000), abi.NewTokenAmount(3000)},
 	}
 
-	newStateCid, err := mapi.createMarketState(ctx, newDeals, newProps, newBalances)
-	require.NoError(t, err)
+	newStateCid := mapi.createMarketState(ctx, newDeals, newProps, newBalances)
 
 	minerAddr, err := address.NewFromString("t00")
 	require.NoError(t, err)

--- a/tasks/actorstate/market_test.go
+++ b/tasks/actorstate/market_test.go
@@ -82,7 +82,7 @@ func TestMarketPredicates(t *testing.T) {
 		tutils.NewIDAddr(t, 5): {abi.NewTokenAmount(3000), abi.NewTokenAmount(1000)},
 	}
 
-	oldStateCid := mapi.createMarketState(ctx, oldDeals, oldProps, oldBalances)
+	oldStateCid := mapi.mustCreateMarketState(ctx, oldDeals, oldProps, oldBalances)
 
 	newDeal1 := &samarket.DealState{
 		SectorStartEpoch: 1,
@@ -129,13 +129,13 @@ func TestMarketPredicates(t *testing.T) {
 		tutils.NewIDAddr(t, 5): {abi.NewTokenAmount(1000), abi.NewTokenAmount(3000)},
 	}
 
-	newStateCid := mapi.createMarketState(ctx, newDeals, newProps, newBalances)
+	newStateCid := mapi.mustCreateMarketState(ctx, newDeals, newProps, newBalances)
 
 	minerAddr := tutils.NewIDAddr(t, 00)
 
-	oldStateTs := mapi.mockTipset(minerAddr, 1)
+	oldStateTs := mapi.fakeTipset(minerAddr, 1)
 	mapi.setActor(oldStateTs.Key(), market.Address, &types.Actor{Code: sabuiltin.StorageMarketActorCodeID, Head: oldStateCid})
-	newStateTs := mapi.mockTipset(minerAddr, 2)
+	newStateTs := mapi.fakeTipset(minerAddr, 2)
 	mapi.setActor(newStateTs.Key(), market.Address, &types.Actor{Code: sabuiltin.StorageMarketActorCodeID, Head: newStateCid})
 
 	info := actorstate.ActorInfo{

--- a/tasks/actorstate/market_test.go
+++ b/tasks/actorstate/market_test.go
@@ -131,14 +131,11 @@ func TestMarketPredicates(t *testing.T) {
 
 	newStateCid := mapi.createMarketState(ctx, newDeals, newProps, newBalances)
 
-	minerAddr, err := address.NewFromString("t00")
-	require.NoError(t, err)
-	oldStateTs, err := mockTipset(minerAddr, 1)
-	require.NoError(t, err)
-	newStateTs, err := mockTipset(minerAddr, 2)
-	require.NoError(t, err)
+	minerAddr := tutils.NewIDAddr(t, 00)
 
+	oldStateTs := mapi.mockTipset(minerAddr, 1)
 	mapi.setActor(oldStateTs.Key(), market.Address, &types.Actor{Code: sabuiltin.StorageMarketActorCodeID, Head: oldStateCid})
+	newStateTs := mapi.mockTipset(minerAddr, 2)
 	mapi.setActor(newStateTs.Key(), market.Address, &types.Actor{Code: sabuiltin.StorageMarketActorCodeID, Head: newStateCid})
 
 	info := actorstate.ActorInfo{

--- a/tasks/actorstate/multisig_test.go
+++ b/tasks/actorstate/multisig_test.go
@@ -49,11 +49,8 @@ func TestMultisigExtractorV0(t *testing.T) {
 		emptyTxStateCid, err := mapi.Store().Put(ctx, emptyTxState)
 		require.NoError(t, err)
 
-		emptyTxStateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
-
+		emptyTxStateTs := mapi.mockTipset(minerAddr, 1)
 		mapi.setActor(emptyTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: emptyTxStateCid})
-		mapi.putTipSet(emptyTxStateTs)
 
 		//
 		// add a transaction in subsequent state.
@@ -78,11 +75,8 @@ func TestMultisigExtractorV0(t *testing.T) {
 		txStateCid, err := mapi.Store().Put(ctx, &newTxState)
 		require.NoError(t, err)
 
-		txStateTs, err := mockTipset(minerAddr, 2)
-		require.NoError(t, err)
-
+		txStateTs := mapi.mockTipset(minerAddr, 2)
 		mapi.setActor(txStateTs.Key(), multiSigAddress, &types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: txStateCid})
-		mapi.putTipSet(txStateTs)
 
 		//
 		// create actor info, previous state has no transaction, current state has a single transaction
@@ -134,10 +128,9 @@ func TestMultisigExtractorV0(t *testing.T) {
 		// update global state
 		singleTxStateCid, err := mapi.Store().Put(ctx, &singleTxState)
 		require.NoError(t, err)
-		singleTxStateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+
+		singleTxStateTs := mapi.mockTipset(minerAddr, 1)
 		mapi.setActor(singleTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: singleTxStateCid})
-		mapi.putTipSet(singleTxStateTs)
 
 		// create second tx
 		txMap, err = adt0.AsMap(mapi.store, singleTxState.PendingTxns)
@@ -168,10 +161,8 @@ func TestMultisigExtractorV0(t *testing.T) {
 		// update global state
 		secondTxStateCid, err := mapi.Store().Put(ctx, &secondTxState)
 		require.NoError(t, err)
-		secondTxStateTs, err := mockTipset(minerAddr, 2)
-		require.NoError(t, err)
+		secondTxStateTs := mapi.mockTipset(minerAddr, 2)
 		mapi.setActor(secondTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: secondTxStateCid})
-		mapi.putTipSet(secondTxStateTs)
 
 		//
 		// create actor info, previous state has single tx, current state has a new tx and modified tx.
@@ -232,10 +223,8 @@ func TestMultisigExtractorV0(t *testing.T) {
 		// update global state
 		singleTxStateCid, err := mapi.Store().Put(ctx, &singleTxState)
 		require.NoError(t, err)
-		genesisTs, err := mockTipset(minerAddr, 1, WithHeight(0))
-		require.NoError(t, err)
+		genesisTs := mapi.mockTipset(minerAddr, 1, WithHeight(0))
 		mapi.setActor(genesisTs.Key(), multiSigAddress, &types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: singleTxStateCid})
-		mapi.putTipSet(genesisTs)
 
 		info := actorstate.ActorInfo{
 			Actor:   types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: singleTxStateCid},
@@ -288,11 +277,8 @@ func TestMultisigExtractorV2(t *testing.T) {
 		emptyTxStateCid, err := mapi.Store().Put(ctx, emptyTxState)
 		require.NoError(t, err)
 
-		emptyTxStateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
-
+		emptyTxStateTs := mapi.mockTipset(minerAddr, 1)
 		mapi.setActor(emptyTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: emptyTxStateCid})
-		mapi.putTipSet(emptyTxStateTs)
 
 		//
 		// add a transaction in subsequent state.
@@ -317,11 +303,8 @@ func TestMultisigExtractorV2(t *testing.T) {
 		txStateCid, err := mapi.Store().Put(ctx, &newTxState)
 		require.NoError(t, err)
 
-		txStateTs, err := mockTipset(minerAddr, 2)
-		require.NoError(t, err)
-
+		txStateTs := mapi.mockTipset(minerAddr, 2)
 		mapi.setActor(txStateTs.Key(), multiSigAddress, &types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: txStateCid})
-		mapi.putTipSet(txStateTs)
 
 		//
 		// create actor info, previous state has no transaction, current state has a single transaction
@@ -373,10 +356,8 @@ func TestMultisigExtractorV2(t *testing.T) {
 		// update global state
 		singleTxStateCid, err := mapi.Store().Put(ctx, &singleTxState)
 		require.NoError(t, err)
-		singleTxStateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		singleTxStateTs := mapi.mockTipset(minerAddr, 1)
 		mapi.setActor(singleTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: singleTxStateCid})
-		mapi.putTipSet(singleTxStateTs)
 
 		// create second tx
 		txMap, err = adt2.AsMap(mapi.store, singleTxState.PendingTxns)
@@ -407,10 +388,9 @@ func TestMultisigExtractorV2(t *testing.T) {
 		// update global state
 		secondTxStateCid, err := mapi.Store().Put(ctx, &secondTxState)
 		require.NoError(t, err)
-		secondTxStateTs, err := mockTipset(minerAddr, 2)
-		require.NoError(t, err)
+
+		secondTxStateTs := mapi.mockTipset(minerAddr, 2)
 		mapi.setActor(secondTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: secondTxStateCid})
-		mapi.putTipSet(secondTxStateTs)
 
 		//
 		// create actor info, previous state has single tx, current state has a new tx and modified tx.
@@ -471,10 +451,8 @@ func TestMultisigExtractorV2(t *testing.T) {
 		// update global state
 		singleTxStateCid, err := mapi.Store().Put(ctx, &singleTxState)
 		require.NoError(t, err)
-		genesisTs, err := mockTipset(minerAddr, 1, WithHeight(0))
-		require.NoError(t, err)
+		genesisTs := mapi.mockTipset(minerAddr, 1, WithHeight(0))
 		mapi.setActor(genesisTs.Key(), multiSigAddress, &types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: singleTxStateCid})
-		mapi.putTipSet(genesisTs)
 
 		info := actorstate.ActorInfo{
 			Actor:   types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: singleTxStateCid},

--- a/tasks/actorstate/multisig_test.go
+++ b/tasks/actorstate/multisig_test.go
@@ -27,7 +27,7 @@ import (
 func TestMultisigExtractorV0(t *testing.T) {
 	ctx := context.Background()
 
-	mapi := NewMockAPI()
+	mapi := NewMockAPI(t)
 	minerAddr := tutils.NewIDAddr(t, 1234)
 
 	emptyPending, err := adt0.MakeEmptyMap(mapi.store).Root()
@@ -266,7 +266,7 @@ func TestMultisigExtractorV0(t *testing.T) {
 func TestMultisigExtractorV2(t *testing.T) {
 	ctx := context.Background()
 
-	mapi := NewMockAPI()
+	mapi := NewMockAPI(t)
 	minerAddr := tutils.NewIDAddr(t, 1234)
 
 	emptyPending, err := adt2.MakeEmptyMap(mapi.store).Root()

--- a/tasks/actorstate/multisig_test.go
+++ b/tasks/actorstate/multisig_test.go
@@ -49,7 +49,7 @@ func TestMultisigExtractorV0(t *testing.T) {
 		emptyTxStateCid, err := mapi.Store().Put(ctx, emptyTxState)
 		require.NoError(t, err)
 
-		emptyTxStateTs := mapi.mockTipset(minerAddr, 1)
+		emptyTxStateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(emptyTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: emptyTxStateCid})
 
 		//
@@ -75,7 +75,7 @@ func TestMultisigExtractorV0(t *testing.T) {
 		txStateCid, err := mapi.Store().Put(ctx, &newTxState)
 		require.NoError(t, err)
 
-		txStateTs := mapi.mockTipset(minerAddr, 2)
+		txStateTs := mapi.fakeTipset(minerAddr, 2)
 		mapi.setActor(txStateTs.Key(), multiSigAddress, &types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: txStateCid})
 
 		//
@@ -129,7 +129,7 @@ func TestMultisigExtractorV0(t *testing.T) {
 		singleTxStateCid, err := mapi.Store().Put(ctx, &singleTxState)
 		require.NoError(t, err)
 
-		singleTxStateTs := mapi.mockTipset(minerAddr, 1)
+		singleTxStateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(singleTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: singleTxStateCid})
 
 		// create second tx
@@ -161,7 +161,7 @@ func TestMultisigExtractorV0(t *testing.T) {
 		// update global state
 		secondTxStateCid, err := mapi.Store().Put(ctx, &secondTxState)
 		require.NoError(t, err)
-		secondTxStateTs := mapi.mockTipset(minerAddr, 2)
+		secondTxStateTs := mapi.fakeTipset(minerAddr, 2)
 		mapi.setActor(secondTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: secondTxStateCid})
 
 		//
@@ -223,7 +223,7 @@ func TestMultisigExtractorV0(t *testing.T) {
 		// update global state
 		singleTxStateCid, err := mapi.Store().Put(ctx, &singleTxState)
 		require.NoError(t, err)
-		genesisTs := mapi.mockTipset(minerAddr, 1, WithHeight(0))
+		genesisTs := mapi.fakeTipset(minerAddr, 1, WithHeight(0))
 		mapi.setActor(genesisTs.Key(), multiSigAddress, &types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: singleTxStateCid})
 
 		info := actorstate.ActorInfo{
@@ -277,7 +277,7 @@ func TestMultisigExtractorV2(t *testing.T) {
 		emptyTxStateCid, err := mapi.Store().Put(ctx, emptyTxState)
 		require.NoError(t, err)
 
-		emptyTxStateTs := mapi.mockTipset(minerAddr, 1)
+		emptyTxStateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(emptyTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: emptyTxStateCid})
 
 		//
@@ -303,7 +303,7 @@ func TestMultisigExtractorV2(t *testing.T) {
 		txStateCid, err := mapi.Store().Put(ctx, &newTxState)
 		require.NoError(t, err)
 
-		txStateTs := mapi.mockTipset(minerAddr, 2)
+		txStateTs := mapi.fakeTipset(minerAddr, 2)
 		mapi.setActor(txStateTs.Key(), multiSigAddress, &types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: txStateCid})
 
 		//
@@ -356,7 +356,7 @@ func TestMultisigExtractorV2(t *testing.T) {
 		// update global state
 		singleTxStateCid, err := mapi.Store().Put(ctx, &singleTxState)
 		require.NoError(t, err)
-		singleTxStateTs := mapi.mockTipset(minerAddr, 1)
+		singleTxStateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(singleTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: singleTxStateCid})
 
 		// create second tx
@@ -389,7 +389,7 @@ func TestMultisigExtractorV2(t *testing.T) {
 		secondTxStateCid, err := mapi.Store().Put(ctx, &secondTxState)
 		require.NoError(t, err)
 
-		secondTxStateTs := mapi.mockTipset(minerAddr, 2)
+		secondTxStateTs := mapi.fakeTipset(minerAddr, 2)
 		mapi.setActor(secondTxStateTs.Key(), multiSigAddress, &types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: secondTxStateCid})
 
 		//
@@ -451,7 +451,7 @@ func TestMultisigExtractorV2(t *testing.T) {
 		// update global state
 		singleTxStateCid, err := mapi.Store().Put(ctx, &singleTxState)
 		require.NoError(t, err)
-		genesisTs := mapi.mockTipset(minerAddr, 1, WithHeight(0))
+		genesisTs := mapi.fakeTipset(minerAddr, 1, WithHeight(0))
 		mapi.setActor(genesisTs.Key(), multiSigAddress, &types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: singleTxStateCid})
 
 		info := actorstate.ActorInfo{

--- a/tasks/actorstate/power_test.go
+++ b/tasks/actorstate/power_test.go
@@ -31,7 +31,7 @@ func TestPowerExtractV0(t *testing.T) {
 
 	mapi := NewMockAPI(t)
 
-	state := mapi.newEmptyPowerStateV0()
+	state := mapi.mustCreateEmptyPowerStateV0()
 	minerAddr := tutils.NewIDAddr(t, 1234)
 
 	t.Run("power state model", func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestPowerExtractV0(t *testing.T) {
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		stateTs := mapi.mockTipset(minerAddr, 1)
+		stateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(stateTs.Key(), power.Address, &types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: stateCid})
 
 		info := actorstate.ActorInfo{
@@ -92,7 +92,7 @@ func TestPowerExtractV0(t *testing.T) {
 		oldStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		oldStateTs := mapi.mockTipset(minerAddr, 1)
+		oldStateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(oldStateTs.Key(), power.Address, &types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: oldStateCid})
 
 		err = claimMap.Put(abi.AddrKey(minerAddr), &newClaim)
@@ -104,7 +104,7 @@ func TestPowerExtractV0(t *testing.T) {
 		newStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		newStateTs := mapi.mockTipset(minerAddr, 1)
+		newStateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(newStateTs.Key(), power.Address, &types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: newStateCid})
 
 		info := actorstate.ActorInfo{
@@ -135,7 +135,7 @@ func TestPowerExtractV2(t *testing.T) {
 
 	mapi := NewMockAPI(t)
 
-	state := mapi.newEmptyPowerStateV2()
+	state := mapi.mustCreateEmptyPowerStateV2()
 	minerAddr := tutils.NewIDAddr(t, 1234)
 
 	t.Run("power state model", func(t *testing.T) {
@@ -154,7 +154,7 @@ func TestPowerExtractV2(t *testing.T) {
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		stateTs := mapi.mockTipset(minerAddr, 1)
+		stateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(stateTs.Key(), power.Address, &types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: stateCid})
 
 		info := actorstate.ActorInfo{
@@ -196,7 +196,7 @@ func TestPowerExtractV2(t *testing.T) {
 		oldStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		oldStateTs := mapi.mockTipset(minerAddr, 1)
+		oldStateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(oldStateTs.Key(), power.Address, &types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: oldStateCid})
 
 		err = claimMap.Put(abi.AddrKey(minerAddr), &newClaim)
@@ -208,7 +208,7 @@ func TestPowerExtractV2(t *testing.T) {
 		newStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		newStateTs := mapi.mockTipset(minerAddr, 1)
+		newStateTs := mapi.fakeTipset(minerAddr, 1)
 		mapi.setActor(newStateTs.Key(), power.Address, &types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: newStateCid})
 
 		info := actorstate.ActorInfo{

--- a/tasks/actorstate/power_test.go
+++ b/tasks/actorstate/power_test.go
@@ -50,8 +50,8 @@ func TestPowerExtractV0(t *testing.T) {
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		stateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		stateTs := mapi.mockTipset(minerAddr, 1)
+		mapi.setActor(stateTs.Key(), power.Address, &types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: stateCid})
 
 		info := actorstate.ActorInfo{
 			Actor:           types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: stateCid},
@@ -59,9 +59,6 @@ func TestPowerExtractV0(t *testing.T) {
 			TipSet:          stateTs.Key(),
 			ParentStateRoot: stateTs.ParentState(),
 		}
-
-		mapi.setActor(stateTs.Key(), power.Address, &types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: stateCid})
-		mapi.putTipSet(stateTs)
 
 		ex := actorstate.StoragePowerExtractor{}
 		res, err := ex.Extract(ctx, info, mapi)
@@ -95,10 +92,8 @@ func TestPowerExtractV0(t *testing.T) {
 		oldStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		oldStateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		oldStateTs := mapi.mockTipset(minerAddr, 1)
 		mapi.setActor(oldStateTs.Key(), power.Address, &types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: oldStateCid})
-		mapi.putTipSet(oldStateTs)
 
 		err = claimMap.Put(abi.AddrKey(minerAddr), &newClaim)
 		require.NoError(t, err)
@@ -109,8 +104,8 @@ func TestPowerExtractV0(t *testing.T) {
 		newStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		newStateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		newStateTs := mapi.mockTipset(minerAddr, 1)
+		mapi.setActor(newStateTs.Key(), power.Address, &types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: newStateCid})
 
 		info := actorstate.ActorInfo{
 			Epoch:           1,
@@ -120,9 +115,6 @@ func TestPowerExtractV0(t *testing.T) {
 			TipSet:          newStateTs.Key(),
 			ParentStateRoot: newStateTs.ParentState(),
 		}
-
-		mapi.setActor(newStateTs.Key(), power.Address, &types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: newStateCid})
-		mapi.putTipSet(newStateTs)
 
 		ex := actorstate.StoragePowerExtractor{}
 		res, err := ex.Extract(ctx, info, mapi)
@@ -162,8 +154,8 @@ func TestPowerExtractV2(t *testing.T) {
 		stateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		stateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		stateTs := mapi.mockTipset(minerAddr, 1)
+		mapi.setActor(stateTs.Key(), power.Address, &types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: stateCid})
 
 		info := actorstate.ActorInfo{
 			Actor:           types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: stateCid},
@@ -171,9 +163,6 @@ func TestPowerExtractV2(t *testing.T) {
 			TipSet:          stateTs.Key(),
 			ParentStateRoot: stateTs.ParentState(),
 		}
-
-		mapi.setActor(stateTs.Key(), power.Address, &types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: stateCid})
-		mapi.putTipSet(stateTs)
 
 		ex := actorstate.StoragePowerExtractor{}
 		res, err := ex.Extract(ctx, info, mapi)
@@ -207,10 +196,8 @@ func TestPowerExtractV2(t *testing.T) {
 		oldStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		oldStateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		oldStateTs := mapi.mockTipset(minerAddr, 1)
 		mapi.setActor(oldStateTs.Key(), power.Address, &types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: oldStateCid})
-		mapi.putTipSet(oldStateTs)
 
 		err = claimMap.Put(abi.AddrKey(minerAddr), &newClaim)
 		require.NoError(t, err)
@@ -221,8 +208,8 @@ func TestPowerExtractV2(t *testing.T) {
 		newStateCid, err := mapi.Store().Put(ctx, state)
 		require.NoError(t, err)
 
-		newStateTs, err := mockTipset(minerAddr, 1)
-		require.NoError(t, err)
+		newStateTs := mapi.mockTipset(minerAddr, 1)
+		mapi.setActor(newStateTs.Key(), power.Address, &types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: newStateCid})
 
 		info := actorstate.ActorInfo{
 			Epoch:           1,
@@ -232,9 +219,6 @@ func TestPowerExtractV2(t *testing.T) {
 			TipSet:          newStateTs.Key(),
 			ParentStateRoot: newStateTs.ParentState(),
 		}
-
-		mapi.setActor(newStateTs.Key(), power.Address, &types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: newStateCid})
-		mapi.putTipSet(newStateTs)
 
 		ex := actorstate.StoragePowerExtractor{}
 		res, err := ex.Extract(ctx, info, mapi)

--- a/tasks/actorstate/power_test.go
+++ b/tasks/actorstate/power_test.go
@@ -29,10 +29,9 @@ import (
 func TestPowerExtractV0(t *testing.T) {
 	ctx := context.Background()
 
-	mapi := NewMockAPI()
+	mapi := NewMockAPI(t)
 
-	state, err := mapi.newEmptyPowerStateV0()
-	require.NoError(t, err)
+	state := mapi.newEmptyPowerStateV0()
 	minerAddr := tutils.NewIDAddr(t, 1234)
 
 	t.Run("power state model", func(t *testing.T) {
@@ -142,10 +141,9 @@ func TestPowerExtractV0(t *testing.T) {
 func TestPowerExtractV2(t *testing.T) {
 	ctx := context.Background()
 
-	mapi := NewMockAPI()
+	mapi := NewMockAPI(t)
 
-	state, err := mapi.newEmptyPowerStateV2()
-	require.NoError(t, err)
+	state := mapi.newEmptyPowerStateV2()
 	minerAddr := tutils.NewIDAddr(t, 1234)
 
 	t.Run("power state model", func(t *testing.T) {

--- a/tasks/actorstate/reward_test.go
+++ b/tasks/actorstate/reward_test.go
@@ -24,10 +24,9 @@ import (
 func TestRewardExtractV0(t *testing.T) {
 	ctx := context.Background()
 
-	mapi := NewMockAPI()
+	mapi := NewMockAPI(t)
 
-	state, err := mapi.newEmptyRewardStateV0(abi.NewStoragePower(500))
-	require.NoError(t, err)
+	state := mapi.newEmptyRewardStateV0(abi.NewStoragePower(500))
 
 	state.CumsumBaseline = big.NewInt(1000)
 	state.CumsumRealized = big.NewInt(2000)
@@ -64,8 +63,7 @@ func TestRewardExtractV0(t *testing.T) {
 
 	assert.EqualValues(t, info.ParentStateRoot.String(), cr.StateRoot, "StateRoot")
 	assert.EqualValues(t, state.CumsumBaseline.String(), cr.CumSumBaseline, "CumSumBaseline")
-	// TODO: assertion fails due to bug in lotus see https://github.com/filecoin-project/lotus/pull/4268
-	// assert.EqualValues(t, state.CumsumRealized.String(), cr.CumSumRealized, "CumSumRealized")
+	assert.EqualValues(t, state.CumsumRealized.String(), cr.CumSumRealized, "CumSumRealized")
 	assert.EqualValues(t, state.EffectiveBaselinePower.String(), cr.EffectiveBaselinePower, "EffectiveBaselinePower")
 	assert.EqualValues(t, state.ThisEpochBaselinePower.String(), cr.NewBaselinePower, "NewBaselinePower")
 	assert.EqualValues(t, state.ThisEpochRewardSmoothed.PositionEstimate.String(), cr.NewRewardSmoothedPositionEstimate, "NewRewardSmoothedPositionEstimate")
@@ -78,10 +76,9 @@ func TestRewardExtractV0(t *testing.T) {
 func TestRewardExtractV2(t *testing.T) {
 	ctx := context.Background()
 
-	mapi := NewMockAPI()
+	mapi := NewMockAPI(t)
 
-	state, err := mapi.newEmptyRewardStateV2(abi.NewStoragePower(500))
-	require.NoError(t, err)
+	state := mapi.newEmptyRewardStateV2(abi.NewStoragePower(500))
 
 	state.CumsumBaseline = big.NewInt(1000)
 	state.CumsumRealized = big.NewInt(2000)
@@ -118,8 +115,7 @@ func TestRewardExtractV2(t *testing.T) {
 
 	assert.EqualValues(t, info.ParentStateRoot.String(), cr.StateRoot, "StateRoot")
 	assert.EqualValues(t, state.CumsumBaseline.String(), cr.CumSumBaseline, "CumSumBaseline")
-	// TODO: assertion fails due to bug in lotus see https://github.com/filecoin-project/lotus/pull/4268
-	// assert.EqualValues(t, state.CumsumRealized.String(), cr.CumSumRealized, "CumSumRealized")
+	assert.EqualValues(t, state.CumsumRealized.String(), cr.CumSumRealized, "CumSumRealized")
 	assert.EqualValues(t, state.EffectiveBaselinePower.String(), cr.EffectiveBaselinePower, "EffectiveBaselinePower")
 	assert.EqualValues(t, state.ThisEpochBaselinePower.String(), cr.NewBaselinePower, "NewBaselinePower")
 	assert.EqualValues(t, state.ThisEpochRewardSmoothed.PositionEstimate.String(), cr.NewRewardSmoothedPositionEstimate, "NewRewardSmoothedPositionEstimate")

--- a/tasks/actorstate/reward_test.go
+++ b/tasks/actorstate/reward_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/reward"
 	"github.com/filecoin-project/lotus/chain/types"
+	tutils "github.com/filecoin-project/specs-actors/support/testing"
+
 	rewardmodel "github.com/filecoin-project/sentinel-visor/model/actors/reward"
 	"github.com/filecoin-project/sentinel-visor/tasks/actorstate"
 
@@ -40,18 +41,15 @@ func TestRewardExtractV0(t *testing.T) {
 	stateCid, err := mapi.Store().Put(ctx, state)
 	require.NoError(t, err)
 
-	minerAddr, err := address.NewFromString("t00")
-	require.NoError(t, err)
-	stateTs, err := mockTipset(minerAddr, 1)
-	require.NoError(t, err)
+	minerAddr := tutils.NewIDAddr(t, 00)
+	stateTs := mapi.mockTipset(minerAddr, 1)
+	mapi.setActor(stateTs.Key(), reward.Address, &types.Actor{Code: sa0builtin.RewardActorCodeID, Head: stateCid})
 
 	info := actorstate.ActorInfo{
 		Actor:   types.Actor{Code: sa0builtin.RewardActorCodeID, Head: stateCid},
 		Address: power.Address,
 		TipSet:  stateTs.Key(),
 	}
-
-	mapi.setActor(stateTs.Key(), reward.Address, &types.Actor{Code: sa0builtin.RewardActorCodeID, Head: stateCid})
 
 	ex := actorstate.RewardExtractor{}
 	res, err := ex.Extract(ctx, info, mapi)
@@ -92,18 +90,15 @@ func TestRewardExtractV2(t *testing.T) {
 	stateCid, err := mapi.Store().Put(ctx, state)
 	require.NoError(t, err)
 
-	minerAddr, err := address.NewFromString("t00")
-	require.NoError(t, err)
-	stateTs, err := mockTipset(minerAddr, 1)
-	require.NoError(t, err)
+	minerAddr := tutils.NewIDAddr(t, 123)
+	stateTs := mapi.mockTipset(minerAddr, 1)
+	mapi.setActor(stateTs.Key(), reward.Address, &types.Actor{Code: sa2builtin.RewardActorCodeID, Head: stateCid})
 
 	info := actorstate.ActorInfo{
 		Actor:   types.Actor{Code: sa2builtin.RewardActorCodeID, Head: stateCid},
 		Address: power.Address,
 		TipSet:  stateTs.Key(),
 	}
-
-	mapi.setActor(stateTs.Key(), reward.Address, &types.Actor{Code: sa2builtin.RewardActorCodeID, Head: stateCid})
 
 	ex := actorstate.RewardExtractor{}
 	res, err := ex.Extract(ctx, info, mapi)

--- a/tasks/actorstate/reward_test.go
+++ b/tasks/actorstate/reward_test.go
@@ -27,7 +27,7 @@ func TestRewardExtractV0(t *testing.T) {
 
 	mapi := NewMockAPI(t)
 
-	state := mapi.newEmptyRewardStateV0(abi.NewStoragePower(500))
+	state := mapi.mustCreateEmptyRewardStateV0(abi.NewStoragePower(500))
 
 	state.CumsumBaseline = big.NewInt(1000)
 	state.CumsumRealized = big.NewInt(2000)
@@ -42,7 +42,7 @@ func TestRewardExtractV0(t *testing.T) {
 	require.NoError(t, err)
 
 	minerAddr := tutils.NewIDAddr(t, 00)
-	stateTs := mapi.mockTipset(minerAddr, 1)
+	stateTs := mapi.fakeTipset(minerAddr, 1)
 	mapi.setActor(stateTs.Key(), reward.Address, &types.Actor{Code: sa0builtin.RewardActorCodeID, Head: stateCid})
 
 	info := actorstate.ActorInfo{
@@ -76,7 +76,7 @@ func TestRewardExtractV2(t *testing.T) {
 
 	mapi := NewMockAPI(t)
 
-	state := mapi.newEmptyRewardStateV2(abi.NewStoragePower(500))
+	state := mapi.mustCreateEmptyRewardStateV2(abi.NewStoragePower(500))
 
 	state.CumsumBaseline = big.NewInt(1000)
 	state.CumsumRealized = big.NewInt(2000)
@@ -91,7 +91,7 @@ func TestRewardExtractV2(t *testing.T) {
 	require.NoError(t, err)
 
 	minerAddr := tutils.NewIDAddr(t, 123)
-	stateTs := mapi.mockTipset(minerAddr, 1)
+	stateTs := mapi.fakeTipset(minerAddr, 1)
 	mapi.setActor(stateTs.Key(), reward.Address, &types.Actor{Code: sa2builtin.RewardActorCodeID, Head: stateCid})
 
 	info := actorstate.ActorInfo{


### PR DESCRIPTION
- remove returned errors from mock api helper methods
- condense tipset creation and storeage of tipset in mock api
- rename methods to reflect their action -- `must` will do the thing or fail the test.