### PR TITLE
chore: move task implementations out of chain package

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -18,6 +18,9 @@ import (
 	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 	visormodel "github.com/filecoin-project/sentinel-visor/model/visor"
+	"github.com/filecoin-project/sentinel-visor/tasks/actorstate"
+	"github.com/filecoin-project/sentinel-visor/tasks/blocks"
+	"github.com/filecoin-project/sentinel-visor/tasks/chaineconomics"
 	"github.com/filecoin-project/sentinel-visor/tasks/messages"
 	"github.com/filecoin-project/sentinel-visor/tasks/msapprovals"
 )
@@ -83,45 +86,45 @@ func NewTipSetIndexer(o lens.APIOpener, d model.Storage, window time.Duration, n
 	for _, task := range tasks {
 		switch task {
 		case BlocksTask:
-			tsi.processors[BlocksTask] = NewBlockProcessor()
+			tsi.processors[BlocksTask] = blocks.NewTask()
 		case MessagesTask:
 			tsi.messageProcessors[MessagesTask] = messages.NewTask(o)
 		case ChainEconomicsTask:
-			tsi.processors[ChainEconomicsTask] = NewChainEconomicsProcessor(o)
+			tsi.processors[ChainEconomicsTask] = chaineconomics.NewTask(o)
 		case ActorStatesRawTask:
-			tsi.actorProcessors[ActorStatesRawTask] = NewActorStateProcessor(o, &RawActorExtractorMap{})
+			tsi.actorProcessors[ActorStatesRawTask] = actorstate.NewTask(o, &actorstate.RawActorExtractorMap{})
 		case ActorStatesPowerTask:
-			tsi.actorProcessors[ActorStatesPowerTask] = NewActorStateProcessor(o, &TypedActorExtractorMap{
+			tsi.actorProcessors[ActorStatesPowerTask] = actorstate.NewTask(o, &actorstate.TypedActorExtractorMap{
 				CodeV1: sa0builtin.StoragePowerActorCodeID,
 				CodeV2: sa2builtin.StoragePowerActorCodeID,
 				CodeV3: sa3builtin.StoragePowerActorCodeID,
 			})
 		case ActorStatesRewardTask:
-			tsi.actorProcessors[ActorStatesRewardTask] = NewActorStateProcessor(o, &TypedActorExtractorMap{
+			tsi.actorProcessors[ActorStatesRewardTask] = actorstate.NewTask(o, &actorstate.TypedActorExtractorMap{
 				CodeV1: sa0builtin.RewardActorCodeID,
 				CodeV2: sa2builtin.RewardActorCodeID,
 				CodeV3: sa3builtin.RewardActorCodeID,
 			})
 		case ActorStatesMinerTask:
-			tsi.actorProcessors[ActorStatesMinerTask] = NewActorStateProcessor(o, &TypedActorExtractorMap{
+			tsi.actorProcessors[ActorStatesMinerTask] = actorstate.NewTask(o, &actorstate.TypedActorExtractorMap{
 				CodeV1: sa0builtin.StorageMinerActorCodeID,
 				CodeV2: sa2builtin.StorageMinerActorCodeID,
 				CodeV3: sa3builtin.StorageMinerActorCodeID,
 			})
 		case ActorStatesInitTask:
-			tsi.actorProcessors[ActorStatesInitTask] = NewActorStateProcessor(o, &TypedActorExtractorMap{
+			tsi.actorProcessors[ActorStatesInitTask] = actorstate.NewTask(o, &actorstate.TypedActorExtractorMap{
 				CodeV1: sa0builtin.InitActorCodeID,
 				CodeV2: sa2builtin.InitActorCodeID,
 				CodeV3: sa3builtin.InitActorCodeID,
 			})
 		case ActorStatesMarketTask:
-			tsi.actorProcessors[ActorStatesMarketTask] = NewActorStateProcessor(o, &TypedActorExtractorMap{
+			tsi.actorProcessors[ActorStatesMarketTask] = actorstate.NewTask(o, &actorstate.TypedActorExtractorMap{
 				CodeV1: sa0builtin.StorageMarketActorCodeID,
 				CodeV2: sa2builtin.StorageMarketActorCodeID,
 				CodeV3: sa3builtin.StorageMarketActorCodeID,
 			})
 		case ActorStatesMultisigTask:
-			tsi.actorProcessors[ActorStatesMultisigTask] = NewActorStateProcessor(o, &TypedActorExtractorMap{
+			tsi.actorProcessors[ActorStatesMultisigTask] = actorstate.NewTask(o, &actorstate.TypedActorExtractorMap{
 				CodeV1: sa0builtin.MultisigActorCodeID,
 				CodeV2: sa2builtin.MultisigActorCodeID,
 				CodeV3: sa3builtin.MultisigActorCodeID,

--- a/tasks/actorstate/task.go
+++ b/tasks/actorstate/task.go
@@ -17,7 +17,7 @@ import (
 	visormodel "github.com/filecoin-project/sentinel-visor/model/visor"
 )
 
-// An Task processes the extraction of actor state according the allowed types in its extracter map.
+// A Task processes the extraction of actor state according the allowed types in its extracter map.
 type Task struct {
 	node         lens.API
 	opener       lens.APIOpener

--- a/tasks/blocks/task.go
+++ b/tasks/blocks/task.go
@@ -1,4 +1,4 @@
-package chain
+package blocks
 
 import (
 	"context"
@@ -10,14 +10,14 @@ import (
 	visormodel "github.com/filecoin-project/sentinel-visor/model/visor"
 )
 
-type BlockProcessor struct {
+type Task struct {
 }
 
-func NewBlockProcessor() *BlockProcessor {
-	return &BlockProcessor{}
+func NewTask() *Task {
+	return &Task{}
 }
 
-func (p *BlockProcessor) ProcessTipSet(ctx context.Context, ts *types.TipSet) (model.Persistable, *visormodel.ProcessingReport, error) {
+func (p *Task) ProcessTipSet(ctx context.Context, ts *types.TipSet) (model.Persistable, *visormodel.ProcessingReport, error) {
 	var pl model.PersistableList
 	for _, bh := range ts.Blocks() {
 		select {
@@ -39,6 +39,6 @@ func (p *BlockProcessor) ProcessTipSet(ctx context.Context, ts *types.TipSet) (m
 	return pl, report, nil
 }
 
-func (p *BlockProcessor) Close() error {
+func (p *Task) Close() error {
 	return nil
 }

--- a/tasks/chaineconomics/economics.go
+++ b/tasks/chaineconomics/economics.go
@@ -1,4 +1,4 @@
-package chain
+package chaineconomics
 
 import (
 	"context"

--- a/tasks/chaineconomics/economics_test.go
+++ b/tasks/chaineconomics/economics_test.go
@@ -1,4 +1,4 @@
-package chain
+package chaineconomics
 
 import (
 	"context"


### PR DESCRIPTION
Moved all the task-processing code out of chain package and into packages under tasks. Renamed some to align with the names of tasks passed on the command line so they are easier for people to locate. Renamed XYZProcessor to Task where needed. No functional changes.