### PR TITLE
fix: enable sync command for repos in non default locations

### DIFF
--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -9,7 +9,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/libp2p/go-libp2p-core/peer"
 
-	// "github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/sentinel-visor/schedule"
 )
 
@@ -32,7 +31,6 @@ type LilyAPI interface {
 
 	// ID returns peerID of libp2p node backing this API
 	ID(context.Context) (peer.ID, error) //perm:read
-
 }
 
 type LilyWatchConfig struct {

--- a/lens/lily/struct.go
+++ b/lens/lily/struct.go
@@ -80,4 +80,12 @@ func (s *LilyAPIStruct) ID(ctx context.Context) (peer.ID, error) {
 	return s.Internal.ID(ctx)
 }
 
+func (s *LilyAPIStruct) SyncState(ctx context.Context) (*api.SyncState, error) {
+	return s.Internal.SyncState(ctx)
+}
+
+func (s *LilyAPIStruct) ChainHead(ctx context.Context) (*types.TipSet, error) {
+	return s.Internal.ChainHead(ctx)
+}
+
 var _ LilyAPI = &LilyAPIStruct{}

--- a/lens/lily/struct.go
+++ b/lens/lily/struct.go
@@ -80,12 +80,4 @@ func (s *LilyAPIStruct) ID(ctx context.Context) (peer.ID, error) {
 	return s.Internal.ID(ctx)
 }
 
-func (s *LilyAPIStruct) SyncState(ctx context.Context) (*api.SyncState, error) {
-	return s.Internal.SyncState(ctx)
-}
-
-func (s *LilyAPIStruct) ChainHead(ctx context.Context) (*types.TipSet, error) {
-	return s.Internal.ChainHead(ctx)
-}
-
 var _ LilyAPI = &LilyAPIStruct{}


### PR DESCRIPTION
Importing the Lotus CLI+API commands directly is problematic since Lotus makes some assumptions about environment variables and cli options. This becomes evident when a non-default location is used for the repo or visor is run on a non-default port. Fix this for the sync command by implementing sync natively, Fix it for other commands by removing them for now. We will re-add when we have the actual need for them. Sync is important because we want to use it during deployments.
