### PR TITLE
feat: improve metric reporting

### DIFF
--- a/chain/actor.go
+++ b/chain/actor.go
@@ -8,9 +8,11 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
+	"go.opencensus.io/tag"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 	visormodel "github.com/filecoin-project/sentinel-visor/model/visor"
 	"github.com/filecoin-project/sentinel-visor/tasks/actorstate"
@@ -119,6 +121,8 @@ func (p *ActorStateProcessor) ProcessActors(ctx context.Context, ts *types.TipSe
 }
 
 func (p *ActorStateProcessor) runActorStateExtraction(ctx context.Context, ts *types.TipSet, pts *types.TipSet, addrStr string, act types.Actor, results chan *ActorStateResult) {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.ActorCode, actorstate.ActorNameByCode(act.Code)))
+
 	res := &ActorStateResult{
 		Code:    act.Code,
 		Head:    act.Head,

--- a/chain/walker.go
+++ b/chain/walker.go
@@ -2,16 +2,15 @@ package chain
 
 import (
 	"context"
+
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/chain/types"
-	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/sentinel-visor/lens"
-	"github.com/filecoin-project/sentinel-visor/metrics"
 )
 
 func NewWalker(obs TipSetObserver, opener lens.APIOpener, minHeight, maxHeight int64) *Walker {
@@ -68,8 +67,6 @@ func (c *Walker) Run(ctx context.Context) error {
 func (c *Walker) WalkChain(ctx context.Context, node lens.API, ts *types.TipSet) error {
 	ctx, span := global.Tracer("").Start(ctx, "Walker.WalkChain", trace.WithAttributes(label.Int64("height", c.maxHeight)))
 	defer span.End()
-
-	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, "indexhistoryblock"))
 
 	log.Debugw("found tipset", "height", ts.Height())
 	if err := c.obs.TipSet(ctx, ts); err != nil {

--- a/chain/watcher.go
+++ b/chain/watcher.go
@@ -2,7 +2,7 @@ package chain
 
 import (
 	"context"
-	"go.opencensus.io/tag"
+
 	"go.opentelemetry.io/otel/api/global"
 	"golang.org/x/xerrors"
 
@@ -10,7 +10,6 @@ import (
 	store "github.com/filecoin-project/lotus/chain/store"
 
 	"github.com/filecoin-project/sentinel-visor/lens"
-	"github.com/filecoin-project/sentinel-visor/metrics"
 )
 
 // NewWatcher creates a new Watcher. confidence sets the number of tipsets that will be held
@@ -66,8 +65,6 @@ func (c *Watcher) Run(ctx context.Context) error {
 func (c *Watcher) index(ctx context.Context, headEvents []*lotus_api.HeadChange) error {
 	ctx, span := global.Tracer("").Start(ctx, "Watcher.index")
 	defer span.End()
-
-	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, "indexheadblock"))
 
 	for _, ch := range headEvents {
 		switch ch.Type {

--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -78,6 +78,11 @@ func (aw *APIWrapper) ChainGetParentMessages(ctx context.Context, bcid cid.Cid) 
 func (aw *APIWrapper) StateGetReceipt(ctx context.Context, bcid cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error) {
 	ctx, span := global.Tracer("").Start(ctx, "Lotus.StateGetReceipt")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.API, "StateGetReceipt"))
+	stop := metrics.Timer(ctx, metrics.LensRequestDuration)
+	defer stop()
+
 	return aw.FullNode.StateGetReceipt(ctx, bcid, tsk)
 }
 
@@ -186,12 +191,21 @@ func (aw *APIWrapper) StateReadState(ctx context.Context, actor address.Address,
 func (aw *APIWrapper) StateVMCirculatingSupplyInternal(ctx context.Context, tsk types.TipSetKey) (api.CirculatingSupply, error) {
 	ctx, span := global.Tracer("").Start(ctx, "Lotus.StateCirculatingSupply")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.API, "StateVMCirculatingSupplyInternal"))
+	stop := metrics.Timer(ctx, metrics.LensRequestDuration)
+	defer stop()
+
 	return aw.FullNode.StateVMCirculatingSupplyInternal(ctx, tsk)
 }
 
 // GetExecutedMessagesForTipset returns a list of messages sent as part of pts (parent) with receipts found in ts (child).
 // No attempt at deduplication of messages is made.
 func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) ([]*lens.ExecutedMessage, error) {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.API, "GetExecutedMessagesForTipset"))
+	stop := metrics.Timer(ctx, metrics.LensRequestDuration)
+	defer stop()
+
 	if !types.CidArrsEqual(ts.Parents().Cids(), pts.Cids()) {
 		return nil, xerrors.Errorf("child tipset (%s) is not on the same chain as parent (%s)", ts.Key(), pts.Key())
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,87 +12,79 @@ import (
 var defaultMillisecondsDistribution = view.Distribution(0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 30000, 50000, 100000, 200000, 500000, 1000000, 2000000, 5000000, 10000000, 10000000)
 
 var (
-	Error, _     = tag.NewKey("error")
-	TaskType, _  = tag.NewKey("task")
+	TaskType, _  = tag.NewKey("task")  // name of task processor
+	Name, _      = tag.NewKey("name")  // name of running instance of visor
+	Table, _     = tag.NewKey("table") // name of table data is persisted for
 	ConnState, _ = tag.NewKey("conn_state")
-	State, _     = tag.NewKey("state")
-	API, _       = tag.NewKey("api")
+	API, _       = tag.NewKey("api")        // name of method on lotus api
+	ActorCode, _ = tag.NewKey("actor_code") // human readable code of actor being processed
 )
 
 var (
-	ProcessingDuration      = stats.Float64("processing_duration_ms", "Time taken to process a single item", stats.UnitMilliseconds)
-	PersistDuration         = stats.Float64("persist_duration_ms", "Duration of a models persist operation", stats.UnitMilliseconds)
-	BatchSelectionDuration  = stats.Float64("batch_selection_duration_ms", "Time taken to select a batch of work", stats.UnitMilliseconds)
-	CompletionDuration      = stats.Float64("completion_duration_ms", "Time taken to mark an item as completed", stats.UnitMilliseconds)
-	DBConns                 = stats.Int64("db_conns", "Database connections held", stats.UnitDimensionless)
-	HistoricalIndexerHeight = stats.Int64("historical_sync_height", "Sync height of the historical indexer", stats.UnitDimensionless)
-	EpochsToSync            = stats.Int64("epochs_to_sync", "Epochs yet to sync", stats.UnitDimensionless)
-	LensRequestDuration     = stats.Float64("lens_request_duration_ms", "Duration of lotus api requets", stats.UnitMilliseconds)
-	TipsetHeight            = stats.Int64("tipset_height", "The height of the tipset being processed", stats.UnitDimensionless)
+	ProcessingDuration  = stats.Float64("processing_duration_ms", "Time taken to process a single item", stats.UnitMilliseconds)
+	PersistDuration     = stats.Float64("persist_duration_ms", "Duration of a models persist operation", stats.UnitMilliseconds)
+	DBConns             = stats.Int64("db_conns", "Database connections held", stats.UnitDimensionless)
+	LensRequestDuration = stats.Float64("lens_request_duration_ms", "Duration of lotus api requets", stats.UnitMilliseconds)
+	TipsetHeight        = stats.Int64("tipset_height", "The height of the tipset being processed", stats.UnitDimensionless)
+	ProcessingFailure   = stats.Int64("processing_failure", "Number of processing failures", stats.UnitDimensionless)
+	PersistFailure      = stats.Int64("persist_failure", "Number of persistence failures", stats.UnitDimensionless)
 )
 
 var (
 	ProcessingDurationView = &view.View{
 		Measure:     ProcessingDuration,
 		Aggregation: defaultMillisecondsDistribution,
-		TagKeys:     []tag.Key{TaskType},
+		TagKeys:     []tag.Key{TaskType, ActorCode},
 	}
 	PersistDurationView = &view.View{
 		Measure:     PersistDuration,
 		Aggregation: defaultMillisecondsDistribution,
-		TagKeys:     []tag.Key{TaskType},
-	}
-	BatchSelectionDurationView = &view.View{
-		Measure:     BatchSelectionDuration,
-		Aggregation: defaultMillisecondsDistribution,
-		TagKeys:     []tag.Key{TaskType},
-	}
-	CompletionDurationView = &view.View{
-		Measure:     CompletionDuration,
-		Aggregation: defaultMillisecondsDistribution,
-		TagKeys:     []tag.Key{TaskType},
+		TagKeys:     []tag.Key{TaskType, Table, ActorCode},
 	}
 	DBConnsView = &view.View{
 		Measure:     DBConns,
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{ConnState},
 	}
-	HistoricalIndexerHeightView = &view.View{
-		Measure:     HistoricalIndexerHeight,
-		Aggregation: view.Sum(),
-	}
-	EpochsToSyncView = &view.View{
-		Measure:     EpochsToSync,
-		Aggregation: view.LastValue(),
-	}
 	LensRequestDurationView = &view.View{
 		Measure:     LensRequestDuration,
 		Aggregation: defaultMillisecondsDistribution,
-		TagKeys:     []tag.Key{TaskType, API},
+		TagKeys:     []tag.Key{TaskType, API, ActorCode},
 	}
 	LensRequestTotal = &view.View{
 		Name:        "lens_request_total",
 		Measure:     LensRequestDuration,
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{TaskType, API},
+		TagKeys:     []tag.Key{TaskType, API, ActorCode},
 	}
 	TipsetHeightView = &view.View{
 		Measure:     TipsetHeight,
 		Aggregation: view.LastValue(),
 		TagKeys:     []tag.Key{TaskType},
 	}
+	ProcessingFailureTotalView = &view.View{
+		Name:        ProcessingFailure.Name() + "_total",
+		Measure:     ProcessingFailure,
+		Aggregation: view.Sum(),
+		TagKeys:     []tag.Key{TaskType, ActorCode},
+	}
+	PersistFailureTotalView = &view.View{
+		Name:        PersistFailure.Name() + "_total",
+		Measure:     PersistFailure,
+		Aggregation: view.Sum(),
+		TagKeys:     []tag.Key{TaskType, Table, ActorCode},
+	}
 )
 
 var DefaultViews = []*view.View{
 	ProcessingDurationView,
 	PersistDurationView,
-	BatchSelectionDurationView,
-	CompletionDurationView,
 	DBConnsView,
-	HistoricalIndexerHeightView,
-	EpochsToSyncView,
 	LensRequestDurationView,
+	LensRequestTotal,
 	TipsetHeightView,
+	ProcessingFailureTotalView,
+	PersistFailureTotalView,
 }
 
 // SinceInMilliseconds returns the duration of time since the provide time as a float64.

--- a/model/actors/common/actors.go
+++ b/model/actors/common/actors.go
@@ -3,10 +3,12 @@ package common
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -23,6 +25,11 @@ type Actor struct {
 func (a *Actor) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "Actor.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actors"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, a)
 }
 
@@ -33,6 +40,10 @@ type ActorList []*Actor
 func (actors ActorList) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "ActorList.Persist", trace.WithAttributes(label.Int("count", len(actors))))
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actors"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
 
 	if len(actors) == 0 {
 		return nil
@@ -51,6 +62,11 @@ type ActorState struct {
 func (as *ActorState) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "ActorState.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actor_states"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, as)
 }
 
@@ -61,6 +77,10 @@ type ActorStateList []*ActorState
 func (states ActorStateList) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "ActorStateList.Persist", trace.WithAttributes(label.Int("count", len(states))))
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actor_states"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
 
 	if len(states) == 0 {
 		return nil

--- a/model/actors/init/idaddress.go
+++ b/model/actors/init/idaddress.go
@@ -3,10 +3,12 @@ package init
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -16,11 +18,24 @@ type IdAddress struct {
 	StateRoot string `pg:",pk,notnull"`
 }
 
+func (ia *IdAddress) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "id_addresses"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
+	return s.PersistModel(ctx, ia)
+}
+
 type IdAddressList []*IdAddress
 
 func (ias IdAddressList) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "IdAddressList.PersistWithTx", trace.WithAttributes(label.Int("count", len(ias))))
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "id_addresses"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	for _, ia := range ias {
 		if err := s.PersistModel(ctx, ia); err != nil {
 			return err

--- a/model/actors/miner/currentdeadline.go
+++ b/model/actors/miner/currentdeadline.go
@@ -3,8 +3,10 @@ package miner
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -24,6 +26,11 @@ type MinerCurrentDeadlineInfo struct {
 func (m *MinerCurrentDeadlineInfo) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MinerCurrentDeadlineInfo.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_current_deadline_infos"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, m)
 }
 
@@ -32,6 +39,11 @@ type MinerCurrentDeadlineInfoList []*MinerCurrentDeadlineInfo
 func (ml MinerCurrentDeadlineInfoList) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MinerCurrentDeadlineInfoList.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_current_deadline_infos"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	if len(ml) == 0 {
 		return nil
 	}

--- a/model/actors/miner/feedebt.go
+++ b/model/actors/miner/feedebt.go
@@ -3,8 +3,10 @@ package miner
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -19,6 +21,11 @@ type MinerFeeDebt struct {
 func (m *MinerFeeDebt) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MinerFeeDebt.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_fee_debts"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, m)
 }
 
@@ -27,6 +34,11 @@ type MinerFeeDebtList []*MinerFeeDebt
 func (ml MinerFeeDebtList) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MinerFeeDebtList.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_fee_debts"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	if len(ml) == 0 {
 		return nil
 	}

--- a/model/actors/miner/lockedfunds.go
+++ b/model/actors/miner/lockedfunds.go
@@ -3,8 +3,10 @@ package miner
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -21,6 +23,11 @@ type MinerLockedFund struct {
 func (m *MinerLockedFund) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MinerLockedFund.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_locked_funds"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, m)
 }
 
@@ -29,6 +36,11 @@ type MinerLockedFundsList []*MinerLockedFund
 func (ml MinerLockedFundsList) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MinerLockedFundsList.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_locked_funds"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	if len(ml) == 0 {
 		return nil
 	}

--- a/model/actors/miner/minerinfo.go
+++ b/model/actors/miner/minerinfo.go
@@ -3,8 +3,10 @@ package miner
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -29,6 +31,11 @@ type MinerInfo struct {
 func (m *MinerInfo) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MinerInfoModel.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_infos"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, m)
 }
 
@@ -37,6 +44,11 @@ type MinerInfoList []*MinerInfo
 func (ml MinerInfoList) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MinerInfoList.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_infos"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	if len(ml) == 0 {
 		return nil
 	}

--- a/model/actors/miner/sectordeals.go
+++ b/model/actors/miner/sectordeals.go
@@ -3,10 +3,12 @@ package miner
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -18,6 +20,10 @@ type MinerSectorDeal struct {
 }
 
 func (ds *MinerSectorDeal) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_deals"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, ds)
 }
 
@@ -26,6 +32,11 @@ type MinerSectorDealList []*MinerSectorDeal
 func (ml MinerSectorDealList) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "MinerSectorDealList.Persist", trace.WithAttributes(label.Int("count", len(ml))))
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_deals"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	if len(ml) == 0 {
 		return nil
 	}

--- a/model/actors/miner/sectorposts.go
+++ b/model/actors/miner/sectorposts.go
@@ -3,10 +3,12 @@ package miner
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -21,6 +23,10 @@ type MinerSectorPost struct {
 type MinerSectorPostList []*MinerSectorPost
 
 func (msp *MinerSectorPost) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_posts"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, msp)
 }
 
@@ -30,5 +36,10 @@ func (ml MinerSectorPostList) Persist(ctx context.Context, s model.StorageBatch)
 	if len(ml) == 0 {
 		return nil
 	}
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_posts"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, ml)
 }

--- a/model/actors/multisig/transactions.go
+++ b/model/actors/multisig/transactions.go
@@ -3,7 +3,9 @@ package multisig
 import (
 	"context"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
+	"go.opencensus.io/tag"
 )
 
 type MultisigTransaction struct {
@@ -21,11 +23,19 @@ type MultisigTransaction struct {
 }
 
 func (m *MultisigTransaction) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "multisig_transactions"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, m)
 }
 
 type MultisigTransactionList []*MultisigTransaction
 
 func (ml MultisigTransactionList) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "multisig_transactions"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, ml)
 }

--- a/model/actors/power/claimedpower.go
+++ b/model/actors/power/claimedpower.go
@@ -3,8 +3,10 @@ package power
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -19,6 +21,11 @@ type PowerActorClaim struct {
 func (p *PowerActorClaim) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "PowerActorClaim.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "power_actor_claims"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, p)
 }
 
@@ -27,6 +34,11 @@ type PowerActorClaimList []*PowerActorClaim
 func (pl PowerActorClaimList) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "PowerActorClaimList.Persist")
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "power_actor_claims"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	if len(pl) == 0 {
 		return nil
 	}

--- a/model/actors/reward/chainreward.go
+++ b/model/actors/reward/chainreward.go
@@ -3,6 +3,7 @@ package reward
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 
 	"github.com/filecoin-project/sentinel-visor/metrics"
@@ -28,6 +29,7 @@ func (r *ChainReward) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "ChainReward.Persist")
 	defer span.End()
 
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "chain_rewards"))
 	stop := metrics.Timer(ctx, metrics.PersistDuration)
 	defer stop()
 

--- a/model/blocks/drand.go
+++ b/model/blocks/drand.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/filecoin-project/lotus/chain/types"
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -28,6 +30,10 @@ type DrandBlockEntrie struct {
 }
 
 func (dbe *DrandBlockEntrie) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "drand_block_entries"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, dbe)
 }
 
@@ -39,5 +45,10 @@ func (dbes DrandBlockEntries) Persist(ctx context.Context, s model.StorageBatch)
 	}
 	ctx, span := global.Tracer("").Start(ctx, "DrandBlockEntries.Persist", trace.WithAttributes(label.Int("count", len(dbes))))
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "drand_block_entries"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, dbes)
 }

--- a/model/blocks/parent.go
+++ b/model/blocks/parent.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/filecoin-project/lotus/chain/types"
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -18,6 +20,10 @@ type BlockParent struct {
 }
 
 func (bp *BlockParent) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_parents"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, bp)
 }
 
@@ -41,5 +47,10 @@ func (bps BlockParents) Persist(ctx context.Context, s model.StorageBatch) error
 	}
 	ctx, span := global.Tracer("").Start(ctx, "BlockParents.Persist", trace.WithAttributes(label.Int("count", len(bps))))
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_parents"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, bps)
 }

--- a/model/chain/economics.go
+++ b/model/chain/economics.go
@@ -3,10 +3,12 @@ package chain
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -21,6 +23,10 @@ type ChainEconomics struct {
 }
 
 func (c *ChainEconomics) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "chain_economics"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, c)
 }
 
@@ -32,5 +38,10 @@ func (l ChainEconomicsList) Persist(ctx context.Context, s model.StorageBatch) e
 	}
 	ctx, span := global.Tracer("").Start(ctx, "ChainEconomicsList.Persist", trace.WithAttributes(label.Int("count", len(l))))
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "chain_economics"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, l)
 }

--- a/model/derived/gasoutputs.go
+++ b/model/derived/gasoutputs.go
@@ -3,10 +3,12 @@ package derived
 import (
 	"context"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -38,6 +40,10 @@ type GasOutputs struct {
 }
 
 func (g *GasOutputs) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "derived_gas_outputs"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, g)
 }
 
@@ -49,5 +55,10 @@ func (l GasOutputsList) Persist(ctx context.Context, s model.StorageBatch) error
 	}
 	ctx, span := global.Tracer("").Start(ctx, "GasOutputsList.Persist", trace.WithAttributes(label.Int("count", len(l))))
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "derived_gas_outputs"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, l)
 }

--- a/model/messages/blockmessage.go
+++ b/model/messages/blockmessage.go
@@ -19,6 +19,10 @@ type BlockMessage struct {
 }
 
 func (bm *BlockMessage) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_messages"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, bm)
 }
 
@@ -31,7 +35,7 @@ func (bms BlockMessages) Persist(ctx context.Context, s model.StorageBatch) erro
 	ctx, span := global.Tracer("").Start(ctx, "BlockMessages.Persist", trace.WithAttributes(label.Int("count", len(bms))))
 	defer span.End()
 
-	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, "message/blockmessage"))
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_messages"))
 	stop := metrics.Timer(ctx, metrics.PersistDuration)
 	defer stop()
 

--- a/model/messages/gaseconomy.go
+++ b/model/messages/gaseconomy.go
@@ -3,6 +3,9 @@ package messages
 import (
 	"context"
 
+	"go.opencensus.io/tag"
+
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -23,5 +26,9 @@ type MessageGasEconomy struct {
 }
 
 func (g *MessageGasEconomy) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "message_gas_economy"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, g)
 }

--- a/model/messages/message.go
+++ b/model/messages/message.go
@@ -29,6 +29,10 @@ type Message struct {
 }
 
 func (m *Message) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "messages"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, m)
 }
 
@@ -41,7 +45,7 @@ func (ms Messages) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "Messages.Persist", trace.WithAttributes(label.Int("count", len(ms))))
 	defer span.End()
 
-	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, "message/message"))
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "messages"))
 	stop := metrics.Timer(ctx, metrics.PersistDuration)
 	defer stop()
 

--- a/model/messages/parsedmessage.go
+++ b/model/messages/parsedmessage.go
@@ -24,6 +24,10 @@ type ParsedMessage struct {
 }
 
 func (pm *ParsedMessage) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "parsed_messages"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, pm)
 }
 
@@ -36,7 +40,7 @@ func (pms ParsedMessages) Persist(ctx context.Context, s model.StorageBatch) err
 	ctx, span := global.Tracer("").Start(ctx, "ParsedMessages.Persist", trace.WithAttributes(label.Int("count", len(pms))))
 	defer span.End()
 
-	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, "message/parsed"))
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "parsed_messages"))
 	stop := metrics.Timer(ctx, metrics.PersistDuration)
 	defer stop()
 

--- a/model/messages/receipt.go
+++ b/model/messages/receipt.go
@@ -23,6 +23,10 @@ type Receipt struct {
 }
 
 func (r *Receipt) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "receipts"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, r)
 }
 
@@ -35,7 +39,7 @@ func (rs Receipts) Persist(ctx context.Context, s model.StorageBatch) error {
 	ctx, span := global.Tracer("").Start(ctx, "Receipts.Persist", trace.WithAttributes(label.Int("count", len(rs))))
 	defer span.End()
 
-	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, "message/receipt"))
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "receipts"))
 	stop := metrics.Timer(ctx, metrics.PersistDuration)
 	defer stop()
 

--- a/model/visor/report.go
+++ b/model/visor/report.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"time"
 
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 
+	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
@@ -38,6 +40,10 @@ type ProcessingReport struct {
 }
 
 func (p *ProcessingReport) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "visor_processing_reports"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
 	return s.PersistModel(ctx, p)
 }
 
@@ -49,6 +55,10 @@ func (pl ProcessingReportList) Persist(ctx context.Context, s model.StorageBatch
 	}
 	ctx, span := global.Tracer("").Start(ctx, "ProcessingReportList.Persist", trace.WithAttributes(label.Int("count", len(pl))))
 	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "visor_processing_reports"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
 
 	return s.PersistModel(ctx, pl)
 }


### PR DESCRIPTION
Various cleanups and improvements:
 - ensure only tasks passed on command line are used in task tag on metrics
 - add tag for actor type (for processing metrics)
 - add tag for table name (for persistence metrics)
 - add count of failed processing and persistence functions
 - export the count of lens calls so it is reported properly
 - add metrics to some missed lens calls

