### PR TITLE
fix(ci): Pin TimescaleDB to v1.7 on Postgres v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
   test:
     docker:
       - image: cimg/go:1.15.2
-      - image: timescale/timescaledb:latest-pg12
+      - image: timescale/timescaledb:1.7.4-pg12
         environment:
           POSTGRES_PASSWORD: password
     steps:


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/sentinel-visor/issues/339