### PR TITLE
feat: add benchmarking of vectors

### DIFF
--- a/vector/README.md
+++ b/vector/README.md
@@ -105,6 +105,26 @@ $ go test -v ./vector/...
 Push your changes to `VECTOR_MANIFEST` up execution in CI.
 
 
+## Running vector benchmarks
+
+The vectors can be executed as part of a Go benchmark suite. The benchmarks output numbers of blockstore gets per operation as a custom metric.
+
+Due to the length of time needed to execute, it is recommended to supply a custom benchtime for running each benchmark and an overall timeout for the test run that is greater than the expected benchtime for all benchmarks.
+
+To run benchmarks for all the vectors
+
+```
+go test -v -bench=BenchmarkExecuteVectors/.* -benchtime 1m -timeout 30m  ./vector/...
+```
+
+To run benchmarks for a single vector:
+
+```
+go test -v -bench=BenchmarkExecuteVectors/QmYhszKDYDFvXyFQF8KefF4M8gcNaoTC8FMYFcgKmfq6pi_miner.* -benchtime 1m -timeout 30m  ./vector/...
+```
+
+Use `go test -run=^$` to disable running the vector tests.
+
 
 
 

--- a/vector/runner.go
+++ b/vector/runner.go
@@ -47,6 +47,7 @@ type Runner struct {
 	schema RunnerSchema
 
 	storage *storage.MemStorage
+	bs      *util.ProxyingBlockstore
 
 	opener lens.APIOpener
 	closer lens.APICloser
@@ -94,6 +95,7 @@ func NewRunner(ctx context.Context, vectorPath string, cacheHint int) (*Runner, 
 	return &Runner{
 		schema:  vs,
 		storage: storage.NewMemStorage(),
+		bs:      cacheDB,
 		opener:  opener,
 		closer:  closer,
 	}, nil
@@ -147,6 +149,15 @@ func (r *Runner) Validate(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (r *Runner) Reset() {
+	r.storage = storage.NewMemStorage()
+	r.bs.ResetMetrics()
+}
+
+func (r *Runner) BlockstoreGetCount() int64 {
+	return r.bs.GetCount()
 }
 
 func modelTypeFromTable(tableName string, expected json.RawMessage, actual []interface{}) (string, error) {

--- a/vector/vector_test.go
+++ b/vector/vector_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestExecuteVectors(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("skipping, short testing specified")
+	}
 	ctx := context.Background()
 	var vectorPaths []string
 	if err := filepath.Walk("./data", func(path string, info os.FileInfo, _ error) error {
@@ -36,6 +39,47 @@ func TestExecuteVectors(t *testing.T) {
 			}
 			if err := runner.Validate(ctx); err != nil {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkExecuteVectors(b *testing.B) {
+	if testing.Short() {
+		b.Skipf("skipping, short testing specified")
+	}
+
+	ctx := context.Background()
+	var vectorPaths []string
+	if err := filepath.Walk("./data", func(path string, info os.FileInfo, _ error) error {
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+		full, err := filepath.Abs(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		vectorPaths = append(vectorPaths, full)
+		return nil
+	}); err != nil {
+		b.Fatal(err)
+	}
+
+	for _, vp := range vectorPaths {
+		vpath := vp
+		b.Run(filepath.Base(vpath), func(b *testing.B) {
+			runner, err := NewRunner(ctx, vpath, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := runner.Run(ctx); err != nil {
+					b.Fatal(err)
+				}
+				b.ReportMetric(float64(runner.BlockstoreGetCount())/float64(b.N), "gets/op")
+				runner.Reset()
 			}
 		})
 	}

--- a/vector/vector_test.go
+++ b/vector/vector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -29,7 +30,7 @@ func TestExecuteVectors(t *testing.T) {
 
 	for _, vp := range vectorPaths {
 		vpath := vp
-		t.Run(filepath.Base(vpath), func(t *testing.T) {
+		t.Run(testName(vpath), func(t *testing.T) {
 			runner, err := NewRunner(ctx, vpath, 0)
 			if err != nil {
 				t.Fatal(err)
@@ -67,7 +68,7 @@ func BenchmarkExecuteVectors(b *testing.B) {
 
 	for _, vp := range vectorPaths {
 		vpath := vp
-		b.Run(filepath.Base(vpath), func(b *testing.B) {
+		b.Run(testName(vpath), func(b *testing.B) {
 			runner, err := NewRunner(ctx, vpath, 0)
 			if err != nil {
 				b.Fatal(err)
@@ -83,4 +84,23 @@ func BenchmarkExecuteVectors(b *testing.B) {
 			}
 		})
 	}
+}
+
+func testName(vpath string) string {
+	name := filepath.Base(vpath)
+
+	ext := filepath.Ext(name)
+
+	if len(ext) > 0 {
+		name = name[:len(name)-len(ext)]
+	}
+
+	if strings.HasPrefix(name, "Qm") {
+		idx := strings.Index(name, "_")
+		if idx > 0 {
+			name = name[idx+1:]
+		}
+	}
+
+	return name
 }


### PR DESCRIPTION
Baseline run

```
17:11 $ go test -v ./vector -run ^$ -bench=.* -benchtime=1m -timeout=30m
goos: linux
goarch: amd64
pkg: github.com/filecoin-project/sentinel-visor/vector
cpu: Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
BenchmarkExecuteVectors
BenchmarkExecuteVectors/market_actor_models_495000_to_495010
BenchmarkExecuteVectors/market_actor_models_495000_to_495010-8         	       3	21806920691 ns/op	   1582196 gets/op	12998351082 B/op	275225185 allocs/op
BenchmarkExecuteVectors/power_actor_modesl_from_495000_to_595010
BenchmarkExecuteVectors/power_actor_modesl_from_495000_to_595010-8     	       9	7077350736 ns/op	     65863 gets/op	5241351523 B/op	91972824 allocs/op
BenchmarkExecuteVectors/chain_economics_models_from_epoch_512980_to_5129990
BenchmarkExecuteVectors/chain_economics_models_from_epoch_512980_to_5129990-8         	   23142	   3216733 ns/op	         0.01296 gets/op	 2390216 B/op	   41717 allocs/op
BenchmarkExecuteVectors/init_actor_model_495000_to_495010
BenchmarkExecuteVectors/init_actor_model_495000_to_495010-8                           	       8	7613673400 ns/op	     83170 gets/op	4869404987 B/op	94529324 allocs/op
BenchmarkExecuteVectors/reward_actor_modesl_from_495000_to_495010
BenchmarkExecuteVectors/reward_actor_modesl_from_495000_to_495010-8                   	      10	6347488744 ns/op	     56320 gets/op	4336520225 B/op	78446833 allocs/op
BenchmarkExecuteVectors/multisig_actor_models_from_431130_to_431140
BenchmarkExecuteVectors/multisig_actor_models_from_431130_to_431140-8                 	      13	5087656900 ns/op	     35144 gets/op	3539729075 B/op	63787492 allocs/op
BenchmarkExecuteVectors/miner_f0114350_miner_info_update_from_epoch_429927_to_429929
BenchmarkExecuteVectors/miner_f0114350_miner_info_update_from_epoch_429927_to_429929-8         	      52	1484633564 ns/op	      2412 gets/op	964417380 B/op	17355877 allocs/op
BenchmarkExecuteVectors/messages_models_from_epoch_512980_to_512990
BenchmarkExecuteVectors/messages_models_from_epoch_512980_to_512990-8                          	      13	4913599605 ns/op	     28052 gets/op	3849413508 B/op	66552727 allocs/op
BenchmarkExecuteVectors/miner_actor_model_for_miner_f020541_from_471000_to_471010
BenchmarkExecuteVectors/miner_actor_model_for_miner_f020541_from_471000_to_471010-8            	      12	5751336192 ns/op	     43997 gets/op	4030282312 B/op	72763845 allocs/op
BenchmarkExecuteVectors/reward_actor_models_from_epoch_512980_to_5129990
BenchmarkExecuteVectors/reward_actor_models_from_epoch_512980_to_5129990-8                     	       8	8415005882 ns/op	     83677 gets/op	5602215364 B/op	101313082 allocs/op
BenchmarkExecuteVectors/block_models_495000_to_4950100
BenchmarkExecuteVectors/block_models_495000_to_4950100-8                                       	   41973	   1800225 ns/op	         0 gets/op	 1526002 B/op	   17196 allocs/op


```

