### PR TITLE
feat: allow finer-grained actor task processing

### DIFF
--- a/chain/actor.go
+++ b/chain/actor.go
@@ -189,7 +189,7 @@ type ActorExtractorMap interface {
 	GetExtractor(code cid.Cid) (actorstate.ActorStateExtractor, bool)
 }
 
-// A RawActorExtractorMap extracts all types of actors using basic actor extraction which only uses shallow state.
+// A RawActorExtractorMap extracts all types of actors using basic actor extraction which only parses shallow state.
 type RawActorExtractorMap struct{}
 
 func (RawActorExtractorMap) Allow(code cid.Cid) bool {
@@ -200,7 +200,7 @@ func (RawActorExtractorMap) GetExtractor(code cid.Cid) (actorstate.ActorStateExt
 	return actorstate.ActorExtractor{}, true
 }
 
-// A TypedActorExtractorMap extracts a single type of actors using full parsing of actor state
+// A TypedActorExtractorMap extracts a single type of actor using full parsing of actor state
 type TypedActorExtractorMap struct {
 	// Simplistic for now, will need to make into a slice when we have more actor versions
 	CodeV1 cid.Cid

--- a/chain/actor.go
+++ b/chain/actor.go
@@ -16,12 +16,12 @@ import (
 	"github.com/filecoin-project/sentinel-visor/tasks/actorstate"
 )
 
+// An ActorStateProcessor processes the extraction of actor state according the allowed types in its extracter map.
 type ActorStateProcessor struct {
 	node         lens.API
 	opener       lens.APIOpener
 	closer       lens.APICloser
 	extracterMap ActorExtractorMap
-	lastTipSet   *types.TipSet
 }
 
 func NewActorStateProcessor(opener lens.APIOpener, extracterMap ActorExtractorMap) *ActorStateProcessor {
@@ -183,11 +183,13 @@ type ActorStateError struct {
 	Error   string
 }
 
+// An ActorExtractorMap controls which actor types may be extracted.
 type ActorExtractorMap interface {
 	Allow(code cid.Cid) bool
 	GetExtractor(code cid.Cid) (actorstate.ActorStateExtractor, bool)
 }
 
+// A RawActorExtractorMap extracts all types of actors using basic actor extraction which only uses shallow state.
 type RawActorExtractorMap struct{}
 
 func (RawActorExtractorMap) Allow(code cid.Cid) bool {
@@ -198,6 +200,7 @@ func (RawActorExtractorMap) GetExtractor(code cid.Cid) (actorstate.ActorStateExt
 	return actorstate.ActorExtractor{}, true
 }
 
+// A TypedActorExtractorMap extracts a single type of actors using full parsing of actor state
 type TypedActorExtractorMap struct {
 	// Simplistic for now, will need to make into a slice when we have more actor versions
 	CodeV1 cid.Cid

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -160,7 +160,7 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 			}
 		}
 
-		// If no parent tipset available then we need to skip processing. It's likely we receoved the last or first tipset
+		// If no parent tipset available then we need to skip processing. It's likely we received the last or first tipset
 		// in a batch. No report is generated because a different run of the indexer could cover the parent and child
 		// for this tipset.
 		if parent != nil {

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -77,7 +77,7 @@ func NewTipSetIndexer(o lens.APIOpener, d Storage, window time.Duration, name st
 		case ActorStatesRawTask:
 			tsi.actorProcessors[ActorStatesRawTask] = NewActorStateProcessor(o, &RawActorExtractorMap{})
 		case ActorStatesPowerTask:
-			tsi.actorProcessors[ActorStatesRawTask] = NewActorStateProcessor(o, &TypedActorExtractorMap{
+			tsi.actorProcessors[ActorStatesPowerTask] = NewActorStateProcessor(o, &TypedActorExtractorMap{
 				CodeV1: sa0builtin.StoragePowerActorCodeID,
 				CodeV2: sa2builtin.StoragePowerActorCodeID,
 			})

--- a/commands/walk.go
+++ b/commands/walk.go
@@ -36,7 +36,7 @@ var Walk = &cli.Command{
 		&cli.StringFlag{
 			Name:    "tasks",
 			Usage:   "Comma separated list of tasks to run.",
-			Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorStateTask}, ","),
+			Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorStatesRawTask}, ","),
 			EnvVars: []string{"VISOR_WALK_TASKS"},
 		},
 	},

--- a/commands/walk.go
+++ b/commands/walk.go
@@ -35,7 +35,7 @@ var Walk = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:    "tasks",
-			Usage:   "Comma separated list of tasks to run.",
+			Usage:   "Comma separated list of tasks to run. Each task is reported separately in the database.",
 			Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorStatesRawTask}, ","),
 			EnvVars: []string{"VISOR_WALK_TASKS"},
 		},

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -31,7 +31,7 @@ var Watch = &cli.Command{
 		&cli.StringFlag{
 			Name:    "tasks",
 			Usage:   "Comma separated list of tasks to run.",
-			Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorRawStateTask}, ","),
+			Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorStatesRawTask}, ","),
 			EnvVars: []string{"VISOR_WATCH_TASKS"},
 		},
 	},

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -30,7 +30,7 @@ var Watch = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:    "tasks",
-			Usage:   "Comma separated list of tasks to run.",
+			Usage:   "Comma separated list of tasks to run. Each task is reported separately in the database.",
 			Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorStatesRawTask}, ","),
 			EnvVars: []string{"VISOR_WATCH_TASKS"},
 		},


### PR DESCRIPTION
This replaces the `actorstates` and `actorstatesparsed` tasks with per-actor tasks which allows us to run visor with selected actors being fully extracted. They are implemented as separate tasks rather than a parameterised version of `actorstates` so that the outcome of each task can be tracked in the `visor_processing_reports` table. This allows users to quickly determine whether actor extraction has been performed for any given epoch.