### PR TITLE
close TipSetObs in walker and watcher

### DIFF
--- a/chain/tipset.go
+++ b/chain/tipset.go
@@ -11,6 +11,7 @@ import (
 // A TipSetObserver waits for notifications of new tipsets.
 type TipSetObserver interface {
 	TipSet(ctx context.Context, ts *types.TipSet) error
+	Close() error
 }
 
 var ErrCacheEmpty = errors.New("cache empty")

--- a/chain/walker.go
+++ b/chain/walker.go
@@ -39,7 +39,13 @@ func (c *Walker) Run(ctx context.Context) error {
 	if err != nil {
 		return xerrors.Errorf("open lens: %w", err)
 	}
-	defer closer()
+
+	defer func() {
+		closer()
+		if err := c.obs.Close(); err != nil {
+			log.Errorw("walker failed to close TipSetObserver", "error", err)
+		}
+	}()
 
 	ts, err := node.ChainHead(ctx)
 	if err != nil {

--- a/chain/watcher.go
+++ b/chain/watcher.go
@@ -40,7 +40,13 @@ func (c *Watcher) Run(ctx context.Context) error {
 	if err != nil {
 		return xerrors.Errorf("open lens: %w", err)
 	}
-	defer closer()
+
+	defer func() {
+		closer()
+		if err := c.obs.Close(); err != nil {
+			log.Errorw("watcher failed to close TipSetObserver", "error", err)
+		}
+	}()
 
 	hc, err := node.ChainNotify(ctx)
 	if err != nil {

--- a/vector/runner.go
+++ b/vector/runner.go
@@ -110,11 +110,6 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return xerrors.Errorf("setup indexer: %w", err)
 	}
-	defer func() {
-		if err := tsIndexer.Close(); err != nil {
-			log.Errorw("failed to close tipset indexer cleanly", "error", err)
-		}
-	}()
 
 	if err := chain.NewWalker(tsIndexer, r.opener, r.schema.Params.From, r.schema.Params.To).Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return err


### PR DESCRIPTION
This change ensures the Run method on walker and watcher will only return once all persistence operations have been completed.