### PR TITLE
docs: Update README and docker-compose to require use of TimescaleDB v1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ docker-compose up --build timescaledb
 
 ### Running tests
 
+To quickly run tests, you can provide the `VISOR_TEST_DB` envvar and execute `make test` like so:
+
+`VISOR_TEST_DB="postgres://postgres:password@localhost:5432/postgres?sslmode=disable" make test`
+
+For more, manual test running, you could also prepare your environment in the following way:
+
 Create a new DB in postgres for testing:
 
 ```sql

--- a/README.md
+++ b/README.md
@@ -22,26 +22,13 @@ Build the `sentinel-visor` binary to the root of the project directory:
 $ make build
 ```
 
-Install PostgreSQL:
+Install TimescaleDB v1.7.4:
+
+In a separate shell, use docker-compose to start the appropriate version of Postgres with TimescaleDB. (Note: Visor requires TimescaleDB v1.7.x and will not work with v2.0.)
 
 ```sh
-brew install postgresql@12
+docker-compose up --build timescaledb
 ```
-
-Install TimescaleDB:
-
-```sh
-brew tap timescale/tap
-brew install timescaledb
-```
-
-You may need to run the following _before_ installing timescale to get it to compile:
-
-```sh
-ln -s /usr/local/Cellar/postgresql@12/12.5/include/postgresql/server /usr/local/Cellar/postgresql@12/12.5/include/server
-```
-
-Run `timescaledb-tune` and/or activate TimescaleDB by adding `shared_preload_libraries = 'timescaledb'` to `postgresql.conf`. Ensure you run `timescaledb_move.sh` as homebrew asks to finish the installation and then restart the postgres server if it's running.
 
 ### Running tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
   timescaledb:
     container_name: timescaledb
-    image: timescale/timescaledb:latest-pg12
+    image: timescale/timescaledb:1.7.4-pg12
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
Fixes #332 