### PR TITLE
Export some helpers and add some types

### DIFF
--- a/commands/debug.go
+++ b/commands/debug.go
@@ -34,13 +34,13 @@ var Debug = &cli.Command{
 			return xerrors.Errorf("setup storage and api: %w", err)
 		}
 		defer func() {
-			rctx.closer()
-			if err := rctx.db.Close(ctx); err != nil {
+			rctx.Closer()
+			if err := rctx.DB.Close(ctx); err != nil {
 				log.Errorw("close database", "error", err)
 			}
 		}()
 
-		p, err := actorstate.NewActorStateProcessor(rctx.db, rctx.opener, 0, 0, 0, 0, actorstate.SupportedActorCodes(), false)
+		p, err := actorstate.NewActorStateProcessor(rctx.DB, rctx.Opener, 0, 0, 0, 0, actorstate.SupportedActorCodes(), false)
 		if err != nil {
 			return err
 		}

--- a/commands/debug.go
+++ b/commands/debug.go
@@ -29,7 +29,7 @@ var Debug = &cli.Command{
 		}
 		defer tcloser()
 
-		ctx, rctx, err := setupStorageAndAPI(cctx)
+		ctx, rctx, err := SetupStorageAndAPI(cctx)
 		if err != nil {
 			return xerrors.Errorf("setup storage and api: %w", err)
 		}

--- a/commands/run.go
+++ b/commands/run.go
@@ -250,7 +250,7 @@ var Run = &cli.Command{
 		}
 		defer tcloser()
 
-		ctx, rctx, err := setupStorageAndAPI(cctx)
+		ctx, rctx, err := SetupStorageAndAPI(cctx)
 		if err != nil {
 			return xerrors.Errorf("setup storage and api: %w", err)
 		}

--- a/commands/setup.go
+++ b/commands/setup.go
@@ -34,10 +34,11 @@ import (
 
 var log = logging.Logger("visor")
 
+// RunContext wraps lens and DB connections.
 type RunContext struct {
-	opener lens.APIOpener
-	closer lens.APICloser
-	db     *storage.Database
+	Opener lens.APIOpener
+	Closer lens.APICloser
+	DB     *storage.Database
 }
 
 // SetupStorageAndAPI setups of the sentinel database and returns a
@@ -98,9 +99,9 @@ func SetupStorageAndAPI(cctx *cli.Context) (context.Context, *RunContext, error)
 	}
 
 	return ctx, &RunContext{
-		opener: opener,
-		closer: closer,
-		db:     db,
+		Opener: opener,
+		Closer: closer,
+		DB:     db,
 	}, nil
 }
 

--- a/commands/setup.go
+++ b/commands/setup.go
@@ -40,7 +40,9 @@ type RunContext struct {
 	db     *storage.Database
 }
 
-func setupStorageAndAPI(cctx *cli.Context) (context.Context, *RunContext, error) {
+// SetupStorageAndAPI setups of the sentinel database and returns a
+// ready-to-use RunContext with Openers and Closers using the chosen lens.
+func SetupStorageAndAPI(cctx *cli.Context) (context.Context, *RunContext, error) {
 	var opener lens.APIOpener // the api opener that is used by tasks
 	var closer lens.APICloser // a closer that cleans up the opener when exiting the application
 	var err error

--- a/model/actors/common/actors.go
+++ b/model/actors/common/actors.go
@@ -2,9 +2,12 @@ package common
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-pg/pg/v10"
 	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/label"
 )
 
 type Actor struct {
@@ -28,6 +31,25 @@ func (a *Actor) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
 	return nil
 }
 
+// ActorList is a slice of Actors persistable in a single batch.
+type ActorList []*Actor
+
+// Persist
+func (actors ActorList) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	ctx, span := global.Tracer("").Start(ctx, "ActorList.PersistWithTx", trace.WithAttributes(label.Int("count", len(actors))))
+	defer span.End()
+
+	if len(actors) == 0 {
+		return nil
+	}
+	if _, err := tx.ModelContext(ctx, &actors).
+		OnConflict("do nothing").
+		Insert(); err != nil {
+		return fmt.Errorf("persisting actors: %w", err)
+	}
+	return nil
+}
+
 type ActorState struct {
 	Height int64  `pg:",pk,notnull,use_zero"`
 	Head   string `pg:",pk,notnull"`
@@ -35,6 +57,7 @@ type ActorState struct {
 	State  string `pg:",type:jsonb,notnull"`
 }
 
+// PersistWithTx inserts the batch using the given transaction.
 func (s *ActorState) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
 	ctx, span := global.Tracer("").Start(ctx, "ActorState.PersistWithTx")
 	defer span.End()
@@ -42,6 +65,25 @@ func (s *ActorState) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
 		OnConflict("do nothing").
 		Insert(); err != nil {
 		return err
+	}
+	return nil
+}
+
+// ActorStateList is a list of ActorStates persistable in a single batch.
+type ActorStateList []*ActorState
+
+// PersistWithTx inserts the batch using the given transaction.
+func (states ActorStateList) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
+	ctx, span := global.Tracer("").Start(ctx, "ActorStateList.PersistWithTx", trace.WithAttributes(label.Int("count", len(states))))
+	defer span.End()
+
+	if len(states) == 0 {
+		return nil
+	}
+	if _, err := tx.ModelContext(ctx, &states).
+		OnConflict("do nothing").
+		Insert(); err != nil {
+		return fmt.Errorf("persisting actorStates: %w", err)
 	}
 	return nil
 }

--- a/model/actors/miner/sectorevents.go
+++ b/model/actors/miner/sectorevents.go
@@ -42,6 +42,11 @@ type MinerSectorEventList []*MinerSectorEvent
 func (l MinerSectorEventList) PersistWithTx(ctx context.Context, tx *pg.Tx) error {
 	ctx, span := global.Tracer("").Start(ctx, "MinerSectorEventList.PersistWithTx", trace.WithAttributes(label.Int("count", len(l))))
 	defer span.End()
+
+	if len(l) == 0 {
+		return nil
+	}
+
 	if _, err := tx.ModelContext(ctx, &l).
 		OnConflict("do nothing").
 		Insert(); err != nil {

--- a/model/interface.go
+++ b/model/interface.go
@@ -2,9 +2,14 @@ package model
 
 import (
 	"context"
+
 	"github.com/go-pg/pg/v10"
 )
 
 type Persistable interface {
 	Persist(ctx context.Context, db *pg.DB) error
+}
+
+type PersistableWithTx interface {
+	PersistWithTx(ctx context.Context, tx *pg.Tx) error
 }

--- a/tasks/message/message.go
+++ b/tasks/message/message.go
@@ -343,7 +343,7 @@ func (p *MessageProcessor) extractMessageModels(ctx context.Context, node lens.A
 					dstActorCode = dstActor.Code.String()
 				}
 
-				if pm, err := parseMsg(message, ts, dstActorCode); err == nil {
+				if pm, err := ParseMsg(message, ts, dstActorCode); err == nil {
 					result.ParsedMessages = append(result.ParsedMessages, pm)
 				} else {
 					return nil, nil, xerrors.Errorf("parse message %s failed: %w", message.Cid().String(), err)
@@ -385,7 +385,9 @@ func cidsEqual(c1, c2 []cid.Cid) bool {
 	return true
 }
 
-func parseMsg(m *types.Message, ts *types.TipSet, destCode string) (*messagemodel.ParsedMessage, error) {
+// ParseMsg extracts message parameters and encodes them as JSON by looking at
+// the messages destination actor type.
+func ParseMsg(m *types.Message, ts *types.TipSet, destCode string) (*messagemodel.ParsedMessage, error) {
 	pm := &messagemodel.ParsedMessage{
 		Cid:    m.Cid().String(),
 		Height: int64(ts.Height()),


### PR DESCRIPTION
The purpose of this rather superficial changes is to better support custom, ad-hoc tooling that re-uses logic present in sentinel-visor.