### PR TITLE
fix(docker): restore semver build; correct names; simplify build pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,50 +32,68 @@ commands:
             - run: sudo apt-get update
       - run: git submodule sync
       - run: git submodule update --init
-  build-docker-and-maybe-push:
-    parameters:
-      push:
-        description: whether to push created docker image after build
-        type: boolean
-        default: false
+  publish-docker-master-production:
     steps:
-      - checkout
-      - setup_remote_docker:
-          version: "18.09.3"
-      - run:
-          name: Build Dev Docker image
-          command: docker build -t ${IMAGE_NAME}-dev -f Dockerfile.dev .
       - run:
           name: Build Production Docker image
           command: docker build -t $IMAGE_NAME -f Dockerfile .
-      - when:
-          condition: << parameters.push >>
-          steps:
-            - run:
-                name: Publish Dev Docker Image to Docker Hub
-                command: |
-                  echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-                  tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-                  ./scripts/push-docker-tags.sh "${IMAGE_NAME}-dev" "$CIRCLE_SHA1" "${CIRCLE_BRANCH}-${tag_suffix}-dev"
-            - run:
-                name: Publish Production Docker Image to Docker Hub
-                command: |
-                  echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-                  tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-                  ./scripts/push-docker-tags.sh "${IMAGE_NAME}-dev" "$CIRCLE_SHA1" "${CIRCLE_BRANCH}-${tag_suffix}"
-                when: always
+      - run:
+          name: Publish Production Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
+            ./scripts/push-docker-tags.sh "${IMAGE_NAME}" "$CIRCLE_SHA1" "${CIRCLE_BRANCH}-${tag_suffix}"
+  publish-docker-master-dev:
+    steps:
+      - run:
+          name: Build Dev Docker image
+          command: docker build -t ${IMAGE_NAME} -f Dockerfile.dev .
+      - run:
+          name: Publish Dev Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
+            ./scripts/push-docker-tags.sh "${IMAGE_NAME}" "$CIRCLE_SHA1" "${CIRCLE_BRANCH}-${tag_suffix}-dev"
+  publish-docker-semver-production:
+    steps:
+      - run:
+          name: Build Production Semver Docker image
+          command: docker build -t ${IMAGE_NAME} -f Dockerfile .
+      - run:
+          name: Publish Production Semver Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            ./scripts/push-docker-tags.sh "${IMAGE_NAME}" "$CIRCLE_SHA1" "${CIRCLE_TAG}"
+  publish-docker-semver-dev:
+    steps:
+      - run:
+          name: Build Dev Semver Docker image
+          command: docker build -t ${IMAGE_NAME} -f Dockerfile.dev .
+      - run:
+          name: Publish Dev Semver Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            ./scripts/push-docker-tags.sh "${IMAGE_NAME}" "$CIRCLE_SHA1" "${CIRCLE_TAG}-dev"
 
 jobs:
-  build-push-master:
+  publish-docker-from-master:
     executor: dockerizer
     steps:
-      - build-docker-and-maybe-push:
-          push: true
-  build-push-semver-tag:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: "18.09.3"
+      - publish-docker-master-dev
+      - publish-docker-master-production
+  publish-docker-from-tag:
     executor: dockerizer
     steps:
-      - build-docker-and-maybe-push:
-          push: true
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: "18.09.3"
+      - publish-docker-semver-dev
+      - publish-docker-semver-production
   mod-tidy-check:
     executor: golang
     steps:
@@ -124,18 +142,18 @@ workflows:
     jobs:
       - mod-tidy-check
       - test
-  docker-and-deploy:
+  build-docker-images:
     # `build-push-*` runs on master or main branches and tags that look like semver
     # see: https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
     jobs:
-      - build-push-master:
+      - publish-docker-from-master:
           # build and push latest master docker image
           filters:
             branches:
               only: /^(master|main)$/
             tags:
               ignore: /.*/
-      - build-push-semver-tag:
+      - publish-docker-from-tag:
           # build and push semver tags docker image
           filters:
             branches:

--- a/scripts/push-docker-tags.sh
+++ b/scripts/push-docker-tags.sh
@@ -9,14 +9,11 @@
 # what tag, if any, to push to dockerhub.
 #
 # Usage:
-#   ./push-docker-tags.sh <image name> <git commit sha1> [git tag name] [dry run]
+#   ./push-docker-tags.sh <image name> <git commit sha1> <docker tag> [dry run]
 #
 # Example:
 #   # dry run. pass a 5th arg to have it print what it would do rather than do it.
 #   ./push-docker-tags.sh myiamge testingsha "" dryrun
-#
-#   # push tag for commit on the main branch
-#   ./push-docker-tags.sh myimage testingsha
 #
 #   # push tag for a new release tag
 #   ./push-docker-tags.sh myimage testingsha v0.5.0
@@ -26,10 +23,10 @@
 #
 set -euo pipefail
 
-if [[ $# -lt 2 ]] ; then
-  echo 'At least 2 args required. Pass 4 args for a dry run.'
+if [[ $# -lt 3 ]] ; then
+  echo 'At least 3 args required. Pass 4 args for a dry run.'
   echo 'Usage:'
-  echo './push-docker-tags.sh <image name> <git commit sha1> [git tag name] [dry run]'
+  echo './push-docker-tags.sh <image name> <git commit sha1> <docker tag> [dry run]'
   exit 1
 fi
 
@@ -40,7 +37,7 @@ GIT_TAG=${3:-""}
 DRY_RUN=${4:-false}
 
 pushTag () {
-  local IMAGE_TAG="${1/\//-}"
+  local IMAGE_TAG="${1//\//-}"
   if [ "$DRY_RUN" != false ]; then
     echo "DRY RUN!"
     echo docker tag "$IMAGE_NAME" "$IMAGE_NAME:$IMAGE_TAG"
@@ -52,8 +49,4 @@ pushTag () {
   fi
 }
 
-if [ -z "${GIT_TAG}" ]; then
-	pushTag "${GIT_BRANCH}-${GIT_SHA1_SHORT}"
-else
-	pushTag "${GIT_TAG}"
-fi
+pushTag "${GIT_TAG}"


### PR DESCRIPTION
This PR includes fixes to further support the automatic deployment pipeline work. Specifically:
- Simplify docker build pipeline and scripts (remove GIT_BRANCH case; isolate workflow commands)
- Fix docker image name (remove extraneous `-dev` on image name)
- Restore semver publishing behavior (trigger was removed in prior PR)
- Fix semver dev image labeled as production
- Fix step names to be understandable in CircleCI UI

Proof of work:
These images were actually pushed to docker hub if you'd like to test them out:
Dev builds have `bin/bash` shell for entrypoint: `docker run -it --rm --entrypoint=/bin/bash filecoin/sentinel-visor:v0.0.0-rc0-dev`
Prod builds have `bin/sh` shell for entrypoint: `docker run -it --rm --entrypoint=/bin/sh filecoin/sentinel-visor:v0.0.0-rc0`

- Example build against `master`: https://app.circleci.com/pipelines/github/filecoin-project/sentinel-visor/1407/workflows/e91e38a0-02a6-4d24-977c-c3f388541ad1/jobs/2892
- Example build aginst tag `v0.0.0-rc0`: https://app.circleci.com/pipelines/github/filecoin-project/sentinel-visor/1411/workflows/9014200a-8828-431f-8709-cf04e2eb93a3/jobs/2899