### PR TITLE
fix: improve reliability of reconnecting to lotus after disconnect

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -282,7 +282,12 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 
 	// Wait for all tasks to complete
 	for inFlight > 0 {
-		res := <-results
+		var res *TaskResult
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case res = <-results:
+		}
 		inFlight--
 
 		llt := ll.With("task", res.Task)

--- a/commands/lily.go
+++ b/commands/lily.go
@@ -19,7 +19,7 @@ func GetAPI(ctx context.Context, addrStr string, token string) (lily.LilyAPI, js
 
 	ainfo := cliutil.APIInfo{Addr: addrStr, Token: []byte(token)}
 
-	addr, err := ainfo.DialArgs()
+	addr, err := ainfo.DialArgs("v0")
 	if err != nil {
 		return nil, nil, xerrors.Errorf("could not get DialArgs: %w", err)
 	}

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -275,6 +275,7 @@ func (c *LotusChainNotifier) Run(ctx context.Context) error {
 		return xerrors.Errorf("open lens: %w", err)
 	}
 	defer closer()
+	log.Debugw("lens opened")
 
 	hc, err := node.ChainNotify(ctx)
 	if err != nil {

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -242,10 +242,7 @@ func NewLotusChainNotifier(opener lens.APIOpener) *LotusChainNotifier {
 }
 
 func (c *LotusChainNotifier) HeadEvents() <-chan *chain.HeadEvent {
-	c.mu.Lock()
-	events := c.events
-	c.mu.Unlock()
-	return events
+	return c.events
 }
 
 func (c *LotusChainNotifier) Err() error {

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,11 @@ require (
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200701152213-3e0f0afdc261
 	github.com/filecoin-project/go-state-types v0.1.0
-	github.com/filecoin-project/lotus v1.6.1-0.20210413121043-9e600eac7e8e
+	github.com/filecoin-project/lotus v1.8.1-0.20210427081517-7e25a811c3d8
 	github.com/filecoin-project/specs-actors v0.9.13
 	github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb
 	github.com/filecoin-project/specs-actors/v3 v3.1.0
-	github.com/filecoin-project/specs-actors/v4 v4.0.0-20210416122111-a0f750e10747
+	github.com/filecoin-project/specs-actors/v4 v4.0.0
 	github.com/filecoin-project/statediff v0.0.23-0.20210325142844-f4ed79079579
 	github.com/go-pg/migrations/v8 v8.0.1
 	github.com/go-pg/pg/v10 v10.3.1

--- a/go.sum
+++ b/go.sum
@@ -332,8 +332,8 @@ github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
 github.com/filecoin-project/lotus v1.5.3/go.mod h1:rOm4THTYK5YcjJ1o9KAsT2fL6bOVJWzJ8rSY9XRRfho=
 github.com/filecoin-project/lotus v1.5.3/go.mod h1:rOm4THTYK5YcjJ1o9KAsT2fL6bOVJWzJ8rSY9XRRfho=
-github.com/filecoin-project/lotus v1.6.1-0.20210413121043-9e600eac7e8e h1:fxYpcTryDLUFtWcdrZ3PKEPng5OUlkBOrpL9y0NHekg=
-github.com/filecoin-project/lotus v1.6.1-0.20210413121043-9e600eac7e8e/go.mod h1:AaI0Xfn0kDZIOFps80XHIyQuhbLTgBSXGofloU3+aTY=
+github.com/filecoin-project/lotus v1.8.1-0.20210427081517-7e25a811c3d8 h1:SB6xsHWUQtJZoOrETpzcedrFKQEjaY/qgx2VkflVKLA=
+github.com/filecoin-project/lotus v1.8.1-0.20210427081517-7e25a811c3d8/go.mod h1:4YC/8rizrrp2wKOYvHQEjCxZbziXi68BhrzvI+FCye0=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/filecoin-project/specs-actors v0.9.12/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/filecoin-project/specs-actors v0.9.13 h1:rUEOQouefi9fuVY/2HOroROJlZbOzWYXXeIh41KF2M4=
@@ -346,8 +346,8 @@ github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb
 github.com/filecoin-project/specs-actors/v3 v3.0.3/go.mod h1:oMcmEed6B7H/wHabM3RQphTIhq0ibAKsbpYs+bQ/uxQ=
 github.com/filecoin-project/specs-actors/v3 v3.1.0 h1:s4qiPw8pgypqBGAy853u/zdZJ7K9cTZdM1rTiSonHrg=
 github.com/filecoin-project/specs-actors/v3 v3.1.0/go.mod h1:mpynccOLlIRy0QnR008BwYBwT9fen+sPR13MA1VmMww=
-github.com/filecoin-project/specs-actors/v4 v4.0.0-20210416122111-a0f750e10747 h1:IMG10k9LI4G3CVEJWLYD82OtzCJbMfPIKzuQRSG5+mU=
-github.com/filecoin-project/specs-actors/v4 v4.0.0-20210416122111-a0f750e10747/go.mod h1:TkHXf/l7Wyw4ZejyXIPS2rK8bBO0rdwhTZyQQgaglng=
+github.com/filecoin-project/specs-actors/v4 v4.0.0 h1:vMALksY5G3J5rj3q9rbcyB+f4Tk1xrLqSgdB3jOok4s=
+github.com/filecoin-project/specs-actors/v4 v4.0.0/go.mod h1:TkHXf/l7Wyw4ZejyXIPS2rK8bBO0rdwhTZyQQgaglng=
 github.com/filecoin-project/specs-storage v0.1.1-0.20201105051918-5188d9774506 h1:Ur/l2+6qN+lQiqjozWWc5p9UDaAMDZKTlDS98oRnlIw=
 github.com/filecoin-project/specs-storage v0.1.1-0.20201105051918-5188d9774506/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
 github.com/filecoin-project/statediff v0.0.23-0.20210325142844-f4ed79079579 h1:OT0dxEo0cDfzs8QRH+ft0akCSgUjYPdYxMjcWldCnjc=

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"sync"
 
-	"go.uber.org/fx"
-
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/node/impl/common"
 	"github.com/filecoin-project/lotus/node/impl/full"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/ipfs/go-cid"
+	"go.uber.org/fx"
 
 	"github.com/filecoin-project/sentinel-visor/chain"
 	"github.com/filecoin-project/sentinel-visor/lens"
@@ -134,6 +135,19 @@ func (m *LilyNodeAPI) GetExecutedMessagesForTipset(ctx context.Context, ts, pts 
 
 func (m *LilyNodeAPI) Store() adt.Store {
 	return m.ChainAPI.Chain.ActorStore(context.TODO())
+}
+
+func (m *LilyNodeAPI) StateGetReceipt(ctx context.Context, msg cid.Cid, from types.TipSetKey) (*types.MessageReceipt, error) {
+	ml, err := m.StateSearchMsg(ctx, from, msg, api.LookbackNoLimit, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if ml == nil {
+		return nil, nil
+	}
+
+	return &ml.Receipt, nil
 }
 
 var _ LilyAPI = &LilyNodeAPI{}

--- a/lens/lily/struct.go
+++ b/lens/lily/struct.go
@@ -3,7 +3,7 @@ package lily
 import (
 	"context"
 
-	"github.com/filecoin-project/lotus/api/apistruct"
+	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	logging "github.com/ipfs/go-log/v2"
@@ -16,11 +16,11 @@ var log = logging.Logger("lily-api")
 
 type LilyAPIStruct struct {
 	// authentication
-	apistruct.CommonStruct
+	v0api.CommonStruct
 
 	// chain notifications and inspection
 	// actor state extraction
-	apistruct.FullNodeStruct
+	v0api.FullNodeStruct
 
 	Internal struct {
 		Store                        func() adt.Store                                                                     `perm:"read"`

--- a/lens/lotus/api.go
+++ b/lens/lotus/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/blockstore"
 	builtininit "github.com/filecoin-project/lotus/chain/actors/builtin/init"
 	miner "github.com/filecoin-project/lotus/chain/actors/builtin/miner"
@@ -23,7 +24,7 @@ import (
 	"github.com/filecoin-project/sentinel-visor/metrics"
 )
 
-func NewAPIWrapper(node api.FullNode, store adt.Store) *APIWrapper {
+func NewAPIWrapper(node v0api.FullNode, store adt.Store) *APIWrapper {
 	return &APIWrapper{
 		FullNode: node,
 		store:    store,
@@ -33,7 +34,7 @@ func NewAPIWrapper(node api.FullNode, store adt.Store) *APIWrapper {
 var _ lens.API = &APIWrapper{}
 
 type APIWrapper struct {
-	api.FullNode
+	v0api.FullNode
 	store adt.Store
 }
 

--- a/lens/lotus/cachestore.go
+++ b/lens/lotus/cachestore.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/sentinel-visor/metrics"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/ipfs/go-cid"
@@ -18,10 +18,10 @@ import (
 type CacheCtxStore struct {
 	cache *lru.ARCCache
 	ctx   context.Context
-	api   api.FullNode
+	api   v0api.FullNode
 }
 
-func NewCacheCtxStore(ctx context.Context, api api.FullNode, cache *lru.ARCCache) (*CacheCtxStore, error) {
+func NewCacheCtxStore(ctx context.Context, api v0api.FullNode, cache *lru.ARCCache) (*CacheCtxStore, error) {
 	return &CacheCtxStore{
 		cache: cache,
 		ctx:   ctx,

--- a/lens/lotus/lotus.go
+++ b/lens/lotus/lotus.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/filecoin-project/lotus/api/client"
+	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/node/repo"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/mitchellh/go-homedir"
@@ -89,10 +90,12 @@ func NewAPIOpener(cctx *cli.Context, cacheSize int) (*APIOpener, lens.APICloser,
 }
 
 func (o *APIOpener) Open(ctx context.Context) (lens.API, lens.APICloser, error) {
-	api, closer, err := client.NewFullNodeRPC(ctx, o.addr, o.headers)
+	apiv1, closer, err := client.NewFullNodeRPCV1(ctx, o.addr, o.headers)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("new full node rpc: %w", err)
 	}
+
+	api := &v0api.WrapperV1Full{FullNode: apiv1}
 
 	cacheStore, err := NewCacheCtxStore(ctx, api, o.cache)
 	if err != nil {

--- a/lens/lotus/lotus.go
+++ b/lens/lotus/lotus.go
@@ -99,6 +99,9 @@ func (o *APIOpener) Open(ctx context.Context) (lens.API, lens.APICloser, error) 
 
 	cacheStore, err := NewCacheCtxStore(ctx, api, o.cache)
 	if err != nil {
+		if closer != nil {
+			closer()
+		}
 		return nil, nil, xerrors.Errorf("new cache store: %w", err)
 	}
 

--- a/lens/lotusrepo/repo.go
+++ b/lens/lotusrepo/repo.go
@@ -197,6 +197,19 @@ func (ra *RepoAPI) ClientRetrieveTryRestartInsufficientFunds(ctx context.Context
 	return fmt.Errorf("unsupported")
 }
 
+func (ra *RepoAPI) StateGetReceipt(ctx context.Context, msg cid.Cid, from types.TipSetKey) (*types.MessageReceipt, error) {
+	ml, err := ra.StateSearchMsg(ctx, from, msg, api.LookbackNoLimit, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if ml == nil {
+		return nil, nil
+	}
+
+	return &ml.Receipt, nil
+}
+
 // From https://github.com/ribasushi/ltsh/blob/5b0211033020570217b0ae37b50ee304566ac218/cmd/lotus-shed/deallifecycles.go#L41-L171
 type fakeVerifier struct{}
 

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -204,6 +204,19 @@ func (ra *LensAPI) ClientRetrieveTryRestartInsufficientFunds(ctx context.Context
 	return fmt.Errorf("unsupported")
 }
 
+func (ra *LensAPI) StateGetReceipt(ctx context.Context, msg cid.Cid, from types.TipSetKey) (*types.MessageReceipt, error) {
+	ml, err := ra.StateSearchMsg(ctx, from, msg, api.LookbackNoLimit, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if ml == nil {
+		return nil, nil
+	}
+
+	return &ml.Receipt, nil
+}
+
 // From https://github.com/ribasushi/ltsh/blob/5b0211033020570217b0ae37b50ee304566ac218/cmd/lotus-shed/deallifecycles.go#L41-L171
 type fakeVerifier struct{}
 

--- a/lens/vector/repo.go
+++ b/lens/vector/repo.go
@@ -16,6 +16,7 @@ import (
 	car "github.com/ipld/go-car"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -147,6 +148,19 @@ func (c *CaptureAPI) Store() adt.Store {
 
 func (c *CaptureAPI) GetExecutedMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) ([]*lens.ExecutedMessage, error) {
 	return util.GetExecutedMessagesForTipset(ctx, c.FullNodeAPI.ChainAPI.Chain, ts, pts)
+}
+
+func (c *CaptureAPI) StateGetReceipt(ctx context.Context, msg cid.Cid, from types.TipSetKey) (*types.MessageReceipt, error) {
+	ml, err := c.StateSearchMsg(ctx, from, msg, api.LookbackNoLimit, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if ml == nil {
+		return nil, nil
+	}
+
+	return &ml.Receipt, nil
 }
 
 // From https://github.com/ribasushi/ltsh/blob/5b0211033020570217b0ae37b50ee304566ac218/cmd/lotus-shed/deallifecycles.go#L41-L171

--- a/schedule/scheduler.go
+++ b/schedule/scheduler.go
@@ -21,7 +21,9 @@ var log = logging.Logger("schedule")
 
 type Job interface {
 	// Run starts running the task and blocks until the context is done or
-	// an error occurs.
+	// an error occurs. Run may be called again after an error or timeout to
+	// retry the job so implemententions must ensure that Run resets any
+	// necessary state.
 	Run(context.Context) error
 }
 

--- a/testutil/lens.go
+++ b/testutil/lens.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/filecoin-project/lotus/api"
 	apitest "github.com/filecoin-project/lotus/api/test"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
@@ -67,4 +68,17 @@ func (aw *APIWrapper) Put(ctx context.Context, v interface{}) (cid.Cid, error) {
 
 func (aw *APIWrapper) Context() context.Context {
 	return aw.ctx
+}
+
+func (aw *APIWrapper) StateGetReceipt(ctx context.Context, msg cid.Cid, from types.TipSetKey) (*types.MessageReceipt, error) {
+	ml, err := aw.StateSearchMsg(ctx, from, msg, api.LookbackNoLimit, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if ml == nil {
+		return nil, nil
+	}
+
+	return &ml.Receipt, nil
 }


### PR DESCRIPTION
This only relates to the `visor run watch` command. When the rpc connection to the api was lost (e.g. Lotus restarting) the chain notifier job would close the event channel by calling Cancel but did not recreate it when the job was restarted. This left the watcher job with a permanently closed channel. 

Fix by not closing the channel between job restarts, but reuse it and send head events once connection to Lotus has been re-established.

Requires #490 to be merged first

Fixes #493