### PR TITLE
feat: clean up command line flags for single-run jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,24 @@
 # Builder
 FROM golang:1.15.2 as builder
+ENV GOROOT=/usr/local/go
 
 # Install deps for filecoin-project/filecoin-ffi
-RUN apt-get update
-RUN apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev
+RUN apt-get update && apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev hwloc libhwloc-dev
 
 WORKDIR /go/src/github.com/filecoin-project/sentinel-visor
 COPY . /go/src/github.com/filecoin-project/sentinel-visor
-RUN make deps && make build
+RUN make deps
+RUN make build
 
 # Runner
 FROM buildpack-deps:buster-curl
 # Grab the things
 COPY --from=builder /go/src/github.com/filecoin-project/sentinel-visor/visor /usr/bin/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libOpenCL.so* /lib/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libhwloc.so* /lib/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libnuma.so* /lib/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libltdl.so* /lib/
 
 ENTRYPOINT ["/usr/bin/visor"]
 CMD ["--help"]
+

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ BUILD_DEPS+=ffi-version-check
 .PHONY: ffi-version-check
 
 
-$(MODULES): $(BUILD_DEPS) ;
+$(MODULES): build/.update-modules ;
 # dummy file that marks the last time modules were updated
 build/.update-modules:
 	git submodule update --init --recursive

--- a/commands/migrate.go
+++ b/commands/migrate.go
@@ -9,18 +9,21 @@ import (
 var MigrateCmd = &cli.Command{
 	Name:  "migrate",
 	Usage: "Reports and verifies the current database schema version and latest available for migration. Use --to or --latest to perform a schema migration.",
-	Flags: []cli.Flag{
-		&cli.IntFlag{
-			Name:  "to",
-			Usage: "Migrate the schema to the `VERSION`.",
-			Value: 0,
+	Flags: flagSet(
+		dbConnectFlags,
+		[]cli.Flag{
+			&cli.IntFlag{
+				Name:  "to",
+				Usage: "Migrate the schema to the `VERSION`.",
+				Value: 0,
+			},
+			&cli.BoolFlag{
+				Name:  "latest",
+				Value: false,
+				Usage: "Migrate the schema to the latest version.",
+			},
 		},
-		&cli.BoolFlag{
-			Name:  "latest",
-			Value: false,
-			Usage: "Migrate the schema to the latest version.",
-		},
-	},
+	),
 	Action: func(cctx *cli.Context) error {
 		if err := setupLogging(cctx); err != nil {
 			return xerrors.Errorf("setup logging: %w", err)

--- a/commands/run.go
+++ b/commands/run.go
@@ -1,8 +1,23 @@
 package commands
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/urfave/cli/v2"
+
+	"github.com/filecoin-project/sentinel-visor/version"
 )
+
+var defaultName = "visor"
+
+func init() {
+	defaultName := "visor_" + version.String()
+	hostname, err := os.Hostname()
+	if err == nil {
+		defaultName = fmt.Sprintf("%s_%s_%d", defaultName, hostname, os.Getpid())
+	}
+}
 
 var RunCmd = &cli.Command{
 	Name:  "run",
@@ -10,5 +25,81 @@ var RunCmd = &cli.Command{
 	Subcommands: []*cli.Command{
 		RunWatchCmd,
 		RunWalkCmd,
+	},
+}
+
+var dbConnectFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "db",
+		EnvVars: []string{"LOTUS_DB"},
+		Value:   "",
+		Usage:   "A connection string for the postgres database, for example postgres://postgres:password@localhost:5432/postgres",
+	},
+	&cli.IntFlag{
+		Name:    "db-pool-size",
+		EnvVars: []string{"LOTUS_DB_POOL_SIZE"},
+		Value:   75,
+	},
+	&cli.StringFlag{
+		Name:    "name",
+		EnvVars: []string{"VISOR_NAME"},
+		Value:   defaultName,
+		Usage:   "A name that helps to identify this instance of visor.",
+	},
+}
+
+var dbBehaviourFlags = []cli.Flag{
+	&cli.BoolFlag{
+		Name:    "db-allow-upsert",
+		EnvVars: []string{"LOTUS_DB_ALLOW_UPSERT"},
+		Value:   false,
+	},
+	&cli.BoolFlag{
+		Name:    "allow-schema-migration",
+		EnvVars: []string{"VISOR_ALLOW_SCHEMA_MIGRATION"},
+		Value:   false,
+	},
+}
+
+var runLensFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "lens",
+		EnvVars: []string{"VISOR_LENS"},
+		Value:   "lotus",
+	},
+	&cli.StringFlag{
+		Name:    "lens-lotus-api",
+		EnvVars: []string{"VISOR_LENS_LOTUS_API"},
+		Value:   "",
+		Usage:   "The multiaddress of a lotus API, needed when using the lotus lens",
+	},
+	&cli.StringFlag{
+		Name:    "lens-repo",
+		EnvVars: []string{"VISOR_LENS_REPO"},
+		Value:   "~/.lotus", // TODO: Consider XDG_DATA_HOME
+		Usage:   "The path of a repo to be opened by the lens",
+	},
+	&cli.IntFlag{
+		Name:    "lens-cache-hint",
+		EnvVars: []string{"VISOR_LENS_CACHE_HINT"},
+		Value:   1024 * 1024,
+	},
+	&cli.StringFlag{
+		Name:    "lens-postgres-namespace",
+		EnvVars: []string{"VISOR_LENS_POSTGRES_NAMESPACE"},
+		Value:   "main", // we need *some* namespace specified, otherwise GetFilTipSetHead() can't work
+		Usage:   "Namespace consulted for current chain head and recency records",
+	},
+	&cli.BoolFlag{
+		Name:    "lens-postgres-preload-recents",
+		EnvVars: []string{"VISOR_LENS_POSTGRES_PRELOAD_RECENTS"},
+		Value:   false,
+		Usage:   "List recent reads within selected namespace, and preload as much as possible into the LRU",
+	},
+	&cli.IntFlag{
+		Name:    "lens-postgres-get-prefetch-depth",
+		EnvVars: []string{"VISOR_LENS_POSTGRES_GET_PREFETCH_DEPTH"},
+		Value:   0,
+		Usage:   "Prefetch that many additional DAG layers of descendents when Get()ing a block",
 	},
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -12,7 +12,7 @@ import (
 var defaultName = "visor"
 
 func init() {
-	defaultName := "visor_" + version.String()
+	defaultName = "visor_" + version.String()
 	hostname, err := os.Hostname()
 	if err == nil {
 		defaultName = fmt.Sprintf("%s_%s_%d", defaultName, hostname, os.Getpid())

--- a/commands/setup.go
+++ b/commands/setup.go
@@ -150,19 +150,17 @@ func setupLogging(cctx *cli.Context) error {
 	}
 
 	llnamed := cctx.String("log-level-named")
-	if llnamed == "" {
-		return nil
-	}
+	if llnamed != "" {
+		for _, llname := range strings.Split(llnamed, ",") {
+			parts := strings.Split(llname, ":")
+			if len(parts) != 2 {
+				return xerrors.Errorf("invalid named log level format: %q", llname)
+			}
+			if err := logging.SetLogLevel(parts[0], parts[1]); err != nil {
+				return xerrors.Errorf("set named log level %q to %q: %w", parts[0], parts[1], err)
+			}
 
-	for _, llname := range strings.Split(llnamed, ",") {
-		parts := strings.Split(llname, ":")
-		if len(parts) != 2 {
-			return xerrors.Errorf("invalid named log level format: %q", llname)
 		}
-		if err := logging.SetLogLevel(parts[0], parts[1]); err != nil {
-			return xerrors.Errorf("set named log level %q to %q: %w", parts[0], parts[1], err)
-		}
-
 	}
 
 	log.Infof("Visor version:%s", version.String())

--- a/commands/util.go
+++ b/commands/util.go
@@ -4,10 +4,21 @@ import (
 	"time"
 
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	"github.com/urfave/cli/v2"
 )
 
 var mainnetGenesis = time.Date(2020, 8, 24, 22, 0, 0, 0, time.UTC)
 
 func estimateCurrentEpoch() int64 {
 	return int64(time.Since(mainnetGenesis) / (builtin.EpochDurationSeconds))
+}
+
+func flagSet(fs ...[]cli.Flag) []cli.Flag {
+	var flags []cli.Flag
+
+	for _, f := range fs {
+		flags = append(flags, f...)
+	}
+
+	return flags
 }

--- a/commands/walk.go
+++ b/commands/walk.go
@@ -116,31 +116,36 @@ var WalkCmd = &cli.Command{
 var RunWalkCmd = &cli.Command{
 	Name:  "walk",
 	Usage: "Walk a range of the filecoin blockchain and process blocks as they are discovered.",
-	Flags: []cli.Flag{
-		&cli.Int64Flag{
-			Name:    "from",
-			Usage:   "Limit actor and message processing to tipsets at or above `HEIGHT`",
-			EnvVars: []string{"VISOR_HEIGHT_FROM"},
+	Flags: flagSet(
+		dbConnectFlags,
+		dbBehaviourFlags,
+		runLensFlags,
+		[]cli.Flag{
+			&cli.Int64Flag{
+				Name:    "from",
+				Usage:   "Limit actor and message processing to tipsets at or above `HEIGHT`",
+				EnvVars: []string{"VISOR_HEIGHT_FROM"},
+			},
+			&cli.Int64Flag{
+				Name:        "to",
+				Usage:       "Limit actor and message processing to tipsets at or below `HEIGHT`",
+				Value:       estimateCurrentEpoch(),
+				DefaultText: "MaxInt64",
+				EnvVars:     []string{"VISOR_HEIGHT_TO"},
+			},
+			&cli.StringFlag{
+				Name:    "tasks",
+				Usage:   "Comma separated list of tasks to run. Each task is reported separately in the database.",
+				Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorStatesRawTask}, ","),
+				EnvVars: []string{"VISOR_WALK_TASKS"},
+			},
+			&cli.StringFlag{
+				Name:   "csv",
+				Usage:  "Path to write csv files.",
+				Hidden: true,
+			},
 		},
-		&cli.Int64Flag{
-			Name:        "to",
-			Usage:       "Limit actor and message processing to tipsets at or below `HEIGHT`",
-			Value:       estimateCurrentEpoch(),
-			DefaultText: "MaxInt64",
-			EnvVars:     []string{"VISOR_HEIGHT_TO"},
-		},
-		&cli.StringFlag{
-			Name:    "tasks",
-			Usage:   "Comma separated list of tasks to run. Each task is reported separately in the database.",
-			Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorStatesRawTask}, ","),
-			EnvVars: []string{"VISOR_WALK_TASKS"},
-		},
-		&cli.StringFlag{
-			Name:   "csv",
-			Usage:  "Path to write csv files.",
-			Hidden: true,
-		},
-	},
+	),
 	Action: func(cctx *cli.Context) error {
 		// Validate flags
 		heightFrom := cctx.Int64("from")

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -113,26 +113,31 @@ var WatchCmd = &cli.Command{
 var RunWatchCmd = &cli.Command{
 	Name:  "watch",
 	Usage: "Watch the head of the filecoin blockchain and process blocks as they arrive.",
-	Flags: []cli.Flag{
-		&cli.IntFlag{
-			Name:    "indexhead-confidence",
-			Usage:   "Sets the size of the cache used to hold tipsets for possible reversion before being committed to the database",
-			Value:   2,
-			EnvVars: []string{"VISOR_INDEXHEAD_CONFIDENCE"},
+	Flags: flagSet(
+		dbConnectFlags,
+		dbBehaviourFlags,
+		runLensFlags,
+		[]cli.Flag{
+			&cli.IntFlag{
+				Name:    "indexhead-confidence",
+				Usage:   "Sets the size of the cache used to hold tipsets for possible reversion before being committed to the database",
+				Value:   2,
+				EnvVars: []string{"VISOR_INDEXHEAD_CONFIDENCE"},
+			},
+			&cli.StringFlag{
+				Name:    "tasks",
+				Usage:   "Comma separated list of tasks to run. Each task is reported separately in the database.",
+				Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorStatesRawTask}, ","),
+				EnvVars: []string{"VISOR_WATCH_TASKS"},
+			},
+			&cli.DurationFlag{
+				Name:   "window",
+				Usage:  "Time window in which data extraction must be completed.",
+				Value:  builtin.EpochDurationSeconds * time.Second,
+				Hidden: true,
+			},
 		},
-		&cli.StringFlag{
-			Name:    "tasks",
-			Usage:   "Comma separated list of tasks to run. Each task is reported separately in the database.",
-			Value:   strings.Join([]string{chain.BlocksTask, chain.MessagesTask, chain.ChainEconomicsTask, chain.ActorStatesRawTask}, ","),
-			EnvVars: []string{"VISOR_WATCH_TASKS"},
-		},
-		&cli.DurationFlag{
-			Name:   "window",
-			Usage:  "Time window in which data extraction must be completed.",
-			Value:  builtin.EpochDurationSeconds * time.Second,
-			Hidden: true,
-		},
-	},
+	),
 	Action: runWatch,
 }
 

--- a/lens/carrepo/carrepo.go
+++ b/lens/carrepo/carrepo.go
@@ -21,7 +21,7 @@ func NewAPIOpener(c *cli.Context) (lens.APIOpener, lens.APICloser, error) {
 		return nil, nil, fmt.Errorf("setting file descriptor limit: %s", err)
 	}
 
-	db, err := carbs.Load(c.String("repo"), false)
+	db, err := carbs.Load(c.String("lens-repo"), false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lens/lotus/lotus.go
+++ b/lens/lotus/lotus.go
@@ -32,8 +32,8 @@ func NewAPIOpener(cctx *cli.Context, cacheSize int) (*APIOpener, lens.APICloser,
 
 	var rawaddr, rawtoken string
 
-	if cctx.IsSet("api") {
-		tokenMaddr := cctx.String("api")
+	if cctx.IsSet("lens-lotus-api") {
+		tokenMaddr := cctx.String("lens-lotus-api")
 		toks := strings.Split(tokenMaddr, ":")
 		if len(toks) != 2 {
 			return nil, nil, fmt.Errorf("invalid api tokens, expected <token>:<maddr>, got: %s", tokenMaddr)
@@ -41,8 +41,8 @@ func NewAPIOpener(cctx *cli.Context, cacheSize int) (*APIOpener, lens.APICloser,
 
 		rawtoken = toks[0]
 		rawaddr = toks[1]
-	} else if cctx.IsSet("repo") {
-		repoPath := cctx.String("repo")
+	} else if cctx.IsSet("lens-repo") {
+		repoPath := cctx.String("lens-repo")
 		p, err := homedir.Expand(repoPath)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("expand home dir (%s): %w", repoPath, err)

--- a/lens/lotus/lotus.go
+++ b/lens/lotus/lotus.go
@@ -66,7 +66,7 @@ func NewAPIOpener(cctx *cli.Context, cacheSize int) (*APIOpener, lens.APICloser,
 		rawaddr = ma.String()
 		rawtoken = string(token)
 	} else {
-		return nil, nil, xerrors.Errorf("cannot connect to lotus api: missing --api or --repo flags")
+		return nil, nil, xerrors.Errorf("cannot connect to lotus api: missing --lens-lotus-api or --lens-repo flags")
 	}
 
 	parsedAddr, err := ma.NewMultiaddr(rawaddr)

--- a/lens/lotusrepo/repo.go
+++ b/lens/lotusrepo/repo.go
@@ -43,7 +43,7 @@ func NewAPIOpener(c *cli.Context) (*APIOpener, lens.APICloser, error) {
 		return nil, nil, fmt.Errorf("setting file descriptor limit: %s", err)
 	}
 
-	r, err := repo.NewFS(c.String("repo"))
+	r, err := repo.NewFS(c.String("lens-repo"))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lens/s3repo/repo.go
+++ b/lens/s3repo/repo.go
@@ -7,7 +7,7 @@ import (
 )
 
 func NewAPIOpener(c *cli.Context) (lens.APIOpener, lens.APICloser, error) {
-	bs, err := NewBlockStore(c.String("repo"))
+	bs, err := NewBlockStore(c.String("lens-repo"))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lens/sqlrepo/repo.go
+++ b/lens/sqlrepo/repo.go
@@ -18,7 +18,7 @@ import (
 
 func NewAPIOpener(c *cli.Context) (lens.APIOpener, lens.APICloser, error) {
 	pgbsCfg := pgchainbs.PgBlockstoreConfig{
-		PgxConnectString:          c.String("repo"),
+		PgxConnectString:          c.String("lens-repo"),
 		InstanceNamespace:         c.String("lens-postgres-namespace"),
 		CachePreloadRecentBlocks:  c.Bool("lens-postgres-preload-recents"),
 		PrefetchDagLayersOnDbRead: int32(c.Int("lens-postgres-get-prefetch-depth")),
@@ -37,7 +37,6 @@ func NewAPIOpener(c *cli.Context) (lens.APIOpener, lens.APICloser, error) {
 	}
 
 	var getHeadWithOffset util.HeadMthd = func(ctx context.Context, lookback int) (*types.TipSetKey, error) {
-
 		tsd, err := pgbs.GetFilTipSetHead(ctx)
 		if err != nil {
 			return nil, err

--- a/lens/vector/repo.go
+++ b/lens/vector/repo.go
@@ -41,7 +41,7 @@ func NewAPIOpener(c *cli.Context) (*APIOpener, lens.APICloser, error) {
 		return nil, nil, fmt.Errorf("setting file descriptor limit: %s", err)
 	}
 
-	r, err := repo.NewFS(c.String("repo"))
+	r, err := repo.NewFS(c.String("lens-repo"))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -37,67 +36,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	defaultName := "visor_" + version.String()
-	hostname, err := os.Hostname()
-	if err == nil {
-		defaultName = fmt.Sprintf("%s_%s_%d", defaultName, hostname, os.Getpid())
-	}
-
 	app := &cli.App{
 		Name:    "visor",
 		Usage:   "Filecoin Chain Monitoring Utility",
 		Version: version.String(),
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:        "lens",
-				EnvVars:     []string{"VISOR_LENS"},
-				Value:       "lotus",
-				Destination: &commands.VisorCmdFlags.Lens,
-			},
-			&cli.StringFlag{
-				Name:        "repo",
-				EnvVars:     []string{"LOTUS_PATH"},
-				Value:       "~/.lotus", // TODO: Consider XDG_DATA_HOME
-				Destination: &commands.VisorCmdFlags.Repo,
-			},
-			&cli.BoolFlag{
-				Name:        "repo-read-only",
-				EnvVars:     []string{"VISOR_REPO_READ_ONLY"},
-				Value:       true,
-				Usage:       "Open the repo in read only mode",
-				Destination: &commands.VisorCmdFlags.RepoRO,
-			},
-			&cli.StringFlag{
-				Name:        "api",
-				EnvVars:     []string{"FULLNODE_API_INFO"},
-				Value:       "",
-				Destination: &commands.VisorCmdFlags.Api,
-			},
-			&cli.StringFlag{
-				Name:        "db",
-				EnvVars:     []string{"LOTUS_DB"},
-				Value:       "",
-				Usage:       "A connection string for the postgres database, for example postgres://postgres:password@localhost:5432/postgres",
-				Destination: &commands.VisorCmdFlags.DB,
-			},
-			&cli.IntFlag{
-				Name:        "db-pool-size",
-				EnvVars:     []string{"LOTUS_DB_POOL_SIZE"},
-				Value:       75,
-				Destination: &commands.VisorCmdFlags.DBPoolSize,
-			},
-			&cli.BoolFlag{
-				Name:        "db-allow-upsert",
-				EnvVars:     []string{"LOTUS_DB_ALLOW_UPSERT"},
-				Value:       false,
-				Destination: &commands.VisorCmdFlags.DBAllowUpsert,
-			},
-			&cli.IntFlag{
-				Name:        "lens-cache-hint",
-				EnvVars:     []string{"VISOR_LENS_CACHE_HINT"},
-				Value:       1024 * 1024,
-				Destination: &commands.VisorCmdFlags.LensCacheHint,
-			},
 			&cli.StringFlag{
 				Name:        "log-level",
 				EnvVars:     []string{"GOLOG_LOG_LEVEL"},
@@ -111,13 +54,6 @@ func main() {
 				Value:       "",
 				Usage:       "A comma delimited list of named loggers and log levels formatted as name:level, for example 'logger1:debug,logger2:info'",
 				Destination: &commands.VisorCmdFlags.LogLevelNamed,
-			},
-			&cli.StringFlag{
-				Name:        "name",
-				EnvVars:     []string{"VISOR_NAME"},
-				Value:       defaultName,
-				Usage:       "A name that helps to identify this instance of visor.",
-				Destination: &commands.VisorCmdFlags.Name,
 			},
 			&cli.BoolFlag{
 				Name:        "tracing",
@@ -155,35 +91,11 @@ func main() {
 				Value:       0.0001,
 				Destination: &commands.VisorCmdFlags.JaegerSamplerParam,
 			},
-			&cli.BoolFlag{
-				Name:        "allow-schema-migration",
-				EnvVars:     []string{"VISOR_ALLOW_SCHEMA_MIGRATION"},
-				Value:       false,
-				Destination: &commands.VisorCmdFlags.DBAllowMigrations,
-			},
 			&cli.StringFlag{
 				Name:        "prometheus-port",
 				EnvVars:     []string{"VISOR_PROMETHEUS_PORT"},
 				Value:       ":9991",
 				Destination: &commands.VisorCmdFlags.PrometheusPort,
-			},
-			&cli.StringFlag{
-				Name:    "lens-postgres-namespace",
-				EnvVars: []string{"VISOR_POSTGRES_NAMESPACE"},
-				Value:   "main", // we need *some* namespace specified, otherwise GetFilTipSetHead() can't work
-				Usage:   "Namespace consulted for current chain head and recency records",
-			},
-			&cli.BoolFlag{
-				Name:    "lens-postgres-preload-recents",
-				EnvVars: []string{"VISOR_POSTGRES_PRELOAD_RECENTS"},
-				Value:   false,
-				Usage:   "List recent reads within selected namespace, and preload as much as possible into the LRU",
-			},
-			&cli.IntFlag{
-				Name:    "lens-postgres-get-prefetch-depth",
-				EnvVars: []string{"VISOR_POSTGRES_GET_PREFETCH_DEPTH"},
-				Value:   0,
-				Usage:   "Prefetch that many additional DAG layers of descendents when Get()ing a block",
 			},
 		},
 		Commands: []*cli.Command{


### PR DESCRIPTION
Builds on #445 to better segregate flags so they only appear on relevant commands. 

The `visor run walk` and `visor run watch` commands now expect their database and lens flags to be specified after the subcommand, instead of after the visor command. This means that where previously we would use:

```
visor --db=foo --lens=lotus walk --from=1000 --to=1001
```

we will now use:

```
visor run walk --db=foo --lens=lotus --from=1000 --to=1001
```

The `migrate` command now also expects flags to be specified after the command.


Some consistency related changes:

 - the `--api` flag has been renamed to `--lens-lotus-api` since it is used by the lotus lens to specify the api that visor will connect to. This reduces confusion from the daemon-oriented `--api` flag which specifies the api address of visor's daemon.
 - the `--repo` flag has been renamed to `--lens-repo` since it is used by various lenses to specify the location of the data file or directory that visor will read from. This distinguishes it from the daemon-oriented `--repo` flag which specifies the path where the visor daemon should write its data.

