### PR TITLE
chore: run vector tests in parallel

### DIFF
--- a/vector/vector_test.go
+++ b/vector/vector_test.go
@@ -31,6 +31,7 @@ func TestExecuteVectors(t *testing.T) {
 	for _, vp := range vectorPaths {
 		vpath := vp
 		t.Run(testName(vpath), func(t *testing.T) {
+			t.Parallel()
 			runner, err := NewRunner(ctx, vpath, 0)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Reduces vector test runtime from ~1.5min to ~25sec