### PR TITLE
feat: extract basic account actor states

### DIFF
--- a/model/nodata.go
+++ b/model/nodata.go
@@ -1,0 +1,16 @@
+package model
+
+import (
+	"context"
+
+	"github.com/go-pg/pg/v10"
+)
+
+type noData struct{}
+
+func (noData) Persist(ctx context.Context, db *pg.DB) error {
+	return nil
+}
+
+// NoData is a model with no data to persist.
+var NoData = noData{}

--- a/tasks/actorstate/account.go
+++ b/tasks/actorstate/account.go
@@ -4,14 +4,16 @@ import (
 	"context"
 
 	"github.com/filecoin-project/sentinel-visor/model"
-	builtin "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	sa0builtin "github.com/filecoin-project/specs-actors/actors/builtin"
+	sa2builtin "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 )
 
 // AccountExtractor is a state extractor that deals with Account actors.
 type AccountExtractor struct{}
 
 func init() {
-	Register(builtin.AccountActorCodeID, AccountExtractor{})
+	Register(sa0builtin.AccountActorCodeID, AccountExtractor{})
+	Register(sa2builtin.AccountActorCodeID, AccountExtractor{})
 }
 
 // Extract will create persistable data for a given actor's state.

--- a/tasks/actorstate/account.go
+++ b/tasks/actorstate/account.go
@@ -3,7 +3,6 @@ package actorstate
 import (
 	"context"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/sentinel-visor/model"
 	builtin "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 )
@@ -15,22 +14,9 @@ func init() {
 	Register(builtin.AccountActorCodeID, AccountExtractor{})
 }
 
-var includeAddrs = []address.Address{builtin.BurntFundsActorAddr}
-
 // Extract will create persistable data for a given actor's state.
 func (AccountExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	return model.NoData, nil
 }
 
-// Filter determines which actors this extractor is willing to extract.
-func (AccountExtractor) Filter(info ActorInfo) bool {
-	for _, a := range includeAddrs {
-		if a == info.Address {
-			return true
-		}
-	}
-	return false
-}
-
 var _ ActorStateExtractor = (*AccountExtractor)(nil)
-var _ FilteredExtractor = (*AccountExtractor)(nil)

--- a/tasks/actorstate/account.go
+++ b/tasks/actorstate/account.go
@@ -1,0 +1,36 @@
+package actorstate
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/sentinel-visor/model"
+	builtin "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+)
+
+// AccountExtractor is a state extractor that deals with Account actors.
+type AccountExtractor struct{}
+
+func init() {
+	Register(builtin.AccountActorCodeID, AccountExtractor{})
+}
+
+var includeAddrs = []address.Address{builtin.BurntFundsActorAddr}
+
+// Extract will create persistable data for a given actor's state.
+func (AccountExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
+	return model.NoData, nil
+}
+
+// Filter determines which actors this extractor is willing to extract.
+func (AccountExtractor) Filter(info ActorInfo) bool {
+	for _, a := range includeAddrs {
+		if a == info.Address {
+			return true
+		}
+	}
+	return false
+}
+
+var _ ActorStateExtractor = (*AccountExtractor)(nil)
+var _ FilteredExtractor = (*AccountExtractor)(nil)

--- a/tasks/actorstate/account_test.go
+++ b/tasks/actorstate/account_test.go
@@ -1,0 +1,31 @@
+package actorstate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/sentinel-visor/model"
+)
+
+func TestAccountExtract(t *testing.T) {
+	ae := AccountExtractor{}
+	d, err := ae.Extract(context.Background(), ActorInfo{}, nil)
+	if d != model.NoData {
+		t.Fatal("expected not to extract any data")
+	}
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+}
+
+func TestAccountFilter(t *testing.T) {
+	ae := AccountExtractor{}
+	filteredAddr, _ := address.NewIDAddress(1138)
+	if ae.Filter(ActorInfo{Address: filteredAddr}) != false {
+		t.Fatal("should be false")
+	}
+	if ae.Filter(ActorInfo{Address: includeAddrs[0]}) != true {
+		t.Fatal("should be true")
+	}
+}

--- a/tasks/actorstate/account_test.go
+++ b/tasks/actorstate/account_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -12,20 +11,9 @@ func TestAccountExtract(t *testing.T) {
 	ae := AccountExtractor{}
 	d, err := ae.Extract(context.Background(), ActorInfo{}, nil)
 	if d != model.NoData {
-		t.Fatal("expected not to extract any data")
+		t.Fatal("expected not to extract any extra data")
 	}
 	if err != nil {
 		t.Fatal("unexpected error", err)
-	}
-}
-
-func TestAccountFilter(t *testing.T) {
-	ae := AccountExtractor{}
-	filteredAddr, _ := address.NewIDAddress(1138)
-	if ae.Filter(ActorInfo{Address: filteredAddr}) != false {
-		t.Fatal("should be false")
-	}
-	if ae.Filter(ActorInfo{Address: includeAddrs[0]}) != true {
-		t.Fatal("should be true")
 	}
 }

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -305,7 +305,7 @@ func (p *ActorStateProcessor) processActor(ctx context.Context, node lens.API, i
 	ctx, span := global.Tracer("").Start(ctx, "ActorStateProcessor.processActor")
 	defer span.End()
 
-	// Find a specific extractor for the actor type
+	// Find the extractor for the actor type
 	extractor, exists := p.extractors[info.Actor.Code]
 	if !exists {
 		return xerrors.Errorf("no extractor defined for actor code %q", info.Actor.Code.String())

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -68,11 +68,6 @@ type ActorStateExtractor interface {
 	Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error)
 }
 
-// FilteredExtractor provides functionality to determine which actors should be extracted.
-type FilteredExtractor interface {
-	Filter(a ActorInfo) bool
-}
-
 // All supported actor state extractors
 var (
 	extractorsMu sync.Mutex
@@ -305,19 +300,6 @@ func (p *ActorStateProcessor) processActor(ctx context.Context, node lens.API, i
 	ctx, span := global.Tracer("").Start(ctx, "ActorStateProcessor.processActor")
 	defer span.End()
 
-	// Find the extractor for the actor type
-	extractor, exists := p.extractors[info.Actor.Code]
-	if !exists {
-		return xerrors.Errorf("no extractor defined for actor code %q", info.Actor.Code.String())
-	}
-
-	// Filter out this particular actor?
-	if fe, ok := extractor.(FilteredExtractor); ok {
-		if !fe.Filter(info) {
-			return nil
-		}
-	}
-
 	var ae ActorExtractor
 
 	// Persist the raw state
@@ -327,6 +309,12 @@ func (p *ActorStateProcessor) processActor(ctx context.Context, node lens.API, i
 	}
 	if err := data.Persist(ctx, p.storage.DB); err != nil {
 		return xerrors.Errorf("persisting raw state: %w", err)
+	}
+
+	// Find a specific extractor for the actor type
+	extractor, exists := p.extractors[info.Actor.Code]
+	if !exists {
+		return xerrors.Errorf("no extractor defined for actor code %q", info.Actor.Code.String())
 	}
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, ActorNameByCode(info.Actor.Code)))

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -68,6 +68,11 @@ type ActorStateExtractor interface {
 	Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error)
 }
 
+// FilteredExtractor provides functionality to determine which actors should be extracted.
+type FilteredExtractor interface {
+	Filter(a ActorInfo) bool
+}
+
 // All supported actor state extractors
 var (
 	extractorsMu sync.Mutex


### PR DESCRIPTION
~~This PR enables Sentinel to persist state for the burnt funds actor without having to extract and persist data for ALL accounts.~~

~~It registers an `AccountExtractor` for the Account Actor CID and introduces the concept of a `FilteredExtractor`. If an extractor is a `FilteredExtractor` then `processActor` will call it's `Filter` method to see if it wants to extract data for a given actor.~~

~~At the moment the `AccountExtractor` is only interested in the burnt funds account and has no specialized extraction needs beyond what is automatically extracted by the common extractor. It means it's `Extract` method is basically a noop.~~

This PR adds an account actor extractor so that basic state is extracted for account actors.