### PR TITLE
perf: remove redundant tipset lookups

### DIFF
--- a/tasks/actorstate/actor.go
+++ b/tasks/actorstate/actor.go
@@ -23,7 +23,7 @@ func (ActorExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateA
 	stop := metrics.Timer(ctx, metrics.ProcessingDuration)
 	defer stop()
 
-	ast, err := node.StateReadState(ctx, a.Address, a.TipSet)
+	ast, err := node.StateReadState(ctx, a.Address, a.TipSet.Key())
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/actorstate/actor_test.go
+++ b/tasks/actorstate/actor_test.go
@@ -44,8 +44,7 @@ func TestActorExtractor(t *testing.T) {
 		Address:         expectedAddress,
 		ParentStateRoot: tipset.ParentState(),
 		Epoch:           expectedHieght,
-		TipSet:          tipset.Key(),
-		ParentTipSet:    tipset.Parents(),
+		TipSet:          tipset,
 	}
 
 	ex := actorstate.ActorExtractor{}

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -28,20 +28,25 @@ type ActorInfo struct {
 	Address         address.Address
 	ParentStateRoot cid.Cid
 	Epoch           abi.ChainEpoch
-	TipSet          types.TipSetKey
-	ParentTipSet    types.TipSetKey
+	TipSet          *types.TipSet
+	ParentTipSet    *types.TipSet
 }
 
 // ActorStateAPI is the minimal subset of lens.API that is needed for actor state extraction
 type ActorStateAPI interface {
-	ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
 	ChainGetParentMessages(ctx context.Context, msg cid.Cid) ([]api.Message, error)
 	StateGetReceipt(ctx context.Context, bcid cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error)
-	ChainHasObj(ctx context.Context, obj cid.Cid) (bool, error)
-	ChainReadObj(ctx context.Context, obj cid.Cid) ([]byte, error)
+
+	// TODO(optimize): StateGetActor is just a wrapper around StateManager.LoadActor with a lookup of the tipset which we already have
 	StateGetActor(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*types.Actor, error)
+
+	// TODO(optimize): StateMinerPower is just a wrapper for stmgr.GetPowerRaw which loads the power actor as we do in StoragePowerExtractor
 	StateMinerPower(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*api.MinerPower, error)
+
+	// TODO(optimize): StateReadState looks up the tipset and actor that we already have available
 	StateReadState(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*api.ActorState, error)
+
+	// TODO(remove): StateMinerSectors loads the actor and then calls miner.Load which StorageMinerExtractor already has available
 	StateMinerSectors(ctx context.Context, addr address.Address, bf *bitfield.BitField, tsk types.TipSetKey) ([]*miner.SectorOnChainInfo, error)
 	Store() adt.Store
 }

--- a/tasks/actorstate/actorstate_test.go
+++ b/tasks/actorstate/actorstate_test.go
@@ -68,10 +68,6 @@ func (m *MockAPI) Store() adt.Store {
 	return m.store
 }
 
-func (m *MockAPI) ChainHasObj(ctx context.Context, c cid.Cid) (bool, error) {
-	return m.bs.Has(c)
-}
-
 func (m *MockAPI) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
 	blk, err := m.bs.Get(c)
 	if err != nil {
@@ -83,10 +79,6 @@ func (m *MockAPI) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
 
 func (m *MockAPI) ChainGetParentMessages(ctx context.Context, msg cid.Cid) ([]api.Message, error) {
 	return []api.Message{}, nil
-}
-
-func (m *MockAPI) ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error) {
-	return m.tipsets[tsk], nil
 }
 
 func (m *MockAPI) StateReadState(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*api.ActorState, error) {

--- a/tasks/actorstate/genesis.go
+++ b/tasks/actorstate/genesis.go
@@ -74,8 +74,7 @@ func (p *GenesisProcessor) ProcessGenesis(ctx context.Context, gen *types.TipSet
 				Address:         addr,
 				ParentStateRoot: gen.ParentState(),
 				Epoch:           gen.Height(),
-				TipSet:          gen.Key(),
-				ParentTipSet:    gen.Parents(),
+				TipSet:          gen,
 			}, p.node)
 			if err != nil {
 				return xerrors.Errorf("power actor state: %w", err)
@@ -96,8 +95,7 @@ func (p *GenesisProcessor) ProcessGenesis(ctx context.Context, gen *types.TipSet
 				Address:         addr,
 				ParentStateRoot: gen.ParentState(),
 				Epoch:           gen.Height(),
-				TipSet:          gen.Key(),
-				ParentTipSet:    gen.Parents(),
+				TipSet:          gen,
 			}, p.node)
 			if err != nil {
 				return xerrors.Errorf("storage miner actor state: %w", err)
@@ -113,8 +111,7 @@ func (p *GenesisProcessor) ProcessGenesis(ctx context.Context, gen *types.TipSet
 				Address:         addr,
 				ParentStateRoot: gen.ParentState(),
 				Epoch:           gen.Height(),
-				TipSet:          gen.Key(),
-				ParentTipSet:    gen.Parents(),
+				TipSet:          gen,
 			}, p.node)
 			if err != nil {
 				return xerrors.Errorf("multisig actor state: %w", err)

--- a/tasks/actorstate/init.go
+++ b/tasks/actorstate/init.go
@@ -54,7 +54,7 @@ func (InitExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAP
 		}
 		return out, nil
 	}
-	prevActor, err := node.StateGetActor(ctx, a.Address, a.ParentTipSet)
+	prevActor, err := node.StateGetActor(ctx, a.Address, a.ParentTipSet.Key())
 	if err != nil {
 		return nil, xerrors.Errorf("loading previous init actor: %w", err)
 	}

--- a/tasks/actorstate/init_test.go
+++ b/tasks/actorstate/init_test.go
@@ -56,8 +56,7 @@ func TestInitExtractorV0(t *testing.T) {
 			Epoch:           0, // genesis
 			Actor:           types.Actor{Code: sa0builtin.InitActorCodeID, Head: stateCid},
 			Address:         init_.Address,
-			ParentTipSet:    stateTs.Parents(),
-			TipSet:          stateTs.Key(),
+			TipSet:          stateTs,
 			ParentStateRoot: stateTs.ParentState(),
 		}
 
@@ -108,8 +107,8 @@ func TestInitExtractorV0(t *testing.T) {
 			Epoch:           1,
 			Actor:           types.Actor{Code: sa0builtin.InitActorCodeID, Head: stateCid},
 			Address:         init_.Address,
-			ParentTipSet:    baseTs.Key(),
-			TipSet:          stateTs.Key(),
+			ParentTipSet:    baseTs,
+			TipSet:          stateTs,
 			ParentStateRoot: baseStateCid,
 		}
 
@@ -162,8 +161,7 @@ func TestInitExtractorV2(t *testing.T) {
 			Epoch:           0, // genesis
 			Actor:           types.Actor{Code: sa2builtin.InitActorCodeID, Head: stateCid},
 			Address:         init_.Address,
-			ParentTipSet:    stateTs.Parents(),
-			TipSet:          stateTs.Key(),
+			TipSet:          stateTs,
 			ParentStateRoot: stateTs.ParentState(),
 		}
 
@@ -214,8 +212,8 @@ func TestInitExtractorV2(t *testing.T) {
 			Epoch:           1,
 			Actor:           types.Actor{Code: sa2builtin.InitActorCodeID, Head: stateCid},
 			Address:         init_.Address,
-			ParentTipSet:    baseTs.Key(),
-			TipSet:          stateTs.Key(),
+			ParentTipSet:    baseTs,
+			TipSet:          stateTs,
 			ParentStateRoot: baseStateCid,
 		}
 
@@ -268,8 +266,7 @@ func TestInitExtractorV3(t *testing.T) {
 			Epoch:           0, // genesis
 			Actor:           types.Actor{Code: sa3builtin.InitActorCodeID, Head: stateCid},
 			Address:         init_.Address,
-			ParentTipSet:    stateTs.Parents(),
-			TipSet:          stateTs.Key(),
+			TipSet:          stateTs,
 			ParentStateRoot: stateTs.ParentState(),
 		}
 
@@ -320,8 +317,8 @@ func TestInitExtractorV3(t *testing.T) {
 			Epoch:           1,
 			Actor:           types.Actor{Code: sa3builtin.InitActorCodeID, Head: stateCid},
 			Address:         init_.Address,
-			ParentTipSet:    baseTs.Key(),
-			TipSet:          stateTs.Key(),
+			ParentTipSet:    baseTs,
+			TipSet:          stateTs,
 			ParentStateRoot: baseStateCid,
 		}
 
@@ -374,8 +371,7 @@ func TestInitExtractorV4(t *testing.T) {
 			Epoch:           0, // genesis
 			Actor:           types.Actor{Code: sa4builtin.InitActorCodeID, Head: stateCid},
 			Address:         init_.Address,
-			ParentTipSet:    stateTs.Parents(),
-			TipSet:          stateTs.Key(),
+			TipSet:          stateTs,
 			ParentStateRoot: stateTs.ParentState(),
 		}
 
@@ -426,8 +422,8 @@ func TestInitExtractorV4(t *testing.T) {
 			Epoch:           1,
 			Actor:           types.Actor{Code: sa4builtin.InitActorCodeID, Head: stateCid},
 			Address:         init_.Address,
-			ParentTipSet:    baseTs.Key(),
-			TipSet:          stateTs.Key(),
+			ParentTipSet:    baseTs,
+			TipSet:          stateTs,
 			ParentStateRoot: baseStateCid,
 		}
 

--- a/tasks/actorstate/market_test.go
+++ b/tasks/actorstate/market_test.go
@@ -131,7 +131,7 @@ func TestMarketPredicates(t *testing.T) {
 
 	newStateCid := mapi.mustCreateMarketState(ctx, newDeals, newProps, newBalances)
 
-	minerAddr := tutils.NewIDAddr(t, 00)
+	minerAddr := tutils.NewIDAddr(t, 0o0)
 
 	oldStateTs := mapi.fakeTipset(minerAddr, 1)
 	mapi.setActor(oldStateTs.Key(), market.Address, &types.Actor{Code: sabuiltin.StorageMarketActorCodeID, Head: oldStateCid})
@@ -141,8 +141,8 @@ func TestMarketPredicates(t *testing.T) {
 	info := actorstate.ActorInfo{
 		Actor:        types.Actor{Code: sabuiltin.StorageMarketActorCodeID, Head: newStateCid},
 		Address:      market.Address,
-		TipSet:       newStateTs.Key(),
-		ParentTipSet: oldStateTs.Key(),
+		TipSet:       newStateTs,
+		ParentTipSet: oldStateTs,
 		Epoch:        1, // must be greater than zero else this has special handling for genesis block.
 	}
 

--- a/tasks/actorstate/multisig_test.go
+++ b/tasks/actorstate/multisig_test.go
@@ -87,8 +87,8 @@ func TestMultisigExtractorV0(t *testing.T) {
 			Actor:        types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: txStateCid},
 			Epoch:        1, // not genesis
 			Address:      multiSigAddress,
-			TipSet:       txStateTs.Key(),
-			ParentTipSet: emptyTxStateTs.Key(),
+			TipSet:       txStateTs,
+			ParentTipSet: emptyTxStateTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -173,8 +173,8 @@ func TestMultisigExtractorV0(t *testing.T) {
 			Actor:        types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: secondTxStateCid},
 			Epoch:        1, // not genesis
 			Address:      multiSigAddress,
-			TipSet:       secondTxStateTs.Key(),
-			ParentTipSet: singleTxStateTs.Key(),
+			TipSet:       secondTxStateTs,
+			ParentTipSet: singleTxStateTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -233,7 +233,7 @@ func TestMultisigExtractorV0(t *testing.T) {
 			Actor:   types.Actor{Code: sa0builtin.MultisigActorCodeID, Head: singleTxStateCid},
 			Epoch:   0, // genesis
 			Address: multiSigAddress,
-			TipSet:  genesisTs.Key(),
+			TipSet:  genesisTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -315,8 +315,8 @@ func TestMultisigExtractorV2(t *testing.T) {
 			Actor:        types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: txStateCid},
 			Epoch:        1, // not genesis
 			Address:      multiSigAddress,
-			TipSet:       txStateTs.Key(),
-			ParentTipSet: emptyTxStateTs.Key(),
+			TipSet:       txStateTs,
+			ParentTipSet: emptyTxStateTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -401,8 +401,8 @@ func TestMultisigExtractorV2(t *testing.T) {
 			Actor:        types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: secondTxStateCid},
 			Epoch:        1, // not genesis
 			Address:      multiSigAddress,
-			TipSet:       secondTxStateTs.Key(),
-			ParentTipSet: singleTxStateTs.Key(),
+			TipSet:       secondTxStateTs,
+			ParentTipSet: singleTxStateTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -461,7 +461,7 @@ func TestMultisigExtractorV2(t *testing.T) {
 			Actor:   types.Actor{Code: sa2builtin.MultisigActorCodeID, Head: singleTxStateCid},
 			Epoch:   0, // genesis
 			Address: multiSigAddress,
-			TipSet:  genesisTs.Key(),
+			TipSet:  genesisTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -546,8 +546,8 @@ func TestMultisigExtractorV3(t *testing.T) {
 			Actor:        types.Actor{Code: sa3builtin.MultisigActorCodeID, Head: txStateCid},
 			Epoch:        1, // not genesis
 			Address:      multiSigAddress,
-			TipSet:       txStateTs.Key(),
-			ParentTipSet: emptyTxStateTs.Key(),
+			TipSet:       txStateTs,
+			ParentTipSet: emptyTxStateTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -632,8 +632,8 @@ func TestMultisigExtractorV3(t *testing.T) {
 			Actor:        types.Actor{Code: sa3builtin.MultisigActorCodeID, Head: secondTxStateCid},
 			Epoch:        1, // not genesis
 			Address:      multiSigAddress,
-			TipSet:       secondTxStateTs.Key(),
-			ParentTipSet: singleTxStateTs.Key(),
+			TipSet:       secondTxStateTs,
+			ParentTipSet: singleTxStateTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -692,7 +692,7 @@ func TestMultisigExtractorV3(t *testing.T) {
 			Actor:   types.Actor{Code: sa3builtin.MultisigActorCodeID, Head: singleTxStateCid},
 			Epoch:   0, // genesis
 			Address: multiSigAddress,
-			TipSet:  genesisTs.Key(),
+			TipSet:  genesisTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -777,8 +777,8 @@ func TestMultisigExtractorV4(t *testing.T) {
 			Actor:        types.Actor{Code: sa4builtin.MultisigActorCodeID, Head: txStateCid},
 			Epoch:        1, // not genesis
 			Address:      multiSigAddress,
-			TipSet:       txStateTs.Key(),
-			ParentTipSet: emptyTxStateTs.Key(),
+			TipSet:       txStateTs,
+			ParentTipSet: emptyTxStateTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -863,8 +863,8 @@ func TestMultisigExtractorV4(t *testing.T) {
 			Actor:        types.Actor{Code: sa4builtin.MultisigActorCodeID, Head: secondTxStateCid},
 			Epoch:        1, // not genesis
 			Address:      multiSigAddress,
-			TipSet:       secondTxStateTs.Key(),
-			ParentTipSet: singleTxStateTs.Key(),
+			TipSet:       secondTxStateTs,
+			ParentTipSet: singleTxStateTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
@@ -923,7 +923,7 @@ func TestMultisigExtractorV4(t *testing.T) {
 			Actor:   types.Actor{Code: sa4builtin.MultisigActorCodeID, Head: singleTxStateCid},
 			Epoch:   0, // genesis
 			Address: multiSigAddress,
-			TipSet:  genesisTs.Key(),
+			TipSet:  genesisTs,
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}

--- a/tasks/actorstate/power_test.go
+++ b/tasks/actorstate/power_test.go
@@ -61,7 +61,7 @@ func TestPowerExtractV0(t *testing.T) {
 		info := actorstate.ActorInfo{
 			Actor:           types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: stateCid},
 			Address:         power.Address,
-			TipSet:          stateTs.Key(),
+			TipSet:          stateTs,
 			ParentStateRoot: stateTs.ParentState(),
 		}
 
@@ -115,8 +115,8 @@ func TestPowerExtractV0(t *testing.T) {
 			Epoch:           1,
 			Actor:           types.Actor{Code: sa0builtin.StoragePowerActorCodeID, Head: newStateCid},
 			Address:         power.Address,
-			ParentTipSet:    oldStateTs.Key(),
-			TipSet:          newStateTs.Key(),
+			ParentTipSet:    oldStateTs,
+			TipSet:          newStateTs,
 			ParentStateRoot: newStateTs.ParentState(),
 		}
 
@@ -164,7 +164,7 @@ func TestPowerExtractV2(t *testing.T) {
 		info := actorstate.ActorInfo{
 			Actor:           types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: stateCid},
 			Address:         power.Address,
-			TipSet:          stateTs.Key(),
+			TipSet:          stateTs,
 			ParentStateRoot: stateTs.ParentState(),
 		}
 
@@ -219,8 +219,8 @@ func TestPowerExtractV2(t *testing.T) {
 			Epoch:           1,
 			Actor:           types.Actor{Code: sa2builtin.StoragePowerActorCodeID, Head: newStateCid},
 			Address:         power.Address,
-			ParentTipSet:    oldStateTs.Key(),
-			TipSet:          newStateTs.Key(),
+			ParentTipSet:    oldStateTs,
+			TipSet:          newStateTs,
 			ParentStateRoot: newStateTs.ParentState(),
 		}
 
@@ -268,7 +268,7 @@ func TestPowerExtractV3(t *testing.T) {
 		info := actorstate.ActorInfo{
 			Actor:           types.Actor{Code: sa3builtin.StoragePowerActorCodeID, Head: stateCid},
 			Address:         power.Address,
-			TipSet:          stateTs.Key(),
+			TipSet:          stateTs,
 			ParentStateRoot: stateTs.ParentState(),
 		}
 
@@ -323,8 +323,8 @@ func TestPowerExtractV3(t *testing.T) {
 			Epoch:           1,
 			Actor:           types.Actor{Code: sa3builtin.StoragePowerActorCodeID, Head: newStateCid},
 			Address:         power.Address,
-			ParentTipSet:    oldStateTs.Key(),
-			TipSet:          newStateTs.Key(),
+			ParentTipSet:    oldStateTs,
+			TipSet:          newStateTs,
 			ParentStateRoot: newStateTs.ParentState(),
 		}
 
@@ -372,7 +372,7 @@ func TestPowerExtractV4(t *testing.T) {
 		info := actorstate.ActorInfo{
 			Actor:           types.Actor{Code: sa3builtin.StoragePowerActorCodeID, Head: stateCid},
 			Address:         power.Address,
-			TipSet:          stateTs.Key(),
+			TipSet:          stateTs,
 			ParentStateRoot: stateTs.ParentState(),
 		}
 
@@ -427,8 +427,8 @@ func TestPowerExtractV4(t *testing.T) {
 			Epoch:           1,
 			Actor:           types.Actor{Code: sa4builtin.StoragePowerActorCodeID, Head: newStateCid},
 			Address:         power.Address,
-			ParentTipSet:    oldStateTs.Key(),
-			TipSet:          newStateTs.Key(),
+			ParentTipSet:    oldStateTs,
+			TipSet:          newStateTs,
 			ParentStateRoot: newStateTs.ParentState(),
 		}
 

--- a/tasks/actorstate/reward.go
+++ b/tasks/actorstate/reward.go
@@ -34,12 +34,7 @@ func (RewardExtractor) Extract(ctx context.Context, a ActorInfo, node ActorState
 	stop := metrics.Timer(ctx, metrics.ProcessingDuration)
 	defer stop()
 
-	rewardActor, err := node.StateGetActor(ctx, reward.Address, a.TipSet)
-	if err != nil {
-		return nil, err
-	}
-
-	rstate, err := reward.Load(node.Store(), rewardActor)
+	rstate, err := reward.Load(node.Store(), &a.Actor)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/actorstate/reward_test.go
+++ b/tasks/actorstate/reward_test.go
@@ -52,7 +52,7 @@ func TestRewardExtractV0(t *testing.T) {
 	info := actorstate.ActorInfo{
 		Actor:   types.Actor{Code: sa0builtin.RewardActorCodeID, Head: stateCid},
 		Address: power.Address,
-		TipSet:  stateTs.Key(),
+		TipSet:  stateTs,
 	}
 
 	ex := actorstate.RewardExtractor{}
@@ -101,7 +101,7 @@ func TestRewardExtractV2(t *testing.T) {
 	info := actorstate.ActorInfo{
 		Actor:   types.Actor{Code: sa2builtin.RewardActorCodeID, Head: stateCid},
 		Address: power.Address,
-		TipSet:  stateTs.Key(),
+		TipSet:  stateTs,
 	}
 
 	ex := actorstate.RewardExtractor{}
@@ -150,7 +150,7 @@ func TestRewardExtractV3(t *testing.T) {
 	info := actorstate.ActorInfo{
 		Actor:   types.Actor{Code: sa3builtin.RewardActorCodeID, Head: stateCid},
 		Address: power.Address,
-		TipSet:  stateTs.Key(),
+		TipSet:  stateTs,
 	}
 
 	ex := actorstate.RewardExtractor{}
@@ -199,7 +199,7 @@ func TestRewardExtractV4(t *testing.T) {
 	info := actorstate.ActorInfo{
 		Actor:   types.Actor{Code: sa4builtin.RewardActorCodeID, Head: stateCid},
 		Address: power.Address,
-		TipSet:  stateTs.Key(),
+		TipSet:  stateTs,
 	}
 
 	ex := actorstate.RewardExtractor{}

--- a/tasks/actorstate/task.go
+++ b/tasks/actorstate/task.go
@@ -149,8 +149,8 @@ func (t *Task) runActorStateExtraction(ctx context.Context, ts *types.TipSet, pt
 		Address:         addr,
 		ParentStateRoot: ts.ParentState(),
 		Epoch:           ts.Height(),
-		TipSet:          ts.Key(),
-		ParentTipSet:    ts.Parents(),
+		TipSet:          ts,
+		ParentTipSet:    pts,
 	}
 
 	extracter, ok := t.extracterMap.GetExtractor(act.Code)


### PR DESCRIPTION
Minor performance optimization.

When extracting actor states we already have the full tipset and its parent available so we can avoid calling the chain store to look up the tipset from its key. All the Lotus APIs do this too so we could further optimize by implementing alternate calls that accept a full tipset - I noted some of these in the ActorStateAPI interface.

Also remove calls to StateGetActor (which did an additional load of the tipset from its key) since the actor info is already passed to each extractor.

This allows us to shrink the ActorStateAPI interface by removing the ChainGetTipSet method. I also removed the ChainHasObj and ChainReadObj methods which were unused.