### PR TITLE
feat: change derived_gas_outputs value columns to numerics

### DIFF
--- a/model/derived/gasoutputs.go
+++ b/model/derived/gasoutputs.go
@@ -17,9 +17,9 @@ type GasOutputs struct {
 	StateRoot          string   `pg:",pk,notnull"`
 	From               string   `pg:",notnull"`
 	To                 string   `pg:",notnull"`
-	Value              string   `pg:",notnull"`
-	GasFeeCap          string   `pg:",notnull"`
-	GasPremium         string   `pg:",notnull"`
+	Value              string   `pg:"type:numeric,notnull"`
+	GasFeeCap          string   `pg:"type:numeric,notnull"`
+	GasPremium         string   `pg:"type:numeric,notnull"`
 	GasLimit           int64    `pg:",use_zero,notnull"`
 	SizeBytes          int      `pg:",use_zero,notnull"`
 	Nonce              uint64   `pg:",use_zero,notnull"`
@@ -27,12 +27,12 @@ type GasOutputs struct {
 	ActorName          string   `pg:",notnull"`
 	ExitCode           int64    `pg:",use_zero,notnull"`
 	GasUsed            int64    `pg:",use_zero,notnull"`
-	ParentBaseFee      string   `pg:",notnull"`
-	BaseFeeBurn        string   `pg:",notnull"`
-	OverEstimationBurn string   `pg:",notnull"`
-	MinerPenalty       string   `pg:",notnull"`
-	MinerTip           string   `pg:",notnull"`
-	Refund             string   `pg:",notnull"`
+	ParentBaseFee      string   `pg:"type:numeric,notnull"`
+	BaseFeeBurn        string   `pg:"type:numeric,notnull"`
+	OverEstimationBurn string   `pg:"type:numeric,notnull"`
+	MinerPenalty       string   `pg:"type:numeric,notnull"`
+	MinerTip           string   `pg:"type:numeric,notnull"`
+	Refund             string   `pg:"type:numeric,notnull"`
 	GasRefund          int64    `pg:",use_zero,notnull"`
 	GasBurned          int64    `pg:",use_zero,notnull"`
 }

--- a/storage/migrations/26_gasoutputs_numerics.go
+++ b/storage/migrations/26_gasoutputs_numerics.go
@@ -1,0 +1,32 @@
+package migrations
+
+import "github.com/go-pg/migrations/v8"
+
+// Schema version 26 converts derived_gas_outputs text columns to numerics
+
+func init() {
+	up := batch(`
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN value TYPE numeric USING (value::numeric);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN gas_fee_cap TYPE numeric USING (gas_fee_cap::numeric);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN gas_premium TYPE numeric USING (gas_premium::numeric);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN parent_base_fee TYPE numeric USING (parent_base_fee::numeric);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN base_fee_burn TYPE numeric USING (base_fee_burn::numeric);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN over_estimation_burn TYPE numeric USING (over_estimation_burn::numeric);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN miner_penalty TYPE numeric USING (miner_penalty::numeric);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN miner_tip TYPE numeric USING (miner_tip::numeric);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN refund TYPE numeric USING (refund::numeric);
+`)
+	down := batch(`
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN value TYPE text USING (value::text);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN gas_fee_cap TYPE text USING (gas_fee_cap::text);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN gas_premium TYPE text USING (gas_premium::text);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN parent_base_fee TYPE text USING (parent_base_fee::text);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN base_fee_burn TYPE text USING (base_fee_burn::text);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN over_estimation_burn TYPE text USING (over_estimation_burn::text);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN miner_penalty TYPE text USING (miner_penalty::text);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN miner_tip TYPE text USING (miner_tip::text);
+	ALTER TABLE public.derived_gas_outputs ALTER COLUMN refund TYPE text USING (refund::text);
+`)
+
+	migrations.MustRegisterTx(up, down)
+}


### PR DESCRIPTION
This changes the model and database table to use the postgres numeric type. The struct fields remain as strings and postgres automatically converts to numeric when inserted (tested against a real postgres db to verify).

Related issue: https://github.com/filecoin-project/sentinel-visor/issues/244