### PR TITLE
fix: do not error when no specialized state processor

### DIFF
--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -314,7 +314,7 @@ func (p *ActorStateProcessor) processActor(ctx context.Context, node lens.API, i
 	// Find a specific extractor for the actor type
 	extractor, exists := p.extractors[info.Actor.Code]
 	if !exists {
-		return xerrors.Errorf("no extractor defined for actor code %q", info.Actor.Code.String())
+		return nil
 	}
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, ActorNameByCode(info.Actor.Code)))


### PR DESCRIPTION
Hopefully I'm reading this right but if there's no _specialized_ state processor, `processActor` will return an error and abort the _whole_ batch. There's no specialized state processor for account actors so I imagine this happens frequently and slows down the process significantly.

This PR allows there to be no specialized processor, allowing general state information to be extracted and saved and the rest of the batch processed.