### PR TITLE
Disable preloader by default (toggle with CLI flag), couple library updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-bitfield v0.2.4
-	github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210308115802-ced2e3b4509a
+	github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210317220859-00d7e157c2a9
 	github.com/filecoin-project/go-fil-markets v1.1.9
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-state-types v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-bitfield v0.2.4
-	github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210317220859-00d7e157c2a9
+	github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210320000622-b8b5d500e368
 	github.com/filecoin-project/go-fil-markets v1.1.9
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-state-types v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/filecoin-project/go-bitfield v0.2.0/go.mod h1:CNl9WG8hgR5mttCnUErjcQj
 github.com/filecoin-project/go-bitfield v0.2.3/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
 github.com/filecoin-project/go-bitfield v0.2.4 h1:uZ7MeE+XfM5lqrHJZ93OnhQKc/rveW8p9au0C68JPgk=
 github.com/filecoin-project/go-bitfield v0.2.4/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
-github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210308115802-ced2e3b4509a h1:c80UjcJBB/WryJ1Lq67uf1CN6if+DnWefWtjmSyzd1o=
-github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210308115802-ced2e3b4509a/go.mod h1:QmOU278LiarmHXSuiE4apM+t4lNI3nd2rbSelrCQckY=
+github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210317220859-00d7e157c2a9 h1:sim8Dgyx3SJyewNy4/WC2goOZOLVXtQ2W0GdjqsRZ9o=
+github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210317220859-00d7e157c2a9/go.mod h1:QmOU278LiarmHXSuiE4apM+t4lNI3nd2rbSelrCQckY=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2 h1:av5fw6wmm58FYMgJeoB/lK9XXrgdugYiTqkdxjTy9k8=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2/go.mod h1:pqTiPHobNkOVM5thSRsHYjyQfq7O5QSCMhvuu9JoDlg=
 github.com/filecoin-project/go-commp-utils v0.0.0-20201119054358-b88f7a96a434 h1:0kHszkYP3hgApcjl5x4rpwONhN9+j7XDobf6at5XfHs=

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/filecoin-project/go-bitfield v0.2.0/go.mod h1:CNl9WG8hgR5mttCnUErjcQj
 github.com/filecoin-project/go-bitfield v0.2.3/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
 github.com/filecoin-project/go-bitfield v0.2.4 h1:uZ7MeE+XfM5lqrHJZ93OnhQKc/rveW8p9au0C68JPgk=
 github.com/filecoin-project/go-bitfield v0.2.4/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
-github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210317220859-00d7e157c2a9 h1:sim8Dgyx3SJyewNy4/WC2goOZOLVXtQ2W0GdjqsRZ9o=
-github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210317220859-00d7e157c2a9/go.mod h1:QmOU278LiarmHXSuiE4apM+t4lNI3nd2rbSelrCQckY=
+github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210320000622-b8b5d500e368 h1:nxghfnS1Sx7h3gQGk8ZuxlyPG2wAAOzrVVJlK3zRWfQ=
+github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210320000622-b8b5d500e368/go.mod h1:QmOU278LiarmHXSuiE4apM+t4lNI3nd2rbSelrCQckY=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2 h1:av5fw6wmm58FYMgJeoB/lK9XXrgdugYiTqkdxjTy9k8=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2/go.mod h1:pqTiPHobNkOVM5thSRsHYjyQfq7O5QSCMhvuu9JoDlg=
 github.com/filecoin-project/go-commp-utils v0.0.0-20201119054358-b88f7a96a434 h1:0kHszkYP3hgApcjl5x4rpwONhN9+j7XDobf6at5XfHs=

--- a/lens/sqlrepo/repo.go
+++ b/lens/sqlrepo/repo.go
@@ -3,7 +3,6 @@ package sqlrepo
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/urfave/cli/v2"
 
@@ -16,18 +15,15 @@ import (
 
 func NewAPIOpener(c *cli.Context) (lens.APIOpener, lens.APICloser, error) {
 	pgbsCfg := pgchainbs.PgBlockstoreConfig{
-		PgxConnectString:        c.String("repo"),
-		CacheInactiveBeforeRead: true,
-		DisableBlocklinkParsing: true,
-		LogCacheStatsOnUSR1:     true,
+		PgxConnectString:         c.String("repo"),
+		InstanceNamespace:        c.String("lens-postgres-namespace"),
+		CachePreloadRecentBlocks: c.Bool("lens-postgres-preload-recents"),
+		CacheInactiveBeforeRead:  true,
+		DisableBlocklinkParsing:  true,
+		LogCacheStatsOnUSR1:      true,
 	}
 
-	enablePreload := os.Getenv("LOTUS_CHAINSTORE_PRELOAD_RECENTS")
-	if enablePreload != "" && enablePreload != "0" && enablePreload != "false" {
-		pgbsCfg.CachePreloadRecentBlocks = true
-	}
-
-	pgbsCfg.InstanceNamespace = c.String("lens-postgres-namespace")
+	// we need *some* namespace specified, otherwise GetFilTipSetHead() can't work
 	if pgbsCfg.InstanceNamespace == "" {
 		pgbsCfg.InstanceNamespace = "main"
 	}

--- a/lens/sqlrepo/repo.go
+++ b/lens/sqlrepo/repo.go
@@ -23,11 +23,6 @@ func NewAPIOpener(c *cli.Context) (lens.APIOpener, lens.APICloser, error) {
 		LogCacheStatsOnUSR1:      true,
 	}
 
-	// we need *some* namespace specified, otherwise GetFilTipSetHead() can't work
-	if pgbsCfg.InstanceNamespace == "" {
-		pgbsCfg.InstanceNamespace = "main"
-	}
-
 	if customCacheSize := c.Int("lens-cache-hint"); customCacheSize != 1024*1024 {
 		pgbsCfg.CacheSizeGiB = uint64(customCacheSize)
 	}

--- a/lens/sqlrepo/repo.go
+++ b/lens/sqlrepo/repo.go
@@ -3,6 +3,7 @@ package sqlrepo
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/urfave/cli/v2"
 
@@ -19,6 +20,11 @@ func NewAPIOpener(c *cli.Context) (lens.APIOpener, lens.APICloser, error) {
 		CacheInactiveBeforeRead: true,
 		DisableBlocklinkParsing: true,
 		LogCacheStatsOnUSR1:     true,
+	}
+
+	enablePreload := os.Getenv("LOTUS_CHAINSTORE_PRELOAD_RECENTS")
+	if enablePreload != "" && enablePreload != "0" && enablePreload != "false" {
+		pgbsCfg.CachePreloadRecentBlocks = true
 	}
 
 	pgbsCfg.InstanceNamespace = c.String("lens-postgres-namespace")

--- a/main.go
+++ b/main.go
@@ -150,7 +150,14 @@ func main() {
 			&cli.StringFlag{
 				Name:    "lens-postgres-namespace",
 				EnvVars: []string{"VISOR_POSTGRES_NAMESPACE"},
-				Value:   "",
+				Value:   "main", // we need *some* namespace specified, otherwise GetFilTipSetHead() can't work
+				Usage:   "Namespace consulted for current chain head and recency records",
+			},
+			&cli.BoolFlag{
+				Name:    "lens-postgres-preload-recents",
+				EnvVars: []string{"VISOR_POSTGRES_PRELOAD_RECENTS"},
+				Value:   false,
+				Usage:   "List recent reads within selected namespace, and preload as much as possible into the LRU",
 			},
 		},
 		Commands: []*cli.Command{


### PR DESCRIPTION
This is a temporary thing to get @thattommyhall over the hump

Tangentially: @iand @hsanjuan can I haz sentinel-visor push perms so I can stop priv-forking?