### PR TITLE
fix(ci): download vectors before running tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
             DOCKERIZE_VERSION: v0.3.0
       - run: sudo apt-get update
       - run: make deps
+      - run: make vector-setup
       - run: make build
       - run:
           name: waiting for db

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ sentinel-visor
 
 build/.*
 vector/data/*.json
+vector/data/.complete
 support/tools/bin
 


### PR DESCRIPTION
Vector downloading was moved to its own make command (previously under `make deps` but removed because we don't want vectors in our docker containers). We need to ensure this command is run before tests in CI.