### PR TITLE
feat: add storage configuration to daemon

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"os"
+	"time"
+
+	"github.com/filecoin-project/lotus/node/config"
+	"golang.org/x/xerrors"
+)
+
+// Conf defines the daemon config. It should be compatible with Lotus config.
+type Conf struct {
+	config.Common
+	Client     config.Client
+	Metrics    config.Metrics
+	Chainstore config.Chainstore
+	Storage    StorageConf
+}
+
+type StorageConf struct {
+	Postgresql map[string]PgStorageConf
+	File       map[string]FileStorageConf
+}
+
+type PgStorageConf struct {
+	URL             string
+	PoolSize        int
+	AllowUpsert     bool
+	AllowMigrations bool
+}
+
+type FileStorageConf struct {
+	Format string
+	Path   string
+}
+
+func defaultConf() Conf {
+	return Conf{
+		Common: config.Common{
+			API: config.API{
+				ListenAddress: "/ip4/127.0.0.1/tcp/1234/http",
+				Timeout:       config.Duration(30 * time.Second),
+			},
+			Libp2p: config.Libp2p{
+				ListenAddresses: []string{
+					"/ip4/0.0.0.0/tcp/0",
+					"/ip6/::/tcp/0",
+				},
+				AnnounceAddresses:   []string{},
+				NoAnnounceAddresses: []string{},
+
+				ConnMgrLow:   150,
+				ConnMgrHigh:  180,
+				ConnMgrGrace: config.Duration(20 * time.Second),
+			},
+			Pubsub: config.Pubsub{
+				Bootstrapper: false,
+				DirectPeers:  nil,
+				RemoteTracer: "/dns4/pubsub-tracer.filecoin.io/tcp/4001/p2p/QmTd6UvR47vUidRNZ1ZKXHrAFhqTJAD27rKL9XYghEKgKX",
+			},
+		},
+		Client: config.Client{
+			SimultaneousTransfers: config.DefaultSimultaneousTransfers,
+		},
+		Storage: StorageConf{
+			Postgresql: map[string]PgStorageConf{
+				"Database1": {
+					URL:             "postgres://postgres:password@localhost:5432/postgres",
+					PoolSize:        20,
+					AllowUpsert:     false,
+					AllowMigrations: false,
+				},
+				"Database2": {
+					URL:             "postgres://postgres:password@localhost:5432/postgres",
+					PoolSize:        10,
+					AllowUpsert:     false,
+					AllowMigrations: false,
+				},
+			},
+
+			File: map[string]FileStorageConf{
+				"CSV": {
+					Format: "CSV",
+					Path:   "/tmp",
+				},
+			},
+		},
+	}
+}
+
+func initConfig(path string) error {
+	_, err := os.Stat(path)
+	if err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	c, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	comm, err := config.ConfigComment(defaultConf())
+	if err != nil {
+		return xerrors.Errorf("comment: %w", err)
+	}
+	_, err = c.Write(comm)
+	if err != nil {
+		return xerrors.Errorf("write config: %w", err)
+	}
+
+	if err := c.Close(); err != nil {
+		return xerrors.Errorf("close config: %w", err)
+	}
+	return nil
+}

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -142,9 +142,10 @@ var DaemonCmd = &cli.Command{
 		stop, err := node.New(ctx,
 			// Start Sentinel Dep injection
 			LilyNodeAPIOption(&api),
+			node.Override(new(*config.Conf), modules.LoadConf(daemonFlags.config)),
 			node.Override(new(*events.Events), modules.NewEvents),
 			node.Override(new(*schedule.Scheduler), schedule.NewSchedulerDaemon),
-			node.Override(new(*storage.Catalog), storage.CatalogConstructor(cfg.Storage)),
+			node.Override(new(*storage.Catalog), modules.NewStorageCatalog),
 			// End Injection
 
 			node.Override(new(dtypes.Bootstrapper), isBootstrapper),

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -20,9 +20,11 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/sentinel-visor/commands/util"
+	"github.com/filecoin-project/sentinel-visor/config"
 	"github.com/filecoin-project/sentinel-visor/lens/lily"
 	"github.com/filecoin-project/sentinel-visor/lens/lily/modules"
 	"github.com/filecoin-project/sentinel-visor/schedule"
+	"github.com/filecoin-project/sentinel-visor/storage"
 )
 
 type daemonOpts struct {
@@ -99,7 +101,7 @@ var DaemonCmd = &cli.Command{
 		}
 
 		if daemonFlags.config != "" {
-			initConfig(daemonFlags.config)
+			config.EnsureExists(daemonFlags.config)
 			r.SetConfigPath(daemonFlags.config)
 		}
 
@@ -142,6 +144,7 @@ var DaemonCmd = &cli.Command{
 			LilyNodeAPIOption(&api),
 			node.Override(new(*events.Events), modules.NewEvents),
 			node.Override(new(*schedule.Scheduler), schedule.NewSchedulerDaemon),
+			node.Override(new(*storage.Catalog), storage.CatalogConstructor(cfg.Storage)),
 			// End Injection
 
 			node.Override(new(dtypes.Bootstrapper), isBootstrapper),

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -99,6 +99,7 @@ var DaemonCmd = &cli.Command{
 		}
 
 		if daemonFlags.config != "" {
+			initConfig(daemonFlags.config)
 			r.SetConfigPath(daemonFlags.config)
 		}
 

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -101,7 +101,9 @@ var DaemonCmd = &cli.Command{
 		}
 
 		if daemonFlags.config != "" {
-			config.EnsureExists(daemonFlags.config)
+			if err := config.EnsureExists(daemonFlags.config); err != nil {
+				return xerrors.Errorf("ensuring config is present at %q: %w", daemonFlags.config, err)
+			}
 			r.SetConfigPath(daemonFlags.config)
 		}
 

--- a/commands/walk.go
+++ b/commands/walk.go
@@ -80,13 +80,6 @@ var WalkCmd = &cli.Command{
 			RestartOnCompletion: false,
 			RestartOnFailure:    false,
 			Storage:             walkFlags.storage,
-			Database: &lily.LilyDatabaseConfig{
-				URL:                  VisorCmdFlags.DB,
-				Name:                 VisorCmdFlags.Name,
-				PoolSize:             VisorCmdFlags.DBPoolSize,
-				AllowUpsert:          VisorCmdFlags.DBAllowUpsert,
-				AllowSchemaMigration: VisorCmdFlags.DBAllowMigrations,
-			},
 		}
 
 		watchID, err := lilyAPI.LilyWalk(ctx, cfg)

--- a/commands/walk.go
+++ b/commands/walk.go
@@ -21,10 +21,11 @@ import (
 )
 
 type walkOps struct {
-	from   int64
-	to     int64
-	tasks  string
-	window time.Duration
+	from    int64
+	to      int64
+	tasks   string
+	window  time.Duration
+	storage string
 }
 
 var walkFlags walkOps
@@ -59,6 +60,12 @@ var WalkCmd = &cli.Command{
 			DefaultText: "MaxInt64",
 			Destination: &walkFlags.to,
 		},
+		&cli.StringFlag{
+			Name:        "storage",
+			Usage:       "Name of storage that results will be written to.",
+			Value:       "",
+			Destination: &walkFlags.storage,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		ctx := lotuscli.ReqContext(cctx)
@@ -72,6 +79,7 @@ var WalkCmd = &cli.Command{
 			RestartDelay:        0,
 			RestartOnCompletion: false,
 			RestartOnFailure:    false,
+			Storage:             walkFlags.storage,
 			Database: &lily.LilyDatabaseConfig{
 				URL:                  VisorCmdFlags.DB,
 				Name:                 VisorCmdFlags.Name,

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -29,6 +29,7 @@ type watchOps struct {
 	confidence int
 	tasks      string
 	window     time.Duration
+	storage    string
 }
 
 var watchFlags watchOps
@@ -57,6 +58,12 @@ var WatchCmd = &cli.Command{
 			Value:       builtin.EpochDurationSeconds * time.Second,
 			Destination: &watchFlags.window,
 		},
+		&cli.StringFlag{
+			Name:        "storage",
+			Usage:       "Name of storage that results will be written to.",
+			Value:       "",
+			Destination: &walkFlags.storage,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		ctx := lotuscli.ReqContext(cctx)
@@ -69,6 +76,7 @@ var WatchCmd = &cli.Command{
 			RestartDelay:        0,
 			RestartOnCompletion: false,
 			RestartOnFailure:    false,
+			Storage:             watchFlags.storage,
 			Database: &lily.LilyDatabaseConfig{
 				URL:                  VisorCmdFlags.DB,
 				Name:                 VisorCmdFlags.Name,

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -77,13 +77,6 @@ var WatchCmd = &cli.Command{
 			RestartOnCompletion: false,
 			RestartOnFailure:    false,
 			Storage:             watchFlags.storage,
-			Database: &lily.LilyDatabaseConfig{
-				URL:                  VisorCmdFlags.DB,
-				Name:                 VisorCmdFlags.Name,
-				PoolSize:             VisorCmdFlags.DBPoolSize,
-				AllowUpsert:          VisorCmdFlags.DBAllowUpsert,
-				AllowSchemaMigration: VisorCmdFlags.DBAllowMigrations,
-			},
 		}
 
 		watchID, err := lilyAPI.LilyWatch(ctx, cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -109,6 +109,7 @@ func EnsureExists(path string) error {
 	}
 	_, err = c.Write(comm)
 	if err != nil {
+		_ = c.Close() // ignore error since we are recovering from a write error anyway
 		return xerrors.Errorf("write config: %w", err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-package commands
+package config
 
 import (
 	"os"
@@ -88,7 +88,7 @@ func defaultConf() Conf {
 	}
 }
 
-func initConfig(path string) error {
+func EnsureExists(path string) error {
 	_, err := os.Stat(path)
 	if err == nil {
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
+	github.com/BurntSushi/toml v0.3.1
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/filecoin-project/go-address v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -14,7 +14,6 @@ cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bP
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
-cloud.google.com/go v0.65.0 h1:Dg9iHVQfrhq82rUNu9ZxUDrJLaxFUe/HlCVaLyRruq8=
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -86,11 +85,9 @@ github.com/akavel/rsrc v0.8.0 h1:zjWn7ukO9Kc5Q62DOJCcxGpXC18RawVtYAGdz2aLlfw=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alecthomas/jsonschema v0.0.0-20200530073317-71f438968921/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -326,7 +323,6 @@ github.com/filecoin-project/go-statestore v0.1.1-0.20210311122610-6c7a5aedbdea h
 github.com/filecoin-project/go-statestore v0.1.1-0.20210311122610-6c7a5aedbdea/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
-github.com/filecoin-project/lotus v1.5.3 h1:UUUYuvKcUO79Cnm/TSZbAiSQzh0YU66dXX9QiyHcf2s=
 github.com/filecoin-project/lotus v1.5.3/go.mod h1:rOm4THTYK5YcjJ1o9KAsT2fL6bOVJWzJ8rSY9XRRfho=
 github.com/filecoin-project/lotus v1.5.4-0.20210325181022-885ecb97ad63 h1:YniYbdOK7kTGfJBDZTNPbAR0rHFz2CMzOcJANN7Ktgg=
 github.com/filecoin-project/lotus v1.5.4-0.20210325181022-885ecb97ad63/go.mod h1:6RqlfPc8eMgOOZUptu5bohghGNfQ3v+DiUpRDgJtBsA=
@@ -489,11 +485,9 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
-github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -1925,7 +1919,6 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 h1:ld7aEMNHoBnnDAX15v1T6z31v8HwR2A9FYOuAhWqkwc=
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -2093,7 +2086,6 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200827010519-17fd2f27a9e3/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
-golang.org/x/tools v0.0.0-20201112185108-eeaa07dd7696 h1:Bfazo+enXJET5SbHeh95NtxabJF6fJ9r/jpfRJgd3j4=
 golang.org/x/tools v0.0.0-20201112185108-eeaa07dd7696/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
@@ -2210,7 +2202,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -31,6 +31,7 @@ type LilyWatchConfig struct {
 	RestartOnFailure    bool
 	RestartOnCompletion bool
 	RestartDelay        time.Duration
+	Storage             string // name of storage system to use, may be empty
 
 	Database *LilyDatabaseConfig
 }
@@ -44,6 +45,7 @@ type LilyWalkConfig struct {
 	RestartOnFailure    bool
 	RestartOnCompletion bool
 	RestartDelay        time.Duration
+	Storage             string // name of storage system to use, may be empty
 
 	Database *LilyDatabaseConfig
 }

--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -32,8 +32,6 @@ type LilyWatchConfig struct {
 	RestartOnCompletion bool
 	RestartDelay        time.Duration
 	Storage             string // name of storage system to use, may be empty
-
-	Database *LilyDatabaseConfig
 }
 
 type LilyWalkConfig struct {
@@ -46,16 +44,4 @@ type LilyWalkConfig struct {
 	RestartOnCompletion bool
 	RestartDelay        time.Duration
 	Storage             string // name of storage system to use, may be empty
-
-	Database *LilyDatabaseConfig
-}
-
-type LilyDatabaseConfig struct {
-	URL  string
-	Name string
-
-	PoolSize int
-
-	AllowUpsert          bool
-	AllowSchemaMigration bool
 }

--- a/lens/lily/modules/events.go
+++ b/lens/lily/modules/events.go
@@ -5,6 +5,9 @@ import (
 	"github.com/filecoin-project/lotus/node/impl/full"
 	"github.com/filecoin-project/lotus/node/modules/helpers"
 	"go.uber.org/fx"
+
+	"github.com/filecoin-project/sentinel-visor/config"
+	"github.com/filecoin-project/sentinel-visor/storage"
 )
 
 func NewEvents(mctx helpers.MetricsCtx, lc fx.Lifecycle, chainAPI full.ChainModuleAPI, stateAPI full.StateModuleAPI) *events.Events {
@@ -17,4 +20,14 @@ func NewEvents(mctx helpers.MetricsCtx, lc fx.Lifecycle, chainAPI full.ChainModu
 	}
 
 	return events.NewEventsWithConfidence(mctx, api, 10)
+}
+
+func NewStorageCatalog(mctx helpers.MetricsCtx, lc fx.Lifecycle, cfg *config.Conf) (*storage.Catalog, error) {
+	return storage.NewCatalog(cfg.Storage)
+}
+
+func LoadConf(path string) func(mctx helpers.MetricsCtx, lc fx.Lifecycle) (*config.Conf, error) {
+	return func(mctx helpers.MetricsCtx, lc fx.Lifecycle) (*config.Conf, error) {
+		return config.FromFile(path)
+	}
 }

--- a/storage/catalog.go
+++ b/storage/catalog.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/filecoin-project/sentinel-visor/config"
+	"github.com/filecoin-project/sentinel-visor/model"
+)
+
+func CatalogConstructor(cfg config.StorageConf) func() *Catalog {
+	panic("not implemented yet")
+}
+
+// A Catalog holds a list of pre-configured storage systems and can open them when requested.
+type Catalog struct {
+}
+
+func (c *Catalog) Open(ctx context.Context, name string) (model.Storage, error) {
+	panic("not implemented yet")
+}

--- a/storage/catalog.go
+++ b/storage/catalog.go
@@ -2,19 +2,84 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/filecoin-project/sentinel-visor/config"
 	"github.com/filecoin-project/sentinel-visor/model"
 )
 
-func CatalogConstructor(cfg config.StorageConf) func() *Catalog {
-	panic("not implemented yet")
+type Connector interface {
+	Connect(context.Context) error
+	IsConnected(context.Context) bool
+	Close(context.Context) error
+}
+
+func NewCatalog(cfg config.StorageConf) (*Catalog, error) {
+	c := &Catalog{
+		storages: make(map[string]model.Storage),
+	}
+
+	for name, sc := range cfg.Postgresql {
+		if _, exists := c.storages[name]; exists {
+			return nil, fmt.Errorf("duplicate storage name: %q", name)
+		}
+
+		db, err := NewDatabase(context.TODO(), sc.URL, sc.PoolSize, sc.ApplicationName, sc.AllowUpsert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create postgresql storage %q: %w", name, err)
+		}
+
+		c.storages[name] = db
+	}
+
+	for name, sc := range cfg.File {
+		if _, exists := c.storages[name]; exists {
+			return nil, fmt.Errorf("duplicate storage name: %q", name)
+		}
+
+		switch sc.Format {
+		case "CSV":
+			db, err := NewCSVStorage(sc.Path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create postgresql storage %q: %w", name, err)
+			}
+			c.storages[name] = db
+
+		default:
+			return nil, fmt.Errorf("unsupported format %q for storage %q", sc.Format, name)
+		}
+
+	}
+
+	return c, nil
 }
 
 // A Catalog holds a list of pre-configured storage systems and can open them when requested.
 type Catalog struct {
+	storages map[string]model.Storage
 }
 
-func (c *Catalog) Open(ctx context.Context, name string) (model.Storage, error) {
-	panic("not implemented yet")
+// Connect returns a storage that is ready for use. If name is empty, a null storage will be returned
+func (c *Catalog) Connect(ctx context.Context, name string) (model.Storage, error) {
+	if name == "" {
+		return &NullStorage{}, nil
+	}
+
+	s, exists := c.storages[name]
+	if !exists {
+		return nil, fmt.Errorf("unknown storage: %q", name)
+	}
+
+	// Does this storage need to be connected?
+	cs, ok := s.(Connector)
+	if ok {
+		if !cs.IsConnected(ctx) {
+			err := cs.Connect(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return s, nil
 }

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -105,6 +105,8 @@ func NewDatabase(ctx context.Context, url string, poolSize int, name string, ups
 	}, nil
 }
 
+var _ Connector = (*Database)(nil)
+
 type Database struct {
 	DB     *pg.DB
 	opt    *pg.Options
@@ -161,6 +163,18 @@ func connect(ctx context.Context, opt *pg.Options) (*pg.DB, error) {
 	}
 
 	return db, nil
+}
+
+func (d *Database) IsConnected(ctx context.Context) bool {
+	if d.DB == nil {
+		return false
+	}
+
+	if err := d.DB.Ping(ctx); err != nil {
+		return false
+	}
+
+	return true
 }
 
 func (d *Database) Close(ctx context.Context) error {


### PR DESCRIPTION
This adds a config file to the visor daemon which contains a section for database settings. The name of the storage can then be used when starting a walk or watch job: `visor watch --storage=MyCSV`

The config is shared with the embedded parts of lotus that we use.

Two types of storage are supported: postgresql and file. Multiple instances of each storage type can be specified:

```
[Storage]
  [Storage.Postgresql]
    [Storage.Postgresql.Database1]
      URL = "postgres://postgres:password@localhost:5432/postgres"
      PoolSize = 20
      AllowUpsert = false
    [Storage.Postgresql.Database2]
      URL = "postgres://postgres:password@localhost:5432/sentinel"
      PoolSize = 10
      AllowUpsert = false
  [Storage.File]
    [Storage.File.MyCSV]
      Format = "CSV"
      Path = "/tmp"
```

This config is not read for the single-use `walk` and `watch` commands. They still look for the `--db` style params, but we should consider reworking them to this scheme.

