### PR TITLE
fix: truncated tables in tests

### DIFF
--- a/tasks/actorstate/genesis_test.go
+++ b/tasks/actorstate/genesis_test.go
@@ -86,16 +86,16 @@ func TestGenesisProcessor(t *testing.T) {
 		assert.NotEqual(t, 0, count)
 	})
 
-	t.Run("miner_powers", func(t *testing.T) {
+	t.Run("power_actor_claims", func(t *testing.T) {
 		var count int
-		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM miner_powers`)
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM power_actor_claims`)
 		require.NoError(t, err)
 		assert.NotEqual(t, 0, count)
 	})
 
-	t.Run("miner_states", func(t *testing.T) {
+	t.Run("miner_infos", func(t *testing.T) {
 		var count int
-		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM miner_states`)
+		_, err := db.QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM miner_infos`)
 		require.NoError(t, err)
 		assert.NotEqual(t, 0, count)
 	})
@@ -125,8 +125,8 @@ func TestGenesisProcessor(t *testing.T) {
 // truncateGenesisTables ensures the indexing tables are empty
 func truncateGenesisTables(tb testing.TB, db *pg.DB) error {
 	tables := []string{
-		"miner_states",
-		"miner_powers",
+		"miner_infos",
+		"power_actor_claims",
 		"miner_sector_infos",
 		"miner_sector_deals",
 		"market_deal_states",

--- a/tasks/indexer/chainheadindexer_test.go
+++ b/tasks/indexer/chainheadindexer_test.go
@@ -212,9 +212,6 @@ func truncateBlockTables(tb testing.TB, db *pg.DB) error {
 	_, err = db.Exec(`TRUNCATE TABLE block_parents`)
 	require.NoError(tb, err, "block_parents")
 
-	_, err = db.Exec(`TRUNCATE TABLE drand_entries`)
-	require.NoError(tb, err, "drand_entries")
-
 	_, err = db.Exec(`TRUNCATE TABLE drand_block_entries`)
 	require.NoError(tb, err, "drand_block_entries")
 


### PR DESCRIPTION
* `miner_states` => `miner_infos` as advised by comment in migration 19
* `miner_powers` => `power_actor_claims` as advised by comment in migration 19
* `drand_entries` removed in migration 20