### PR TITLE
fix(migration): don't recreate miner_sector_deals primary key if it is correct

### DIFF
--- a/storage/migrations/23_miner_sector_deals_pk.go
+++ b/storage/migrations/23_miner_sector_deals_pk.go
@@ -8,16 +8,37 @@ import (
 
 func init() {
 	up := batch(`
-		-- old index from when table was named miner_deal_sectors
-		ALTER TABLE public.miner_sector_deals DROP CONSTRAINT IF EXISTS miner_deal_sectors_pkey;
+		-- Only run this destructive migration if the constraint doesn't exist
+		DO $$
+		    BEGIN
+				IF (
+					SELECT count(*)
+					  FROM information_schema.constraint_column_usage
+					 WHERE table_schema = 'public'
+					   AND table_name = 'miner_sector_deals'
+					    AND constraint_name='miner_sector_deals_pkey'
+					   AND column_name IN ('height','miner_id','sector_id','deal_id')
+				   ) != 4
 
-		ALTER TABLE public.miner_sector_deals DROP CONSTRAINT IF EXISTS miner_sector_deals_pkey;
-	   	ALTER TABLE public.miner_sector_deals ADD PRIMARY KEY (height, miner_id, sector_id, deal_id);
+				THEN
+
+					-- Can't change primary key while data exists
+					TRUNCATE TABLE public.miner_sector_deals;
+
+					-- old index from when table was named miner_deal_sectors
+					ALTER TABLE public.miner_sector_deals DROP CONSTRAINT IF EXISTS miner_deal_sectors_pkey;
+
+					ALTER TABLE public.miner_sector_deals DROP CONSTRAINT IF EXISTS miner_sector_deals_pkey;
+				   	ALTER TABLE public.miner_sector_deals ADD PRIMARY KEY (height, miner_id, sector_id, deal_id);
+
+				END IF;
+			END
+		$$;
 `)
 
 	down := batch(`
-		ALTER TABLE public.miner_sector_deals DROP CONSTRAINT IF EXISTS miner_sector_deals_pkey;
-	   	ALTER TABLE public.miner_sector_deals ADD PRIMARY KEY (height, miner_id, sector_id);
+		-- don't recreate the buggy constraint
+		SELECT 1;
 `)
 
 	migrations.MustRegisterTx(up, down)


### PR DESCRIPTION
This retrospectively changes migration 23 but keeps backwards compatibility. Changing the primary key on a hypertable can't be done while it contains data. Since the data in miner_sector_deals is incomplete and we need to backfill then we can truncate the table. 

This change introduces a pattern we can use to only perform destructive data changes when needed. We wrap the migration in a check for the existence of the new constraint. 