### PR TITLE
chore(api): trim the lens API to required methods

### DIFF
--- a/lens/interface.go
+++ b/lens/interface.go
@@ -2,9 +2,11 @@ package lens
 
 import (
 	"context"
-
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
@@ -12,10 +14,49 @@ import (
 )
 
 type API interface {
-	Store() adt.Store
-	api.FullNode
+	StoreAPI
+	ChainAPI
+	StateAPI
+
 	ComputeGasOutputs(gasUsed, gasLimit int64, baseFee, feeCap, gasPremium abi.TokenAmount) vm.GasOutputs
 	GetExecutedMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) ([]*ExecutedMessage, error)
+}
+
+type StoreAPI interface {
+	Store() adt.Store
+}
+
+
+type ChainAPI interface {
+	ChainNotify(context.Context) (<-chan []*api.HeadChange, error)
+	ChainHead(context.Context) (*types.TipSet, error)
+
+	ChainHasObj(ctx context.Context, obj cid.Cid) (bool, error)
+	ChainReadObj(ctx context.Context, obj cid.Cid) ([]byte, error)
+
+	ChainGetGenesis(ctx context.Context) (*types.TipSet, error)
+	ChainGetTipSet(context.Context, types.TipSetKey) (*types.TipSet, error)
+	ChainGetTipSetByHeight(context.Context, abi.ChainEpoch, types.TipSetKey) (*types.TipSet, error)
+
+	ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*api.BlockMessages, error)
+	ChainGetParentMessages(ctx context.Context, blockCid cid.Cid) ([]api.Message, error)
+	ChainGetParentReceipts(ctx context.Context, blockCid cid.Cid) ([]*types.MessageReceipt, error)
+}
+
+type StateAPI interface {
+	StateGetActor(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*types.Actor, error)
+	StateListActors(context.Context, types.TipSetKey) ([]address.Address, error)
+	StateChangedActors(context.Context, cid.Cid, cid.Cid) (map[string]types.Actor, error)
+
+	StateMinerSectors(ctx context.Context, addr address.Address, bf *bitfield.BitField, tsk types.TipSetKey) ([]*miner.SectorOnChainInfo, error)
+	StateMinerPower(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*api.MinerPower, error)
+
+	StateMarketDeals(context.Context, types.TipSetKey) (map[string]api.MarketDeal, error)
+
+	StateReadState(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*api.ActorState, error)
+	StateGetReceipt(ctx context.Context, bcid cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error)
+	StateVMCirculatingSupplyInternal(context.Context, types.TipSetKey) (api.CirculatingSupply, error)
+
 }
 
 type APICloser func()

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -227,7 +227,7 @@ func (p *ActorStateProcessor) Run(ctx context.Context) error {
 	})
 }
 
-func (p *ActorStateProcessor) processBatch(ctx context.Context, node lens.API) (bool, error) {
+func (p *ActorStateProcessor) processBatch(ctx context.Context, node ActorStateAPI) (bool, error) {
 	// the actor represents the "raw" actor data model that is persisted
 	// this gets overridden with the specific actor type once we know
 	// which it is.
@@ -303,7 +303,7 @@ func (p *ActorStateProcessor) processBatch(ctx context.Context, node lens.API) (
 	return false, nil
 }
 
-func (p *ActorStateProcessor) processActor(ctx context.Context, node lens.API, info ActorInfo) error {
+func (p *ActorStateProcessor) processActor(ctx context.Context, node ActorStateAPI, info ActorInfo) error {
 	ctx, span := global.Tracer("").Start(ctx, "ActorStateProcessor.processActor")
 	defer span.End()
 


### PR DESCRIPTION
### Motivation
There has been some discussion of embedding visor into a lotus daemon. Reducing the API required by visor aims to decrease friction of making that change.