### PR TITLE
fix: guard concurrent accesses to node api

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -88,7 +88,7 @@ func NewTipSetIndexer(o lens.APIOpener, d model.Storage, window time.Duration, n
 		case BlocksTask:
 			tsi.processors[BlocksTask] = blocks.NewTask()
 		case MessagesTask:
-			tsi.messageProcessors[MessagesTask] = messages.NewTask(o)
+			tsi.messageProcessors[MessagesTask] = messages.NewTask()
 		case ChainEconomicsTask:
 			tsi.processors[ChainEconomicsTask] = chaineconomics.NewTask(o)
 		case ActorStatesRawTask:

--- a/tasks/messages/message.go
+++ b/tasks/messages/message.go
@@ -28,27 +28,13 @@ import (
 var log = logging.Logger("messages")
 
 type Task struct {
-	node   lens.API
-	opener lens.APIOpener
-	closer lens.APICloser
 }
 
-func NewTask(opener lens.APIOpener) *Task {
-	return &Task{
-		opener: opener,
-	}
+func NewTask() *Task {
+	return &Task{}
 }
 
 func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types.TipSet, emsgs []*lens.ExecutedMessage) (model.Persistable, *visormodel.ProcessingReport, error) {
-	if p.node == nil {
-		node, closer, err := p.opener.Open(ctx)
-		if err != nil {
-			return nil, nil, xerrors.Errorf("unable to open lens: %w", err)
-		}
-		p.node = node
-		p.closer = closer
-	}
-
 	report := &visormodel.ProcessingReport{
 		Height:    int64(pts.Height()),
 		StateRoot: pts.ParentState().String(),
@@ -258,11 +244,6 @@ func (p *Task) parseMessageParams(m *types.Message, destCode cid.Cid) (string, s
 }
 
 func (p *Task) Close() error {
-	if p.closer != nil {
-		p.closer()
-		p.closer = nil
-	}
-	p.node = nil
 	return nil
 }
 


### PR DESCRIPTION
Following investigation by @placer14 we suspect the panic in #411 is due to concurrent modifications of the node field in the actor state task. When originally written this code was sequential but recent changes have introduced concurrent accesses to the field, namely when the Close method is called. I speculate this can happen when another task fails while an actor state task is still spawning goroutines. The task failure is detected by the indexer which closes all lenses used by the other running tasks, setting the node field to nil which is then passed to a new goroutine by the still-running task.  

This change guards accesses to the node field with mutexes in each of the tasks. The actor state task checks whether the api lens is available before processing and if it isn't returns a non-fatal error for each actor which will be logged in visor_processing_reports for that tipset+task+actor combination.

Also removed the node field from the messages task since it is not used.

Fixes https://github.com/filecoin-project/sentinel-visor/issues/411