### PR TITLE
fix(indexer): only close TIpSetIndexer in walk and watch

### DIFF
--- a/commands/walk.go
+++ b/commands/walk.go
@@ -104,11 +104,6 @@ func walk(cctx *cli.Context) error {
 	if err != nil {
 		return xerrors.Errorf("setup indexer: %w", err)
 	}
-	defer func() {
-		if err := tsIndexer.Close(); err != nil {
-			log.Errorw("failed to close tipset indexer cleanly", "error", err)
-		}
-	}()
 
 	scheduler.Add(schedule.TaskConfig{
 		Name:                "Walker",

--- a/vector/builder.go
+++ b/vector/builder.go
@@ -105,11 +105,6 @@ func (b *Builder) Build(ctx context.Context) (*BuilderSchema, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("setup indexer: %w", err)
 	}
-	defer func() {
-		if err := tsIndexer.Close(); err != nil {
-			log.Errorw("failed to close tipset indexer cleanly", "error", err)
-		}
-	}()
 
 	if err := chain.NewWalker(tsIndexer, b.opener, b.From, b.To).Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return nil, err


### PR DESCRIPTION
- else subsequent calls to close will hang forever and jobs will never exit, e.g. walk will never exit without this change. Thanks @thattommyhall for reporting.
- fixes logic introduced in 8c6f0eed480c31218cd9de990b21f38127b65a1d