### PR TITLE
feat: add init command

### DIFF
--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -28,12 +28,11 @@ import (
 )
 
 type daemonOpts struct {
-	api            string
-	repo           string
-	bootstrap      bool // TODO: is this necessary - do we want to run visor in this mode?
-	config         string
-	importsnapshot string
-	genesis        string
+	api       string
+	repo      string
+	bootstrap bool // TODO: is this necessary - do we want to run visor in this mode?
+	config    string
+	genesis   string
 }
 
 var daemonFlags daemonOpts
@@ -68,12 +67,6 @@ var DaemonCmd = &cli.Command{
 			Usage:       "Specify path of config file to use.",
 			EnvVars:     []string{"VISOR_CONFIG"},
 			Destination: &daemonFlags.config,
-		},
-		&cli.StringFlag{
-			Name:        "import-snapshot",
-			Usage:       "Import chain state from a given chain export file or url.",
-			EnvVars:     []string{"VISOR_SNAPSHOT"},
-			Destination: &daemonFlags.importsnapshot,
 		},
 		&cli.StringFlag{
 			Name:        "genesis",
@@ -123,12 +116,6 @@ var DaemonCmd = &cli.Command{
 			}
 		} else {
 			genBytes = lotusbuild.MaybeGenesis()
-		}
-
-		if daemonFlags.importsnapshot != "" {
-			if err := util.ImportChain(ctx, r, daemonFlags.importsnapshot, true); err != nil {
-				return err
-			}
 		}
 
 		genesis := node.Options()

--- a/commands/init.go
+++ b/commands/init.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"context"
+
+	paramfetch "github.com/filecoin-project/go-paramfetch"
+	lotusbuild "github.com/filecoin-project/lotus/build"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/lib/lotuslog"
+	"github.com/filecoin-project/lotus/node/repo"
+	"github.com/mitchellh/go-homedir"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/commands/util"
+	"github.com/filecoin-project/sentinel-visor/config"
+)
+
+var initFlags struct {
+	repo           string
+	config         string
+	importSnapshot string
+}
+
+var InitCmd = &cli.Command{
+	Name:  "init",
+	Usage: "Initialaise a visorrepository.",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:        "repo",
+			Usage:       "Specify path where visor should store chain state.",
+			EnvVars:     []string{"VISOR_REPO"},
+			Value:       "~/.lotus",
+			Destination: &initFlags.repo,
+		},
+		&cli.StringFlag{
+			Name:        "config",
+			Usage:       "Specify path of config file to use.",
+			EnvVars:     []string{"VISOR_CONFIG"},
+			Destination: &initFlags.config,
+		},
+		&cli.StringFlag{
+			Name:        "import-snapshot",
+			Usage:       "Import chain state from a given chain export file or url.",
+			EnvVars:     []string{"VISOR_SNAPSHOT"},
+			Destination: &initFlags.importSnapshot,
+		},
+	},
+	Action: func(c *cli.Context) error {
+		lotuslog.SetupLogLevels()
+		ctx := context.Background()
+		{
+			dir, err := homedir.Expand(initFlags.repo)
+			if err != nil {
+				log.Warnw("could not expand repo location", "error", err)
+			} else {
+				log.Infof("lotus repo: %s", dir)
+			}
+		}
+
+		r, err := repo.NewFS(initFlags.repo)
+		if err != nil {
+			return xerrors.Errorf("opening fs repo: %w", err)
+		}
+
+		if initFlags.config != "" {
+			if err := config.EnsureExists(initFlags.config); err != nil {
+				return xerrors.Errorf("ensuring config is present at %q: %w", initFlags.config, err)
+			}
+			r.SetConfigPath(initFlags.config)
+		}
+
+		err = r.Init(repo.FullNode)
+		if err != nil && err != repo.ErrRepoExists {
+			return xerrors.Errorf("repo init error: %w", err)
+		}
+
+		if err := paramfetch.GetParams(lcli.ReqContext(c), lotusbuild.ParametersJSON(), 0); err != nil {
+			return xerrors.Errorf("fetching proof parameters: %w", err)
+		}
+
+		if initFlags.importSnapshot != "" {
+			if err := util.ImportChain(ctx, r, initFlags.importSnapshot, true); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			commands.DaemonCmd,
+			commands.InitCmd,
 			commands.JobCmd,
 			commands.MigrateCmd,
 			commands.RunCmd,


### PR DESCRIPTION
Splits out the import of a chain export into a separate command. This allows deployments to have external logic that controls when a repo should be initialised. For example in kubernetes we will have an init container that will run before the main container starts. The init container will write a marker file after import and then skip importing if the pod is restarted.