### PR TITLE
feat: record multisig approvals

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/filecoin-project/sentinel-visor/model"
 	visormodel "github.com/filecoin-project/sentinel-visor/model/visor"
 	"github.com/filecoin-project/sentinel-visor/tasks/messages"
+	"github.com/filecoin-project/sentinel-visor/tasks/msapprovals"
 )
 
 const (
@@ -32,6 +33,7 @@ const (
 	BlocksTask              = "blocks"              // task that extracts block data
 	MessagesTask            = "messages"            // task that extracts message data
 	ChainEconomicsTask      = "chaineconomics"      // task that extracts chain economics data
+	MultisigApprovalsTask   = "msapprovals"         // task that extracts multisig actor approvals
 )
 
 var log = logging.Logger("chain")
@@ -115,6 +117,8 @@ func NewTipSetIndexer(o lens.APIOpener, d model.Storage, window time.Duration, n
 				CodeV2: sa2builtin.MultisigActorCodeID,
 				CodeV3: sa3builtin.MultisigActorCodeID,
 			})
+		case MultisigApprovalsTask:
+			tsi.messageProcessors[MultisigApprovalsTask] = msapprovals.NewTask(o)
 		default:
 			return nil, xerrors.Errorf("unknown task: %s", task)
 		}

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -39,16 +39,17 @@ var _ TipSetObserver = (*TipSetIndexer)(nil)
 
 // A TipSetWatcher waits for tipsets and persists their block data into a database.
 type TipSetIndexer struct {
-	window          time.Duration
-	storage         model.Storage
-	processors      map[string]TipSetProcessor
-	actorProcessors map[string]ActorProcessor
-	name            string
-	persistSlot     chan struct{}
-	lastTipSet      *types.TipSet
-	node            lens.API
-	opener          lens.APIOpener
-	closer          lens.APICloser
+	window            time.Duration
+	storage           model.Storage
+	processors        map[string]TipSetProcessor
+	messageProcessors map[string]MessageProcessor
+	actorProcessors   map[string]ActorProcessor
+	name              string
+	persistSlot       chan struct{}
+	lastTipSet        *types.TipSet
+	node              lens.API
+	opener            lens.APIOpener
+	closer            lens.APICloser
 }
 
 // A TipSetIndexer extracts block, message and actor state data from a tipset and persists it to storage. Extraction
@@ -57,13 +58,14 @@ type TipSetIndexer struct {
 // indexer is used as the reporter in the visor_processing_reports table.
 func NewTipSetIndexer(o lens.APIOpener, d model.Storage, window time.Duration, name string, tasks []string) (*TipSetIndexer, error) {
 	tsi := &TipSetIndexer{
-		storage:         d,
-		window:          window,
-		name:            name,
-		persistSlot:     make(chan struct{}, 1), // allow one concurrent persistence job
-		processors:      map[string]TipSetProcessor{},
-		actorProcessors: map[string]ActorProcessor{},
-		opener:          o,
+		storage:           d,
+		window:            window,
+		name:              name,
+		persistSlot:       make(chan struct{}, 1), // allow one concurrent persistence job
+		processors:        map[string]TipSetProcessor{},
+		messageProcessors: map[string]MessageProcessor{},
+		actorProcessors:   map[string]ActorProcessor{},
+		opener:            o,
 	}
 
 	for _, task := range tasks {
@@ -71,7 +73,7 @@ func NewTipSetIndexer(o lens.APIOpener, d model.Storage, window time.Duration, n
 		case BlocksTask:
 			tsi.processors[BlocksTask] = NewBlockProcessor()
 		case MessagesTask:
-			tsi.processors[MessagesTask] = NewMessageProcessor(o)
+			tsi.messageProcessors[MessagesTask] = NewMessageExtractor(o)
 		case ChainEconomicsTask:
 			tsi.processors[ChainEconomicsTask] = NewChainEconomicsProcessor(o)
 		case ActorStatesRawTask:
@@ -135,6 +137,8 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 	}
 	defer cancel()
 
+	ll := log.With("height", int64(ts.Height()))
+
 	start := time.Now()
 
 	inFlight := 0
@@ -149,8 +153,8 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 		go t.runProcessor(tctx, p, name, ts, results)
 	}
 
-	// Run each actor processing task concurrently if we have any and we've seen a previous tipset to compare with
-	if len(t.actorProcessors) > 0 {
+	// Run each actor or message processing task concurrently if we have any and we've seen a previous tipset to compare with
+	if len(t.actorProcessors) > 0 || len(t.messageProcessors) > 0 {
 
 		// Actor processors perform a diff between two tipsets so we need to keep track of parent and child
 		var parent, child *types.TipSet
@@ -181,35 +185,64 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 				t.closer = closer
 			}
 
-			changes, err := t.node.StateChangedActors(tctx, parent.ParentState(), child.ParentState())
-			if err != nil {
-
-				terr := xerrors.Errorf("failed to extract actor changes: %w", err)
-				// We need to report that all actor tasks failed
-				for name := range t.actorProcessors {
-					report := &visormodel.ProcessingReport{
-						Height:         int64(ts.Height()),
-						StateRoot:      ts.ParentState().String(),
-						Reporter:       t.name,
-						Task:           name,
-						StartedAt:      start,
-						CompletedAt:    time.Now(),
-						Status:         visormodel.ProcessingStatusError,
-						ErrorsDetected: terr,
+			// If we have message processors then extract the messages and receipts
+			if len(t.messageProcessors) > 0 {
+				emsgs, err := t.node.GetExecutedMessagesForTipset(ctx, child, parent)
+				if err == nil {
+					// Start all the message processors
+					for name, p := range t.messageProcessors {
+						inFlight++
+						go t.runMessageProcessor(tctx, p, name, child, parent, emsgs, results)
 					}
-					taskOutputs[name] = model.PersistableList{report}
+				} else {
+					ll.Errorw("failed to extract messages", "error", err)
+					terr := xerrors.Errorf("failed to extract messages: %w", err)
+					// We need to report that all message tasks failed
+					for name := range t.messageProcessors {
+						report := &visormodel.ProcessingReport{
+							Height:         int64(ts.Height()),
+							StateRoot:      ts.ParentState().String(),
+							Reporter:       t.name,
+							Task:           name,
+							StartedAt:      start,
+							CompletedAt:    time.Now(),
+							Status:         visormodel.ProcessingStatusError,
+							ErrorsDetected: terr,
+						}
+						taskOutputs[name] = model.PersistableList{report}
+					}
 				}
-				return terr
 			}
 
-			for name, p := range t.actorProcessors {
-				inFlight++
-				go t.runActorProcessor(tctx, p, name, child, parent, changes, results)
+			// If we have actor processors then find actors that have changed state
+			if len(t.actorProcessors) > 0 {
+				changes, err := t.node.StateChangedActors(tctx, parent.ParentState(), child.ParentState())
+				if err == nil {
+					for name, p := range t.actorProcessors {
+						inFlight++
+						go t.runActorProcessor(tctx, p, name, child, parent, changes, results)
+					}
+				} else {
+					ll.Errorw("failed to extract actor changes", "error", err)
+					terr := xerrors.Errorf("failed to extract actor changes: %w", err)
+					// We need to report that all actor tasks failed
+					for name := range t.actorProcessors {
+						report := &visormodel.ProcessingReport{
+							Height:         int64(ts.Height()),
+							StateRoot:      ts.ParentState().String(),
+							Reporter:       t.name,
+							Task:           name,
+							StartedAt:      start,
+							CompletedAt:    time.Now(),
+							Status:         visormodel.ProcessingStatusError,
+							ErrorsDetected: terr,
+						}
+						taskOutputs[name] = model.PersistableList{report}
+					}
+				}
 			}
 		}
 	}
-
-	ll := log.With("height", int64(ts.Height()))
 
 	// Wait for all tasks to complete
 	for inFlight > 0 {
@@ -326,6 +359,28 @@ func (t *TipSetIndexer) runProcessor(ctx context.Context, p TipSetProcessor, nam
 	}
 }
 
+func (t *TipSetIndexer) runMessageProcessor(ctx context.Context, p MessageProcessor, name string, ts, pts *types.TipSet, emsgs []*lens.ExecutedMessage, results chan *TaskResult) {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, name))
+	stats.Record(ctx, metrics.TipsetHeight.M(int64(ts.Height())))
+	stop := metrics.Timer(ctx, metrics.ProcessingDuration)
+	defer stop()
+
+	data, report, err := p.ProcessMessages(ctx, ts, pts, emsgs)
+	if err != nil {
+		stats.Record(ctx, metrics.ProcessingFailure.M(1))
+		results <- &TaskResult{
+			Task:  name,
+			Error: err,
+		}
+		return
+	}
+	results <- &TaskResult{
+		Task:   name,
+		Report: report,
+		Data:   data,
+	}
+}
+
 func (t *TipSetIndexer) runActorProcessor(ctx context.Context, p ActorProcessor, name string, ts, pts *types.TipSet, actors map[string]types.Actor, results chan *TaskResult) {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, name))
 	stats.Record(ctx, metrics.TipsetHeight.M(int64(ts.Height())))
@@ -381,6 +436,13 @@ type TipSetProcessor interface {
 	// ProcessTipSet processes a tipset. If error is non-nil then the processor encountered a fatal error.
 	// Any data returned must be accompanied by a processing report.
 	ProcessTipSet(ctx context.Context, ts *types.TipSet) (model.Persistable, *visormodel.ProcessingReport, error)
+	Close() error
+}
+
+type MessageProcessor interface {
+	// ProcessMessages processes messages contained within a tipset. If error is non-nil then the processor encountered a fatal error.
+	// Any data returned must be accompanied by a processing report.
+	ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types.TipSet, emsgs []*lens.ExecutedMessage) (model.Persistable, *visormodel.ProcessingReport, error)
 	Close() error
 }
 

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 	visormodel "github.com/filecoin-project/sentinel-visor/model/visor"
+	"github.com/filecoin-project/sentinel-visor/tasks/messages"
 )
 
 const (
@@ -73,7 +74,7 @@ func NewTipSetIndexer(o lens.APIOpener, d model.Storage, window time.Duration, n
 		case BlocksTask:
 			tsi.processors[BlocksTask] = NewBlockProcessor()
 		case MessagesTask:
-			tsi.messageProcessors[MessagesTask] = NewMessageExtractor(o)
+			tsi.messageProcessors[MessagesTask] = messages.NewTask(o)
 		case ChainEconomicsTask:
 			tsi.processors[ChainEconomicsTask] = NewChainEconomicsProcessor(o)
 		case ActorStatesRawTask:

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -446,6 +446,7 @@ type TipSetProcessor interface {
 
 type MessageProcessor interface {
 	// ProcessMessages processes messages contained within a tipset. If error is non-nil then the processor encountered a fatal error.
+	// pts is the tipset containing the messages, ts is the tipset containing the receipts
 	// Any data returned must be accompanied by a processing report.
 	ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types.TipSet, emsgs []*lens.ExecutedMessage) (model.Persistable, *visormodel.ProcessingReport, error)
 	Close() error

--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -225,7 +225,9 @@ func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 	actorCodes := map[address.Address]cid.Cid{}
 	if err := stateTree.ForEach(func(a address.Address, act *types.Actor) error {
 		actorCodes[a] = act.Code
-		fmt.Printf("found address=%s code=%s\n", a.String(), act.Code.String())
+
+		id, _ := stateTree.LookupID(a)
+		fmt.Printf("found address=%s id=%s code=%s\n", a.String(), id.String(), act.Code.String())
 		return nil
 	}); err != nil {
 		return nil, xerrors.Errorf("iterate actors: %w", err)

--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -242,10 +242,7 @@ func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 
 	getActorCode := func(a address.Address) cid.Cid {
 		ra, found, err := initActorState.ResolveAddress(a)
-		if err == nil && !found {
-			return cid.Undef
-		}
-		if err != nil {
+		if err != nil || !found {
 			return cid.Undef
 		}
 

--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -225,7 +225,6 @@ func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 	actorCodes := map[address.Address]cid.Cid{}
 	if err := stateTree.ForEach(func(a address.Address, act *types.Actor) error {
 		actorCodes[a] = act.Code
-		fmt.Printf("address=%s code=%s\n", a.String(), act.Code.String())
 		return nil
 	}); err != nil {
 		return nil, xerrors.Errorf("iterate actors: %w", err)
@@ -237,6 +236,7 @@ func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 			return c
 		}
 
+		fmt.Printf("unknown address=%s\n", a.String())
 		return cid.Undef
 	}
 

--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -225,13 +225,7 @@ func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 	actorCodes := map[address.Address]cid.Cid{}
 	if err := stateTree.ForEach(func(a address.Address, act *types.Actor) error {
 		actorCodes[a] = act.Code
-		return nil
-	}); err != nil {
-		return nil, xerrors.Errorf("iterate actors: %w", err)
-	}
-
-	if err := parentStateTree.ForEach(func(a address.Address, act *types.Actor) error {
-		actorCodes[a] = act.Code
+		fmt.Printf("found address=%s code=%s\n", a.String(), act.Code.String())
 		return nil
 	}); err != nil {
 		return nil, xerrors.Errorf("iterate actors: %w", err)

--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -2,7 +2,6 @@ package lotus
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
@@ -236,8 +235,6 @@ func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 	actorCodes := map[address.Address]cid.Cid{}
 	if err := stateTree.ForEach(func(a address.Address, act *types.Actor) error {
 		actorCodes[a] = act.Code
-
-		fmt.Printf("found address=%s  code=%s\n", a.String(), act.Code.String())
 		return nil
 	}); err != nil {
 		return nil, xerrors.Errorf("iterate actors: %w", err)
@@ -246,10 +243,9 @@ func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 	getActorCode := func(a address.Address) cid.Cid {
 		ra, found, err := initActorState.ResolveAddress(a)
 		if err == nil && !found {
-			fmt.Printf("not found in init actor address=%s\n", a.String())
+			return cid.Undef
 		}
 		if err != nil {
-			fmt.Printf("resolve address error for address %s: %v\n", a.String(), err)
 			return cid.Undef
 		}
 
@@ -258,7 +254,6 @@ func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 			return c
 		}
 
-		fmt.Printf("unknown address=%s\n", a.String())
 		return cid.Undef
 	}
 

--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -230,6 +230,13 @@ func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 		return nil, xerrors.Errorf("iterate actors: %w", err)
 	}
 
+	if err := parentStateTree.ForEach(func(a address.Address, act *types.Actor) error {
+		actorCodes[a] = act.Code
+		return nil
+	}); err != nil {
+		return nil, xerrors.Errorf("iterate actors: %w", err)
+	}
+
 	getActorCode := func(a address.Address) cid.Cid {
 		c, ok := actorCodes[a]
 		if ok {

--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -2,6 +2,7 @@ package lotus
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
@@ -224,6 +225,7 @@ func (aw *APIWrapper) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 	actorCodes := map[address.Address]cid.Cid{}
 	if err := stateTree.ForEach(func(a address.Address, act *types.Actor) error {
 		actorCodes[a] = act.Code
+		fmt.Printf("address=%s code=%s\n", a.String(), act.Code.String())
 		return nil
 	}); err != nil {
 		return nil, xerrors.Errorf("iterate actors: %w", err)

--- a/model/msapprovals/msapprovals.go
+++ b/model/msapprovals/msapprovals.go
@@ -14,11 +14,13 @@ type MultisigApproval struct {
 	Height         int64    `pg:",pk,notnull,use_zero"`
 	StateRoot      string   `pg:",pk,notnull"`
 	MultisigID     string   `pg:",pk,notnull"`
-	Message        string   `pg:",pk,notnull"` // cid of message
-	TransactionID  int64    `pg:",notnull,use_zero"`
+	Message        string   `pg:",pk,notnull"`       // cid of message
 	Method         uint64   `pg:",notnull,use_zero"` // method number used for the approval 2=propose, 3=approve
+	Approver       string   `pg:",pk,notnull"`       // address of signer that triggerd approval
+	TransactionID  int64    `pg:",notnull,use_zero"`
 	Threshold      uint64   `pg:",notnull,use_zero"`
 	InitialBalance string   `pg:"type:numeric,notnull"`
+	Signers        []string `pg:",notnull"`
 }
 
 func (ma *MultisigApproval) Persist(ctx context.Context, s model.StorageBatch) error {

--- a/model/msapprovals/msapprovals.go
+++ b/model/msapprovals/msapprovals.go
@@ -17,10 +17,13 @@ type MultisigApproval struct {
 	Message        string   `pg:",pk,notnull"`       // cid of message
 	Method         uint64   `pg:",notnull,use_zero"` // method number used for the approval 2=propose, 3=approve
 	Approver       string   `pg:",pk,notnull"`       // address of signer that triggerd approval
-	TransactionID  int64    `pg:",notnull,use_zero"`
 	Threshold      uint64   `pg:",notnull,use_zero"`
 	InitialBalance string   `pg:"type:numeric,notnull"`
 	Signers        []string `pg:",notnull"`
+	GasUsed        int64    `pg:",use_zero"`
+	TransactionID  int64    `pg:",notnull,use_zero"`
+	To             string   `pg:",use_zero"`            // address funds will move to in transaction
+	Value          string   `pg:"type:numeric,notnull"` // amount of funds moved in transaction
 }
 
 func (ma *MultisigApproval) Persist(ctx context.Context, s model.StorageBatch) error {

--- a/model/msapprovals/msapprovals.go
+++ b/model/msapprovals/msapprovals.go
@@ -1,0 +1,43 @@
+package msapprovals
+
+import (
+	"context"
+
+	"go.opencensus.io/tag"
+
+	"github.com/filecoin-project/sentinel-visor/metrics"
+	"github.com/filecoin-project/sentinel-visor/model"
+)
+
+type MultisigApproval struct {
+	tableName      struct{} `pg:"multisig_approvals"` // nolint: structcheck,unused
+	Height         int64    `pg:",pk,notnull,use_zero"`
+	StateRoot      string   `pg:",pk,notnull"`
+	MultisigID     string   `pg:",pk,notnull"`
+	Message        string   `pg:",pk,notnull"` // cid of message
+	TransactionID  int64    `pg:",notnull,use_zero"`
+	Method         uint64   `pg:",notnull,use_zero"` // method number used for the approval 2=propose, 3=approve
+	Threshold      uint64   `pg:",notnull,use_zero"`
+	InitialBalance string   `pg:"type:numeric,notnull"`
+}
+
+func (ma *MultisigApproval) Persist(ctx context.Context, s model.StorageBatch) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "multisig_approvals"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
+	return s.PersistModel(ctx, ma)
+}
+
+type MultisigApprovalList []*MultisigApproval
+
+func (mal MultisigApprovalList) Persist(ctx context.Context, s model.StorageBatch) error {
+	if len(mal) == 0 {
+		return nil
+	}
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "multisig_approvals"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
+	return s.PersistModel(ctx, mal)
+}

--- a/storage/migrations/28_multisig_approvals.go
+++ b/storage/migrations/28_multisig_approvals.go
@@ -1,0 +1,42 @@
+package migrations
+
+import (
+	"github.com/go-pg/migrations/v8"
+)
+
+// Schema version 28 adds multisig_approvals
+
+func init() {
+	up := batch(`
+	CREATE TABLE IF NOT EXISTS "multisig_approvals" (
+		"height"           bigint  not null,
+		"state_root"       text    not null,
+        "multisig_id"      text    not null,
+        "message"          text    not null,
+        "method"           bigint  not null,
+        "approver"         text    not null,
+        "threshold"        bigint  not null,
+        "initial_balance"  numeric not null,
+        "gas_used"         bigint  not null,
+        "transaction_id"   bigint  not null,
+        "to"               text    not null,
+        "value"            numeric not null,
+        "signers"          jsonb  not null,
+        PRIMARY KEY ("height", "state_root", "multisig_id")
+	);
+
+	-- Chunked per 30 days (86400 epochs)
+	SELECT create_hypertable(
+		'multisig_approvals',
+		'height',
+		chunk_time_interval => 86400,
+		if_not_exists => TRUE
+	);
+`)
+
+	down := batch(`
+	DROP TABLE IF EXISTS public.multisig_approvals;
+`)
+
+	migrations.MustRegisterTx(up, down)
+}

--- a/storage/migrations/28_multisig_approvals.go
+++ b/storage/migrations/28_multisig_approvals.go
@@ -22,7 +22,7 @@ func init() {
         "to"               text    not null,
         "value"            numeric not null,
         "signers"          jsonb  not null,
-        PRIMARY KEY ("height", "state_root", "multisig_id")
+        PRIMARY KEY ("height", "state_root", "multisig_id",  "message", "approver")
 	);
 
 	-- Chunked per 30 days (86400 epochs)

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -3,6 +3,10 @@ package storage
 import (
 	"context"
 	"errors"
+	"reflect"
+	"sort"
+	"strings"
+
 	"github.com/go-pg/pg/v10"
 	"github.com/go-pg/pg/v10/orm"
 	"github.com/go-pg/pg/v10/types"
@@ -10,9 +14,6 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/raulk/clock"
 	"golang.org/x/xerrors"
-	"reflect"
-	"sort"
-	"strings"
 
 	"github.com/filecoin-project/sentinel-visor/model"
 	"github.com/filecoin-project/sentinel-visor/model/actors/common"
@@ -26,6 +27,7 @@ import (
 	"github.com/filecoin-project/sentinel-visor/model/chain"
 	"github.com/filecoin-project/sentinel-visor/model/derived"
 	"github.com/filecoin-project/sentinel-visor/model/messages"
+	"github.com/filecoin-project/sentinel-visor/model/msapprovals"
 )
 
 var models = []interface{}{
@@ -63,6 +65,7 @@ var models = []interface{}{
 
 	(*derived.GasOutputs)(nil),
 	(*chain.ChainEconomics)(nil),
+	(*msapprovals.MultisigApproval)(nil),
 }
 
 var log = logging.Logger("storage")

--- a/tasks/actorstate/multisig.go
+++ b/tasks/actorstate/multisig.go
@@ -70,10 +70,32 @@ func ExtractMultisigTransactions(a ActorInfo, ec *MsigExtractionContext) (multis
 		return out, nil
 	}
 
+	previb, _ := ec.PrevState.InitialBalance()
+	prevlb, _ := ec.PrevState.LockedBalance(ec.CurrTs.Height() - 1)
+	prevud, _ := ec.PrevState.UnlockDuration()
+	prevthres, _ := ec.PrevState.Threshold()
+	prevsigners, _ := ec.PrevState.Signers()
+	log.Debugw("multisig previous state", "initial_balance", previb, "locked_balance", prevlb, "unlock_duration", prevud, "threshold", prevthres, "signers", len(prevsigners))
+
+	currib, _ := ec.CurrState.InitialBalance()
+	currlb, _ := ec.CurrState.LockedBalance(ec.CurrTs.Height())
+	currud, _ := ec.CurrState.UnlockDuration()
+	currthres, _ := ec.CurrState.Threshold()
+	currsigners, _ := ec.CurrState.Signers()
+	log.Debugw("multisig current state", "initial_balance", currib, "locked_balance", currlb, "unlock_duration", currud, "threshold", currthres, "signers", len(currsigners))
+
+	// StartEpoch() (abi.ChainEpoch, error)
+	// UnlockDuration() (abi.ChainEpoch, error)
+	// InitialBalance() (abi.TokenAmount, error)
+	// Threshold() (uint64, error)
+	// Signers() ([]address.Address, error)
+
 	changes, err := multisig.DiffPendingTransactions(ec.PrevState, ec.CurrState)
 	if err != nil {
 		return nil, xerrors.Errorf("diffing pending transactions: %w", err)
 	}
+
+	log.Debugw("multisig diff", "added", len(changes.Added), "modified", len(changes.Modified), "removed", len(changes.Removed))
 
 	for _, added := range changes.Added {
 		approved := make([]string, len(added.Tx.Approved))

--- a/tasks/actorstate/multisig.go
+++ b/tasks/actorstate/multisig.go
@@ -70,26 +70,6 @@ func ExtractMultisigTransactions(a ActorInfo, ec *MsigExtractionContext) (multis
 		return out, nil
 	}
 
-	previb, _ := ec.PrevState.InitialBalance()
-	prevlb, _ := ec.PrevState.LockedBalance(ec.CurrTs.Height() - 1)
-	prevud, _ := ec.PrevState.UnlockDuration()
-	prevthres, _ := ec.PrevState.Threshold()
-	prevsigners, _ := ec.PrevState.Signers()
-	log.Debugw("multisig previous state", "initial_balance", previb, "locked_balance", prevlb, "unlock_duration", prevud, "threshold", prevthres, "signers", len(prevsigners))
-
-	currib, _ := ec.CurrState.InitialBalance()
-	currlb, _ := ec.CurrState.LockedBalance(ec.CurrTs.Height())
-	currud, _ := ec.CurrState.UnlockDuration()
-	currthres, _ := ec.CurrState.Threshold()
-	currsigners, _ := ec.CurrState.Signers()
-	log.Debugw("multisig current state", "initial_balance", currib, "locked_balance", currlb, "unlock_duration", currud, "threshold", currthres, "signers", len(currsigners))
-
-	// StartEpoch() (abi.ChainEpoch, error)
-	// UnlockDuration() (abi.ChainEpoch, error)
-	// InitialBalance() (abi.TokenAmount, error)
-	// Threshold() (uint64, error)
-	// Signers() ([]address.Address, error)
-
 	changes, err := multisig.DiffPendingTransactions(ec.PrevState, ec.CurrState)
 	if err != nil {
 		return nil, xerrors.Errorf("diffing pending transactions: %w", err)

--- a/tasks/messages/message.go
+++ b/tasks/messages/message.go
@@ -28,10 +28,9 @@ import (
 var log = logging.Logger("messages")
 
 type Task struct {
-	node       lens.API
-	opener     lens.APIOpener
-	closer     lens.APICloser
-	lastTipSet *types.TipSet
+	node   lens.API
+	opener lens.APIOpener
+	closer lens.APICloser
 }
 
 func NewTask(opener lens.APIOpener) *Task {

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -60,6 +60,7 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 	ll := log.With("height", int64(pts.Height()))
 
 	errorsDetected := make([]*MultisigError, 0, len(emsgs))
+	results := make(msapprovals.MultisigApprovalList, 0) // no inital size capacity since approvals are rare
 
 	for _, m := range emsgs {
 		// Stop processing if we have been told to cancel
@@ -154,6 +155,8 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 
 		log.Debugf("MultisigApproval: %+v", appr)
 
+		results = append(results, &appr)
+
 		// ExitCode exitcode.ExitCode
 		// Return   []byte
 		// GasUsed  int64
@@ -176,7 +179,7 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 		report.ErrorsDetected = errorsDetected
 	}
 
-	return nil, report, nil
+	return results, report, nil
 }
 
 func (p *Task) Close() error {

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -13,7 +13,6 @@ import (
 	sa3builtin "github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	multisig3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/multisig"
 	"github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log/v2"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/sentinel-visor/lens"
@@ -22,18 +21,15 @@ import (
 	visormodel "github.com/filecoin-project/sentinel-visor/model/visor"
 )
 
-var log = logging.Logger("msapprovals")
-
 const (
 	ProposeMethodNum = 2
 	ApproveMethodNum = 3
 )
 
 type Task struct {
-	node       lens.API
-	opener     lens.APIOpener
-	closer     lens.APICloser
-	lastTipSet *types.TipSet
+	node   lens.API
+	opener lens.APIOpener
+	closer lens.APICloser
 }
 
 func NewTask(opener lens.APIOpener) *Task {

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -127,6 +127,7 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 			Message:       m.Cid.String(),
 			TransactionID: int64(ret.TxnID),
 			Method:        uint64(m.Message.Method),
+			Approver:      m.Message.From.String(),
 		}
 
 		ib, err := actorState.InitialBalance()
@@ -139,8 +140,6 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 		}
 		appr.InitialBalance = ib.String()
 
-		log.Debugf("MultisigApproval: %+v", appr)
-
 		signers, err := actorState.Signers()
 		if err != nil {
 			errorsDetected = append(errorsDetected, &MultisigError{
@@ -149,11 +148,11 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 			})
 			continue
 		}
-
 		for _, addr := range signers {
-			log.Debugf("signer: %s", addr.String())
-			// approved[i] = addr.String()
+			appr.Signers = append(appr.Signers, addr.String())
 		}
+
+		log.Debugf("MultisigApproval: %+v", appr)
 
 		// ExitCode exitcode.ExitCode
 		// Return   []byte

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -59,7 +59,7 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 		default:
 		}
 
-		ll.Infow("found message", "to", m.ToActorCode, "addr", m.Message.To.String())
+		ll.Infow("found message", "to", m.ToActorCode.String(), "addr", m.Message.To.String())
 
 		if !isMultisigActor(m.ToActorCode) {
 			continue

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -20,6 +20,8 @@ import (
 
 var log = logging.Logger("msapprovals")
 
+const ProposeMethodNum = 2
+
 type Task struct {
 	node       lens.API
 	opener     lens.APIOpener
@@ -49,7 +51,7 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 		StateRoot: pts.ParentState().String(),
 	}
 
-	ll := log.With("height", int64(ts.Height()))
+	ll := log.With("height", int64(pts.Height()))
 
 	for _, m := range emsgs {
 		// Stop processing if we have been told to cancel
@@ -61,11 +63,28 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 
 		// ll.Infow("found message", "to", m.ToActorCode.String(), "addr", m.Message.To.String())
 
+		// Only interested in messages to multisig actors
 		if !isMultisigActor(m.ToActorCode) {
 			continue
 		}
 
-		ll.Infow("found multisig", "addr", m.Message.To.String())
+		ll.Infow("found multisig", "addr", m.Message.To.String(), "method", m.Message.Method, "exit_code", m.Receipt.ExitCode, "gas_used", m.Receipt.GasUsed)
+
+		// Only interested in propose messages
+		if m.Message.Method != ProposeMethodNum {
+			continue
+		}
+
+		ll.Infow("found multisig", "addr", m.Message.To.String(), "method", m.Message.Method)
+
+		// Only interested in successful messages
+		if !m.Receipt.ExitCode.IsSuccess() {
+			continue
+		}
+
+		// ExitCode exitcode.ExitCode
+		// Return   []byte
+		// GasUsed  int64
 
 	}
 

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -59,7 +59,7 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 		default:
 		}
 
-		ll.Infow("found message", "to", m.ToActorCode.String(), "addr", m.Message.To.String())
+		// ll.Infow("found message", "to", m.ToActorCode.String(), "addr", m.Message.To.String())
 
 		if !isMultisigActor(m.ToActorCode) {
 			continue

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -59,6 +59,8 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 		default:
 		}
 
+		ll.Infow("found message", "to", m.ToActorCode, "addr", m.Message.To.String())
+
 		if !isMultisigActor(m.ToActorCode) {
 			continue
 		}

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -1,0 +1,84 @@
+// Package msapprovals provides a task for recording multisig approvals
+
+package msapprovals
+
+import (
+	"context"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	sa0builtin "github.com/filecoin-project/specs-actors/actors/builtin"
+	sa2builtin "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	sa3builtin "github.com/filecoin-project/specs-actors/v3/actors/builtin"
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/lens"
+	"github.com/filecoin-project/sentinel-visor/model"
+	visormodel "github.com/filecoin-project/sentinel-visor/model/visor"
+)
+
+var log = logging.Logger("msapprovals")
+
+type Task struct {
+	node       lens.API
+	opener     lens.APIOpener
+	closer     lens.APICloser
+	lastTipSet *types.TipSet
+}
+
+func NewTask(opener lens.APIOpener) *Task {
+	return &Task{
+		opener: opener,
+	}
+}
+
+func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types.TipSet, emsgs []*lens.ExecutedMessage) (model.Persistable, *visormodel.ProcessingReport, error) {
+	// TODO: refactor this boilerplate into a helper
+	if p.node == nil {
+		node, closer, err := p.opener.Open(ctx)
+		if err != nil {
+			return nil, nil, xerrors.Errorf("unable to open lens: %w", err)
+		}
+		p.node = node
+		p.closer = closer
+	}
+
+	report := &visormodel.ProcessingReport{
+		Height:    int64(pts.Height()),
+		StateRoot: pts.ParentState().String(),
+	}
+
+	ll := log.With("height", int64(ts.Height()))
+
+	for _, m := range emsgs {
+		// Stop processing if we have been told to cancel
+		select {
+		case <-ctx.Done():
+			return nil, nil, xerrors.Errorf("context done: %w", ctx.Err())
+		default:
+		}
+
+		if !isMultisigActor(m.ToActorCode) {
+			continue
+		}
+
+		ll.Infow("found multisig", "addr", m.Message.To.String())
+
+	}
+
+	return nil, report, nil
+}
+
+func (p *Task) Close() error {
+	if p.closer != nil {
+		p.closer()
+		p.closer = nil
+	}
+	p.node = nil
+	return nil
+}
+
+func isMultisigActor(code cid.Cid) bool {
+	return code == sa0builtin.MultisigActorCodeID || code == sa2builtin.MultisigActorCodeID || code == sa3builtin.MultisigActorCodeID
+}

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -101,8 +101,8 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 
 		ll.Infow("found multisig", "txn_id", ret.TxnID, "applied", ret.Applied, "code", ret.Code)
 
-		// Get state of actor after the message has been applied
-		act, err := p.node.StateGetActor(ctx, m.Message.To, ts.Key())
+		// Get state of actor before the message has been applied
+		act, err := p.node.StateGetActor(ctx, m.Message.To, pts.Key())
 		if err != nil {
 			errorsDetected = append(errorsDetected, &MultisigError{
 				Addr:  m.Message.To.String(),

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -129,6 +129,16 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 		}
 		appr.InitialBalance = ib.String()
 
+		threshold, err := actorState.Threshold()
+		if err != nil {
+			errorsDetected = append(errorsDetected, &MultisigError{
+				Addr:  m.Message.To.String(),
+				Error: xerrors.Errorf("failed to read initial balance: %w", err).Error(),
+			})
+			continue
+		}
+		appr.Threshold = threshold
+
 		signers, err := actorState.Signers()
 		if err != nil {
 			errorsDetected = append(errorsDetected, &MultisigError{

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -65,8 +65,6 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 		default:
 		}
 
-		// ll.Infow("found message", "to", m.ToActorCode.String(), "addr", m.Message.To.String())
-
 		// Only interested in messages to multisig actors
 		if !isMultisigActor(m.ToActorCode) {
 			continue


### PR DESCRIPTION
Create and populate a new `multisig_approvals` table containing multisig transaction approvals derived from propose and approve messages sent to the multisig actor. Create a new task called `msapprovals` to run the extraction. 

Refactored the message task and moved it under the tasks package and then created a msapprovals package as a sibling. Ideally I would like to see all the named tasks move in this way so the chain package just contains chain walking/watching logic.

Anecdotally the `msapprovals`  task takes a few seconds to run per tipset, depending on the number of multisig messages.

(apologies for the dozens of hacky commits which I needed for shipping code for intractive testing - will squash them anyway before merge) 

Fixes #388 