### PR TITLE
chore: make default docker image name deterministic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,6 @@ commands:
       - run: git submodule update --init
   build-docker-and-maybe-push:
     parameters:
-      tagname:
-        description: docker tag name with which to build and push
-        type: string
-        default: $CIRCLE_TAG
       push:
         description: whether to push created docker image after build
         type: boolean
@@ -59,12 +55,15 @@ commands:
                 name: Publish Dev Docker Image to Docker Hub
                 command: |
                   echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-                  ./scripts/push-docker-tags.sh "${IMAGE_NAME}-dev" "$CIRCLE_SHA1" "$CIRCLE_BRANCH" "<< parameters.tagname >>-dev"
+                  tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
+                  ./scripts/push-docker-tags.sh "${IMAGE_NAME}-dev" "$CIRCLE_SHA1" "${CIRCLE_BRANCH}-${tag_suffix}-dev"
             - run:
                 name: Publish Production Docker Image to Docker Hub
                 command: |
                   echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-                  ./scripts/push-docker-tags.sh "$IMAGE_NAME" "$CIRCLE_SHA1" "$CIRCLE_BRANCH" "<< parameters.tagname >>"
+                  tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
+                  ./scripts/push-docker-tags.sh "${IMAGE_NAME}-dev" "$CIRCLE_SHA1" "${CIRCLE_BRANCH}-${tag_suffix}"
+                when: always
 
 jobs:
   build-push-master:
@@ -72,13 +71,11 @@ jobs:
     steps:
       - build-docker-and-maybe-push:
           push: true
-          tagname: master-latest
   build-push-semver-tag:
     executor: dockerizer
     steps:
       - build-docker-and-maybe-push:
           push: true
-          # use default tagname
   mod-tidy-check:
     executor: golang
     steps:

--- a/scripts/push-docker-tags.sh
+++ b/scripts/push-docker-tags.sh
@@ -9,37 +9,35 @@
 # what tag, if any, to push to dockerhub.
 #
 # Usage:
-#   ./push-docker-tags.sh <image name> <git commit sha1> <git branch name> [git tag name] [dry run]
+#   ./push-docker-tags.sh <image name> <git commit sha1> [git tag name] [dry run]
 #
 # Example:
 #   # dry run. pass a 5th arg to have it print what it would do rather than do it.
-#   ./push-docker-tags.sh myiamge testingsha master "" dryrun
+#   ./push-docker-tags.sh myiamge testingsha "" dryrun
 #
 #   # push tag for commit on the main branch
-#   ./push-docker-tags.sh myimage testingsha main
+#   ./push-docker-tags.sh myimage testingsha
 #
 #   # push tag for a new release tag
-#   ./push-docker-tags.sh myimage testingsha release v0.5.0
+#   ./push-docker-tags.sh myimage testingsha v0.5.0
 #
 #   # serving suggestion in circle ci - https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
-#   ./push-docker-tags.sh filecoin/sentinel-visor $CIRCLE_SHA1 $CIRCLE_BRANCH $CIRCLE_TAG
+#   ./push-docker-tags.sh filecoin/sentinel-visor $CIRCLE_SHA1 $CIRCLE_TAG
 #
 set -euo pipefail
 
-if [[ $# -lt 3 ]] ; then
-  echo 'At least 3 args required. Pass 5 args for a dry run.'
+if [[ $# -lt 2 ]] ; then
+  echo 'At least 2 args required. Pass 4 args for a dry run.'
   echo 'Usage:'
-  echo './push-docker-tags.sh <image name> <git commit sha1> <git branch name> [git tag name] [dry run]'
+  echo './push-docker-tags.sh <image name> <git commit sha1> [git tag name] [dry run]'
   exit 1
 fi
 
 IMAGE_NAME=$1
 GIT_SHA1=$2
-GIT_SHA1_SHORT=$(echo "$GIT_SHA1" | cut -c 1-7)
-GIT_BRANCH=$3
-GIT_TAG=${4:-""}
-DRY_RUN=${5:-false}
-DATE_SHORT=$(date -u +%F)
+GIT_SHA1_SHORT=$(echo "$GIT_SHA1" | cut -c 1-8)
+GIT_TAG=${3:-""}
+DRY_RUN=${4:-false}
 
 pushTag () {
   local IMAGE_TAG="${1/\//-}"
@@ -54,8 +52,8 @@ pushTag () {
   fi
 }
 
-if [ -z "$GIT_TAG" ]; then
-	pushTag "$GIT_BRANCH-${DATE_SHORT}-${GIT_SHA1_SHORT}"
+if [ -z "${GIT_TAG}" ]; then
+	pushTag "${GIT_BRANCH}-${GIT_SHA1_SHORT}"
 else
-	pushTag "$GIT_TAG"
+	pushTag "${GIT_TAG}"
 fi


### PR DESCRIPTION
Minor adjustments:
- increase default SHA length to 8 chars
- include truncated SHA as part of tag name for all `master` docker images
- cleanup unused behavior in docker build script

The name adjustments are to support automated deployments of `master` branch with versioned tags.