### PR TITLE
fix(miner): extract miner PoSt's from parent messages

### DIFF
--- a/lens/interface.go
+++ b/lens/interface.go
@@ -26,7 +26,6 @@ type StoreAPI interface {
 	Store() adt.Store
 }
 
-
 type ChainAPI interface {
 	ChainNotify(context.Context) (<-chan []*api.HeadChange, error)
 	ChainHead(context.Context) (*types.TipSet, error)
@@ -56,7 +55,6 @@ type StateAPI interface {
 	StateReadState(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*api.ActorState, error)
 	StateGetReceipt(ctx context.Context, bcid cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error)
 	StateVMCirculatingSupplyInternal(context.Context, types.TipSetKey) (api.CirculatingSupply, error)
-
 }
 
 type APICloser func()

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -32,7 +32,7 @@ type ActorInfo struct {
 // ActorStateAPI is the minimal subset of lens.API that is needed for actor state extraction
 type ActorStateAPI interface {
 	ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
-	ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*api.BlockMessages, error)
+	ChainGetParentMessages(ctx context.Context, msg cid.Cid) ([]api.Message, error)
 	StateGetReceipt(ctx context.Context, bcid cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error)
 	ChainHasObj(ctx context.Context, obj cid.Cid) (bool, error)
 	ChainReadObj(ctx context.Context, obj cid.Cid) ([]byte, error)

--- a/tasks/actorstate/actorstate_test.go
+++ b/tasks/actorstate/actorstate_test.go
@@ -75,12 +75,8 @@ func (m *MockAPI) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
 	return blk.RawData(), nil
 }
 
-func (m *MockAPI) ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*api.BlockMessages, error) {
-	return &api.BlockMessages{
-		BlsMessages:   []*types.Message{},
-		SecpkMessages: []*types.SignedMessage{},
-		Cids:          []cid.Cid{},
-	}, nil
+func (m *MockAPI) ChainGetParentMessages(ctx context.Context, msg cid.Cid) ([]api.Message, error) {
+	return []api.Message{}, nil
 }
 
 func (m *MockAPI) ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error) {


### PR DESCRIPTION
- closes #342

Due to the complexity of the miner actor state there there is no test coverage for this change, manual verification is required.

Manual validation was performed by running:
```
./visor --log-level=debug --db="postgres://postgres:password@localhost:5432/postgres?sslmode=disable" --lens="lotusrepo" --repo="~/.lotus" --repo-read-only=false walk --from 10000 --to 11000 --tasks=actorstatesminer
``` 
A CSV of the `miner_sector_posts` table after running the above command can be seen here: https://ipfs.io/ipfs/QmV4RbVzgtD5Nc9ujpMRqyuAsjBSzELSqo7eWY4RP7Hn26

When the aformentioned command was ran against master the `miner_sector_posts` table was empty.