### PR TITLE
fix(linter): make deps before linting in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
     steps:
       - install-deps
       - prepare
+      - run: make deps
       - run:
           command: make -j3 support/tools/bin/golangci-lint
       - run:

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -122,7 +122,7 @@ func setupDatabase(ctx context.Context, cfg *LilyDatabaseConfig) (*storage.Datab
 
 	// Make sure the schema is a compatible with what this version of Visor requires
 	if err := db.VerifyCurrentSchema(ctx); err != nil {
-		db.Close(ctx)
+		db.Close(ctx) // nolint: errcheck
 		return nil, xerrors.Errorf("verify schema: %w", err)
 	}
 


### PR DESCRIPTION
Linter error attempting to fix:
```
WARN [runner] Can't run linter goanalysis_metalinter: deadcode: analysis skipped: errors in package: [/home/circleci/project/lens/interface.go:14:2: could not import github.com/filecoin-project/lotus/chain/vm (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/chain/vm/syscalls.go:26:2: could not import github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/extern/sector-storage/ffiwrapper/sealer_cgo.go:17:6: could not import github.com/filecoin-project/filecoin-ffi (/home/circleci/project/extern/filecoin-ffi/distributed.go:6:2: could not import github.com/filecoin-project/filecoin-ffi/generated (/home/circleci/project/extern/filecoin-ffi/generated/cgo_helpers.go:13:8: could not import C (cgo preprocessing failed))))) /home/circleci/project/lens/util.go:10:2: could not import github.com/filecoin-project/lotus/node/impl/full (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/node/impl/full/chain.go:34:2: could not import github.com/filecoin-project/lotus/chain/store (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/chain/store/store.go:29:2: could not import github.com/filecoin-project/lotus/chain/vm (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/chain/vm/syscalls.go:26:2: could not import github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/extern/sector-storage/ffiwrapper/sealer_cgo.go:17:6: could not import github.com/filecoin-project/filecoin-ffi (/home/circleci/project/extern/filecoin-ffi/distributed.go:6:2: could not import github.com/filecoin-project/filecoin-ffi/generated (/home/circleci/project/extern/filecoin-ffi/generated/cgo_helpers.go:13:8: could not import C (cgo preprocessing failed)))))))] 
INFO [runner] processing took 4.278µs with stages: max_same_issues: 759ns, path_prettifier: 410ns, skip_dirs: 396ns, nolint: 392ns, max_from_linter: 274ns, cgo: 233ns, uniq_by_line: 193ns, identifier_marker: 187ns, diff: 175ns, source_code: 172ns, skip_files: 167ns, filename_unadjuster: 160ns, autogenerated_exclude: 154ns, path_shortener: 146ns, exclude-rules: 89ns, path_prefixer: 84ns, exclude: 80ns, sort_results: 74ns, max_per_file_from_linter: 68ns, severity-rules: 65ns 
INFO [runner] linters took 2m4.873403488s with stages: goanalysis_metalinter: 2m4.873339399s 
ERRO Running error: deadcode: analysis skipped: errors in package: [/home/circleci/project/lens/interface.go:14:2: could not import github.com/filecoin-project/lotus/chain/vm (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/chain/vm/syscalls.go:26:2: could not import github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/extern/sector-storage/ffiwrapper/sealer_cgo.go:17:6: could not import github.com/filecoin-project/filecoin-ffi (/home/circleci/project/extern/filecoin-ffi/distributed.go:6:2: could not import github.com/filecoin-project/filecoin-ffi/generated (/home/circleci/project/extern/filecoin-ffi/generated/cgo_helpers.go:13:8: could not import C (cgo preprocessing failed))))) /home/circleci/project/lens/util.go:10:2: could not import github.com/filecoin-project/lotus/node/impl/full (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/node/impl/full/chain.go:34:2: could not import github.com/filecoin-project/lotus/chain/store (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/chain/store/store.go:29:2: could not import github.com/filecoin-project/lotus/chain/vm (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/chain/vm/syscalls.go:26:2: could not import github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper (/go/pkg/mod/github.com/filecoin-project/lotus@v1.5.1-0.20210304004200-f7ad0c6a2fac/extern/sector-storage/ffiwrapper/sealer_cgo.go:17:6: could not import github.com/filecoin-project/filecoin-ffi (/home/circleci/project/extern/filecoin-ffi/distributed.go:6:2: could not import github.com/filecoin-project/filecoin-ffi/generated (/home/circleci/project/extern/filecoin-ffi/generated/cgo_helpers.go:13:8: could not import C (cgo preprocessing failed)))))))] 
INFO Memory: 1777 samples, avg is 1208.1MB, max is 2102.5MB 
INFO Execution took 2m59.901994904s               

Exited with code exit status 3

CircleCI received exit code 3
```

Solution:
run `make deps` before linting since code must compile before for linter to work. 