### PR TITLE
fix: parse plain value transfer messages

### DIFF
--- a/tasks/messages/message.go
+++ b/tasks/messages/message.go
@@ -272,6 +272,11 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 }
 
 func (p *Task) parseMessageParams(m *types.Message, destCode cid.Cid) (string, string, error) {
+	// Method is optional, zero means a plain value transfer
+	if m.Method == 0 {
+		return "Send", "", nil
+	}
+
 	actor, ok := statediff.LotusActorCodes[destCode.String()]
 	if !ok {
 		actor = statediff.LotusTypeUnknown


### PR DESCRIPTION
Ensures plain value transfers will appear in parsed_messages table. Currently they are skipped and an error is written to visor_processing reports `{"Error": "failed to parse message params: unknown method for actor type bafkqadlgnfwc6nbpmfrwg33vnz2a: 0"}`