### PR TITLE
fix(api): jsonrpc only supports returning 2 params

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -216,12 +216,12 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 
 			// If we have message processors then extract the messages and receipts
 			if len(t.messageProcessors) > 0 {
-				emsgs, blkMsgs, err := t.node.GetExecutedAndBlockMessagesForTipset(ctx, child, parent)
+				tsMsgs, err := t.node.GetExecutedAndBlockMessagesForTipset(ctx, child, parent)
 				if err == nil {
 					// Start all the message processors
 					for name, p := range t.messageProcessors {
 						inFlight++
-						go t.runMessageProcessor(tctx, p, name, child, parent, emsgs, blkMsgs, results)
+						go t.runMessageProcessor(tctx, p, name, child, parent, tsMsgs.Executed, tsMsgs.Block, results)
 					}
 				} else {
 					ll.Errorw("failed to extract messages", "error", err)

--- a/lens/interface.go
+++ b/lens/interface.go
@@ -21,7 +21,7 @@ type API interface {
 	ChainAPI
 	StateAPI
 
-	GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) ([]*ExecutedMessage, []*BlockMessages, error)
+	GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*TipSetMessages, error)
 }
 
 type StoreAPI interface {
@@ -65,6 +65,11 @@ type APICloser func()
 
 type APIOpener interface {
 	Open(context.Context) (API, APICloser, error)
+}
+
+type TipSetMessages struct {
+	Executed []*ExecutedMessage
+	Block    []*BlockMessages
 }
 
 type ExecutedMessage struct {

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -129,7 +129,7 @@ func (m *LilyNodeAPI) Open(_ context.Context) (lens.API, lens.APICloser, error) 
 	return m, func() {}, nil
 }
 
-func (m *LilyNodeAPI) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) ([]*lens.ExecutedMessage, []*lens.BlockMessages, error) {
+func (m *LilyNodeAPI) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
 	return util.GetExecutedAndBlockMessagesForTipset(ctx, m.ChainAPI.Chain, ts, pts)
 }
 

--- a/lens/lily/struct.go
+++ b/lens/lily/struct.go
@@ -23,8 +23,8 @@ type LilyAPIStruct struct {
 	v0api.FullNodeStruct
 
 	Internal struct {
-		Store                                func() adt.Store                                                                                            `perm:"read"`
-		GetExecutedAndBlockMessagesForTipset func(context.Context, *types.TipSet, *types.TipSet) ([]*lens.ExecutedMessage, []*lens.BlockMessages, error) `perm:"read"`
+		Store                                func() adt.Store                                                                  `perm:"read"`
+		GetExecutedAndBlockMessagesForTipset func(context.Context, *types.TipSet, *types.TipSet) (*lens.TipSetMessages, error) `perm:"read"`
 
 		LilyWatch func(context.Context, *LilyWatchConfig) (schedule.JobID, error) `perm:"read"`
 		LilyWalk  func(context.Context, *LilyWalkConfig) (schedule.JobID, error)  `perm:"read"`
@@ -59,7 +59,7 @@ func (s *LilyAPIStruct) LilyJobList(ctx context.Context) ([]schedule.JobResult, 
 	return s.Internal.LilyJobList(ctx)
 }
 
-func (s *LilyAPIStruct) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) ([]*lens.ExecutedMessage, []*lens.BlockMessages, error) {
+func (s *LilyAPIStruct) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
 	return s.Internal.GetExecutedAndBlockMessagesForTipset(ctx, ts, pts)
 }
 

--- a/lens/lotusrepo/repo.go
+++ b/lens/lotusrepo/repo.go
@@ -109,7 +109,7 @@ type RepoAPI struct {
 	cacheSize int
 }
 
-func (ra *RepoAPI) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) ([]*lens.ExecutedMessage, []*lens.BlockMessages, error) {
+func (ra *RepoAPI) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
 	return util.GetExecutedAndBlockMessagesForTipset(ctx, ra.FullNodeAPI.ChainAPI.Chain, ts, pts)
 }
 

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -116,7 +116,7 @@ type LensAPI struct {
 	cs        *store.ChainStore
 }
 
-func (ra *LensAPI) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) ([]*lens.ExecutedMessage, []*lens.BlockMessages, error) {
+func (ra *LensAPI) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
 	return GetExecutedAndBlockMessagesForTipset(ctx, ra.cs, ts, pts)
 }
 
@@ -241,29 +241,29 @@ func (m fakeVerifier) GenerateWinningPoStSectorChallenge(ctx context.Context, pr
 // GetMessagesForTipset returns a list of messages sent as part of pts (parent) with receipts found in ts (child).
 // No attempt at deduplication of messages is made. A list of blocks with their corresponding messages is also returned - it contains all messages
 // in the block regardless if they were applied during the state change.
-func GetExecutedAndBlockMessagesForTipset(ctx context.Context, cs *store.ChainStore, ts, pts *types.TipSet) ([]*lens.ExecutedMessage, []*lens.BlockMessages, error) {
+func GetExecutedAndBlockMessagesForTipset(ctx context.Context, cs *store.ChainStore, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
 	if !types.CidArrsEqual(ts.Parents().Cids(), pts.Cids()) {
-		return nil, nil, xerrors.Errorf("child tipset (%s) is not on the same chain as parent (%s)", ts.Key(), pts.Key())
+		return nil, xerrors.Errorf("child tipset (%s) is not on the same chain as parent (%s)", ts.Key(), pts.Key())
 	}
 
 	stateTree, err := state.LoadStateTree(cs.ActorStore(ctx), ts.ParentState())
 	if err != nil {
-		return nil, nil, xerrors.Errorf("load state tree: %w", err)
+		return nil, xerrors.Errorf("load state tree: %w", err)
 	}
 
 	parentStateTree, err := state.LoadStateTree(cs.ActorStore(ctx), pts.ParentState())
 	if err != nil {
-		return nil, nil, xerrors.Errorf("load state tree: %w", err)
+		return nil, xerrors.Errorf("load state tree: %w", err)
 	}
 
 	initActor, err := stateTree.GetActor(builtininit.Address)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("getting init actor: %w", err)
+		return nil, xerrors.Errorf("getting init actor: %w", err)
 	}
 
 	initActorState, err := builtininit.Load(cs.ActorStore(ctx), initActor)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("loading init actor state: %w", err)
+		return nil, xerrors.Errorf("loading init actor state: %w", err)
 	}
 
 	// Build a lookup of actor codes
@@ -272,7 +272,7 @@ func GetExecutedAndBlockMessagesForTipset(ctx context.Context, cs *store.ChainSt
 		actorCodes[a] = act.Code
 		return nil
 	}); err != nil {
-		return nil, nil, xerrors.Errorf("iterate actors: %w", err)
+		return nil, xerrors.Errorf("iterate actors: %w", err)
 	}
 
 	getActorCode := func(a address.Address) cid.Cid {
@@ -294,7 +294,7 @@ func GetExecutedAndBlockMessagesForTipset(ctx context.Context, cs *store.ChainSt
 	for blockIdx, bh := range pts.Blocks() {
 		blscids, secpkcids, err := cs.ReadMsgMetaCids(bh.Messages)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("read messages for block: %w", err)
+			return nil, xerrors.Errorf("read messages for block: %w", err)
 		}
 
 		for _, c := range blscids {
@@ -309,13 +309,13 @@ func GetExecutedAndBlockMessagesForTipset(ctx context.Context, cs *store.ChainSt
 
 	bmsgs, err := cs.BlockMsgsForTipset(pts)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("block messages for tipset: %w", err)
+		return nil, xerrors.Errorf("block messages for tipset: %w", err)
 	}
 
 	pblocks := pts.Blocks()
 	if len(bmsgs) != len(pblocks) {
 		// logic error somewhere
-		return nil, nil, xerrors.Errorf("mismatching number of blocks returned from block messages, got %d wanted %d", len(bmsgs), len(pblocks))
+		return nil, xerrors.Errorf("mismatching number of blocks returned from block messages, got %d wanted %d", len(bmsgs), len(pblocks))
 	}
 
 	count := 0
@@ -364,12 +364,12 @@ func GetExecutedAndBlockMessagesForTipset(ctx context.Context, cs *store.ChainSt
 	// Retrieve receipts using a block from the child tipset
 	rs, err := adt.AsArray(cs.ActorStore(ctx), ts.Blocks()[0].ParentMessageReceipts)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("amt load: %w", err)
+		return nil, xerrors.Errorf("amt load: %w", err)
 	}
 
 	if rs.Length() != uint64(len(emsgs)) {
 		// logic error somewhere
-		return nil, nil, xerrors.Errorf("mismatching number of receipts: got %d wanted %d", rs.Length(), len(emsgs))
+		return nil, xerrors.Errorf("mismatching number of receipts: got %d wanted %d", rs.Length(), len(emsgs))
 	}
 
 	// Create a skeleton vm just for calling ShouldBurn
@@ -379,22 +379,22 @@ func GetExecutedAndBlockMessagesForTipset(ctx context.Context, cs *store.ChainSt
 		Bstore:    cs.StateBlockstore(),
 	})
 	if err != nil {
-		return nil, nil, xerrors.Errorf("creating temporary vm: %w", err)
+		return nil, xerrors.Errorf("creating temporary vm: %w", err)
 	}
 
 	// Receipts are in same order as BlockMsgsForTipset
 	for _, em := range emsgs {
 		var r types.MessageReceipt
 		if found, err := rs.Get(em.Index, &r); err != nil {
-			return nil, nil, err
+			return nil, err
 		} else if !found {
-			return nil, nil, xerrors.Errorf("failed to find receipt %d", em.Index)
+			return nil, xerrors.Errorf("failed to find receipt %d", em.Index)
 		}
 		em.Receipt = &r
 
 		burn, err := vmi.ShouldBurn(parentStateTree, em.Message, em.Receipt.ExitCode)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("deciding whether should burn failed: %w", err)
+			return nil, xerrors.Errorf("deciding whether should burn failed: %w", err)
 		}
 
 		em.GasOutputs = vm.ComputeGasOutputs(em.Receipt.GasUsed, em.Message.GasLimit, em.BlockHeader.ParentBaseFee, em.Message.GasFeeCap, em.Message.GasPremium, burn)
@@ -404,7 +404,7 @@ func GetExecutedAndBlockMessagesForTipset(ctx context.Context, cs *store.ChainSt
 	for idx, blk := range ts.Blocks() {
 		msgs, smsgs, err := cs.MessagesForBlock(blk)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		blkMsgs[idx] = &lens.BlockMessages{
 			Block:        blk,
@@ -413,5 +413,8 @@ func GetExecutedAndBlockMessagesForTipset(ctx context.Context, cs *store.ChainSt
 		}
 	}
 
-	return emsgs, blkMsgs, nil
+	return &lens.TipSetMessages{
+		Executed: emsgs,
+		Block:    blkMsgs,
+	}, nil
 }

--- a/lens/vector/repo.go
+++ b/lens/vector/repo.go
@@ -146,7 +146,7 @@ func (c *CaptureAPI) Store() adt.Store {
 	return adtStore
 }
 
-func (c *CaptureAPI) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) ([]*lens.ExecutedMessage, []*lens.BlockMessages, error) {
+func (c *CaptureAPI) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
 	return util.GetExecutedAndBlockMessagesForTipset(ctx, c.FullNodeAPI.ChainAPI.Chain, ts, pts)
 }
 

--- a/testutil/lens.go
+++ b/testutil/lens.go
@@ -39,8 +39,8 @@ func (aw *APIWrapper) Store() adt.Store {
 	return aw
 }
 
-func (aw *APIWrapper) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) ([]*lens.ExecutedMessage, []*lens.BlockMessages, error) {
-	return nil, nil, xerrors.Errorf("GetExecutedAndBlockMessagesForTipset is not implemented")
+func (aw *APIWrapper) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
+	return nil, xerrors.Errorf("GetExecutedAndBlockMessagesForTipset is not implemented")
 }
 
 func (aw *APIWrapper) Get(ctx context.Context, c cid.Cid, out interface{}) error {


### PR DESCRIPTION
- fix bug introduced in #491

where jsonrpc enforces 2 out params https://github.com/filecoin-project/go-jsonrpc/blob/45ea43ac2bec4c1134204bf0bf9ae7b9bc878fb9/util.go#L53