### PR TITLE
Market actor: Export some methods and improve batching

### DIFF
--- a/model/actors/market/dealproposal.go
+++ b/model/actors/market/dealproposal.go
@@ -3,11 +3,10 @@ package market
 import (
 	"context"
 
+	"github.com/filecoin-project/sentinel-visor/model"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
-
-	"github.com/filecoin-project/sentinel-visor/model"
 )
 
 type MarketDealProposal struct {
@@ -41,10 +40,5 @@ type MarketDealProposals []*MarketDealProposal
 func (dps MarketDealProposals) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MarketDealProposals.Persist", trace.WithAttributes(label.Int("count", len(dps))))
 	defer span.End()
-	for _, dp := range dps {
-		if err := s.PersistModel(ctx, dp); err != nil {
-			return err
-		}
-	}
-	return nil
+	return s.PersistModel(ctx, dps)
 }

--- a/model/actors/market/dealstate.go
+++ b/model/actors/market/dealstate.go
@@ -3,11 +3,10 @@ package market
 import (
 	"context"
 
+	"github.com/filecoin-project/sentinel-visor/model"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
-
-	"github.com/filecoin-project/sentinel-visor/model"
 )
 
 type MarketDealState struct {
@@ -29,10 +28,5 @@ type MarketDealStates []*MarketDealState
 func (dss MarketDealStates) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MarketDealStates.PersistWithTx", trace.WithAttributes(label.Int("count", len(dss))))
 	defer span.End()
-	for _, ds := range dss {
-		if err := s.PersistModel(ctx, ds); err != nil {
-			return err
-		}
-	}
-	return nil
+	return s.PersistModel(ctx, dss)
 }


### PR DESCRIPTION
I had these changes laying around. The market actor model was still looping every element on the slice when doing a batched-persist, which is very slow. That said, the whole market-actor processing does NOT get sped-up too much by this.

Additionally, export some extractor methods for the market actor, as that allowed me playing with a custom extractor, even though it was still too slow.