### PR TITLE
fix: ensure persistence semaphore channel is drained on close

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -472,6 +472,7 @@ func (t *TipSetIndexer) Close() error {
 		// wait for the persistence to finish, which is when the channel can be sent on
 		log.Debug("waiting for persistence to complete")
 		t.persistSlot <- struct{}{}
+		log.Debug("persistence completed")
 	}
 
 	// When we reach here there will always be a single token in the channel (our probe) which needs to be drained so

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -51,7 +51,7 @@ type TipSetIndexer struct {
 	messageProcessors map[string]MessageProcessor
 	actorProcessors   map[string]ActorProcessor
 	name              string
-	persistSlot       chan struct{}
+	persistSlot       chan struct{} // filled with a token when a gorroutine is persisting data
 	lastTipSet        *types.TipSet
 	node              lens.API
 	opener            lens.APIOpener
@@ -331,7 +331,7 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	case t.persistSlot <- struct{}{}:
-		// Slot is free so we can continue
+		// Slot was free so we can continue. Slot is now taken.
 	}
 
 	// Persist all results
@@ -459,8 +459,24 @@ func (t *TipSetIndexer) closeProcessors() error {
 }
 
 func (t *TipSetIndexer) Close() error {
-	// ensure there are no persist go routines left running
-	t.persistSlot <- struct{}{}
+	log.Debug("closing tipset indexer")
+
+	// We need to ensure that any persistence goroutine has completed. Since the channel has capacity 1 we can detect
+	// when the persistence goroutine is running by attempting to send a probe value on the channel. When the channel
+	// contains a token then we are still persisting and we should wait for that to be done.
+	select {
+	case t.persistSlot <- struct{}{}:
+		// no token was in channel so there was no persistence goroutine running
+	default:
+		// channel contained a token so persistence goroutine is running
+		// wait for the persistence to finish, which is when the channel can be sent on
+		log.Debug("waiting for persistence to complete")
+		t.persistSlot <- struct{}{}
+	}
+
+	// When we reach here there will always be a single token in the channel (our probe) which needs to be drained so
+	// the channel is empty for reuse.
+	<-t.persistSlot
 
 	return t.closeProcessors()
 }

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -32,6 +32,12 @@ var Watch = &cli.Command{
 			Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorStatesRawTask}, ","),
 			EnvVars: []string{"VISOR_WATCH_TASKS"},
 		},
+		&cli.DurationFlag{
+			Name:   "window",
+			Usage:  "Time window in which data extraction must be completed.",
+			Value:  builtin.EpochDurationSeconds * time.Second,
+			Hidden: true,
+		},
 	},
 	Action: watch,
 }
@@ -72,7 +78,7 @@ func watch(cctx *cli.Context) error {
 		storage = db
 	}
 
-	tsIndexer, err := chain.NewTipSetIndexer(lensOpener, storage, builtin.EpochDurationSeconds*time.Second, cctx.String("name"), tasks)
+	tsIndexer, err := chain.NewTipSetIndexer(lensOpener, storage, cctx.Duration("window"), cctx.String("name"), tasks)
 	if err != nil {
 		return xerrors.Errorf("setup indexer: %w", err)
 	}

--- a/tasks/actorstate/task.go
+++ b/tasks/actorstate/task.go
@@ -91,7 +91,6 @@ func (t *Task) ProcessActors(ctx context.Context, ts *types.TipSet, pts *types.T
 	for inFlight > 0 {
 		res := <-results
 		inFlight--
-		elapsed := time.Since(start)
 		lla := log.With("height", int64(ts.Height()), "actor", ActorNameByCode(res.Code), "address", res.Address)
 
 		if res.Error != nil {
@@ -111,9 +110,10 @@ func (t *Task) ProcessActors(ctx context.Context, ts *types.TipSet, pts *types.T
 			skippedActors++
 		}
 
-		lla.Debugw("actor returned with data", "time", elapsed)
 		data = append(data, res.Data)
 	}
+
+	log.Debugw("completed processing actor state changes", "height", ts.Height(), "success", len(actors)-len(errorsDetected)-skippedActors, "errors", len(errorsDetected), "skipped", skippedActors, "time", time.Since(start))
 
 	if skippedActors > 0 {
 		report.StatusInformation = fmt.Sprintf("did not parse %d actors", skippedActors)

--- a/tasks/actorstate/task.go
+++ b/tasks/actorstate/task.go
@@ -95,7 +95,7 @@ func (t *Task) ProcessActors(ctx context.Context, ts *types.TipSet, pts *types.T
 
 		if res.Error != nil {
 			lla.Errorw("actor returned with error", "error", res.Error.Error())
-			report.ErrorsDetected = append(errorsDetected, &ActorStateError{
+			errorsDetected = append(errorsDetected, &ActorStateError{
 				Code:    res.Code.String(),
 				Name:    ActorNameByCode(res.Code),
 				Head:    res.Head.String(),


### PR DESCRIPTION
This fixes a hang that can occur when the tipset indexer is exited and restarted (such as when the api is unavailable). When this happened `t.persistSlot` would be filled with a token which caused the restarted indexer to assume there was a persistence goroutine running and wait forever. Fix this by probing the channel and then ensuring the probe token is removed.

Separately fix a bug that was preventing actor task errors from being persisted properly. They were being appended incorrectly to the slice.
