### PR TITLE
fix(repo-util): set chainstore on repo lens util

### DIFF
--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -78,6 +78,7 @@ func NewAPIOpener(c *cli.Context, bs blockstore.Blockstore, head HeadMthd) (*API
 
 	sm := stmgr.NewStateManager(cs)
 
+	rapi.cs = cs
 	rapi.FullNodeAPI.ChainAPI.Chain = cs
 	rapi.FullNodeAPI.ChainAPI.ChainModuleAPI = &full.ChainModule{Chain: cs}
 	rapi.FullNodeAPI.StateAPI.Chain = cs


### PR DESCRIPTION
Ensure the chain store is set on LensAPI to avoid a null pointer when StateGetActor is called.