### PR TITLE
chore: increase lens object cache size

### DIFF
--- a/commands/setup.go
+++ b/commands/setup.go
@@ -103,7 +103,7 @@ func setupDatabase(cctx *cli.Context) (*storage.Database, error) {
 func setupLens(cctx *cli.Context) (lens.APIOpener, lens.APICloser, error) {
 	switch cctx.String("lens") {
 	case "lotus":
-		return vapi.NewAPIOpener(cctx, 10_000)
+		return vapi.NewAPIOpener(cctx, 50_000)
 	case "lotusrepo":
 		return repoapi.NewAPIOpener(cctx)
 	case "carrepo":


### PR DESCRIPTION
Metrics show that we are continually fetching ~20k blocks per tipset which suggests that the LRU cache used is too small. Increasing it to 500k made a big difference in performance as shown in grafana screenshot below. This change bumps the LRU to 50k to balance memory consumption with performance.

Top-right: note number of requests being made to API drop off dramatically with a larger LRU
Mid-right: note processing times are lower
Bottom-left: memory consumption is up, but not greatly so

The spikes appear to be unrelated and are not present once visor has been running for a while.

![Screenshot from 2021-02-01 17-40-31](https://user-images.githubusercontent.com/18375/106496322-a7616180-64b4-11eb-8683-6a2f28a527f0.png)
