### PR TITLE
schema: remove use of add_drop_chunks_policy timescale function

### DIFF
--- a/storage/migrations/9_processing_stats.go
+++ b/storage/migrations/9_processing_stats.go
@@ -27,9 +27,6 @@ SELECT create_hypertable(
 	if_not_exists => TRUE
 );
 
--- Set retention policy for stats, 3 months of data
-SELECT add_drop_chunks_policy('visor_processing_stats', INTERVAL '3 months');
-
 `)
 
 	down := batch(`


### PR DESCRIPTION
Created a new database for calibnet analysis and unfortunately it defaults to v2.0.1 of the timescale extension and there is no way to downgrade it. This function has been renamed in v2 so our migration fails. Since this table is no longer used it was simplest to remove the function from the migration.