### PR TITLE
refactor(cmd): Modify command line default parameters

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 			&cli.StringFlag{
 				Name:    "jaeger-service-name",
 				EnvVars: []string{"JAEGER_SERVICE_NAME"},
-				Value:   "sentinel-visor",
+				Value:   "visor",
 			},
 			&cli.StringFlag{
 				Name:    "jaeger-sampler-type",


### PR DESCRIPTION
Change the default parameter sentinel-visor to visor in the command line
jaeger-service-name, because the compiled binary is visor by default.