### PR TITLE
Fix #484: Add Height to IDAddress and ChainEconomics

### DIFF
--- a/model/actors/init/idaddress.go
+++ b/model/actors/init/idaddress.go
@@ -13,6 +13,7 @@ import (
 )
 
 type IdAddress struct {
+	Height    int64  `pg:",pk,notnull,use_zero"`
 	ID        string `pg:",pk,notnull"`
 	Address   string `pg:",pk,notnull"`
 	StateRoot string `pg:",pk,notnull"`

--- a/model/chain/economics.go
+++ b/model/chain/economics.go
@@ -13,7 +13,9 @@ import (
 )
 
 type ChainEconomics struct {
+	//lint:ignore U1000 structcheck, unused
 	tableName       struct{} `pg:"chain_economics"` // nolint: structcheck,unused
+	Height          int64    `pg:",pk,notnull,use_zero"`
 	ParentStateRoot string   `pg:",notnull"`
 	CirculatingFil  string   `pg:",notnull"`
 	VestedFil       string   `pg:",notnull"`

--- a/tasks/actorstate/init.go
+++ b/tasks/actorstate/init.go
@@ -44,6 +44,7 @@ func (InitExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAP
 				return err
 			}
 			out = append(out, &initmodel.IdAddress{
+				Height:    int64(a.Epoch),
 				ID:        idAddr.String(),
 				Address:   addr.String(),
 				StateRoot: a.ParentStateRoot.String(),

--- a/tasks/chaineconomics/economics.go
+++ b/tasks/chaineconomics/economics.go
@@ -30,6 +30,7 @@ func ExtractChainEconomicsModel(ctx context.Context, node ChainEconomicsLens, ts
 	}
 
 	return &chainmodel.ChainEconomics{
+		Height:          int64(ts.Height()),
 		ParentStateRoot: ts.ParentState().String(),
 		VestedFil:       supply.FilVested.String(),
 		MinedFil:        supply.FilMined.String(),


### PR DESCRIPTION
Fixes #484. These two tables are missing heights, which makes difficult to
partition exports.