### PR TITLE
fix(cli): remove redundant window flags from watch

### DIFF
--- a/commands/watch.go
+++ b/commands/watch.go
@@ -85,18 +85,6 @@ var WatchCmd = &cli.Command{
 			Value:       "",
 			Destination: &watchFlags.name,
 		},
-		&cli.DurationFlag{
-			Name:   "window",
-			Usage:  "Time window in which data extraction must be completed.",
-			Value:  builtin.EpochDurationSeconds * time.Second,
-			Hidden: true,
-		},
-		&cli.DurationFlag{
-			Name:   "window",
-			Usage:  "Time window in which data extraction must be completed.",
-			Value:  builtin.EpochDurationSeconds * time.Second,
-			Hidden: true,
-		},
 	},
 	Action: func(cctx *cli.Context) error {
 		ctx := lotuscli.ReqContext(cctx)


### PR DESCRIPTION
- we only need 1 window flag, else cli library panics