### PR TITLE
fix: docker builds to include hwloc dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.15.2 as builder
 ENV GOROOT=/usr/local/go
 
 # Install deps for filecoin-project/filecoin-ffi
-RUN apt-get update && apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev hwloc libhwloc-dev
+RUN apt-get update
+RUN apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev hwloc libhwloc-dev
 
 WORKDIR /go/src/github.com/filecoin-project/sentinel-visor
 COPY . /go/src/github.com/filecoin-project/sentinel-visor

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.15.2 as builder
 ENV GOROOT=/usr/local/go
 
 # Install deps for filecoin-project/filecoin-ffi
-RUN apt-get update
-RUN apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev hwloc libhwloc-dev
+RUN apt-get update && apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev hwloc libhwloc-dev
 
 WORKDIR /go/src/github.com/filecoin-project/sentinel-visor
 COPY . /go/src/github.com/filecoin-project/sentinel-visor

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM golang:1.15.2
 
 # Install deps for filecoin-project/filecoin-ffi
 RUN apt-get update
-RUN apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev
+RUN apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev hwloc libhwloc-dev
 
 RUN go get github.com/go-delve/delve/cmd/dlv
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,7 @@
 FROM golang:1.15.2
 
 # Install deps for filecoin-project/filecoin-ffi
-RUN apt-get update
-RUN apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev hwloc libhwloc-dev
+RUN apt-get update && apt-get install -y jq mesa-opencl-icd ocl-icd-opencl-dev hwloc libhwloc-dev
 
 RUN go get github.com/go-delve/delve/cmd/dlv
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ testfull: build
 	docker-compose up -d
 	sleep 2
 	./visor migrate --latest
-	TZ= PGSSLMODE=disable go test ./... -v || echo ""
+	-TZ= PGSSLMODE=disable go test ./... -v
 	docker-compose down
 
 # testshort runs tests that don't require external dependencies such as postgres or redis

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ CLEAN+=build/.update-modules
 # tools
 toolspath:=support/tools
 
-
 ldflags=-X=github.com/filecoin-project/sentinel-visor/version.GitVersion=$(GITVERSION)
 ifneq ($(strip $(LDFLAGS)),)
 	ldflags+=-extldflags=$(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,15 @@ build: deps visor
 
 .PHONY: deps
 deps: $(BUILD_DEPS)
+
+.PHONY: vector-setup
+vector-setup: ./vector/data/.complete
+
+./vector/data/.complete:
 	cd ./vector; ./fetch_vectors.sh
+	touch $@
+CLEAN+=./vector/data/.complete
+CLEAN+=./vector/data/*.json
 
 # test starts dependencies and runs all tests
 .PHONY: test
@@ -108,8 +116,6 @@ docker-image:
 .PHONY: clean
 clean:
 	rm -rf $(CLEAN) $(BINS)
-	rm ./vector/data/*json
-.PHONY: vector-clean
 
 .PHONY: dist-clean
 dist-clean:


### PR DESCRIPTION
Noticed CI was broken on master. This has a few improvements.

Fixes:
- fix dev docker build to include hwloc dep ([example](https://app.circleci.com/pipelines/github/filecoin-project/sentinel-visor/1728/workflows/91dba3b9-42a5-40fc-9ad9-6a564c15d5bc/jobs/3798))
- remove vector data from `make dep` target (and from docker images) and add vector data artifacts to `make clean`. Vector data now available as `make vector-setup`.
- remove `||` on `make testfull` hack