### PR TITLE
fix: fall back to using config in repo directory if unspecified

### DIFF
--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"io/ioutil"
+	"path/filepath"
 
 	paramfetch "github.com/filecoin-project/go-paramfetch"
 	lotusbuild "github.com/filecoin-project/lotus/build"
@@ -106,13 +107,15 @@ var DaemonCmd = &cli.Command{
 			return xerrors.Errorf("opening fs repo: %w", err)
 		}
 
-		if daemonFlags.config != "" {
-			log.Infof("visor config: %s", daemonFlags.config)
-			if err := config.EnsureExists(daemonFlags.config); err != nil {
-				return xerrors.Errorf("ensuring config is present at %q: %w", daemonFlags.config, err)
-			}
-			r.SetConfigPath(daemonFlags.config)
+		if daemonFlags.config == "" {
+			daemonFlags.config = filepath.Join(daemonFlags.repo, "config.toml")
 		}
+
+		log.Infof("visor config: %s", daemonFlags.config)
+		if err := config.EnsureExists(daemonFlags.config); err != nil {
+			return xerrors.Errorf("ensuring config is present at %q: %w", daemonFlags.config, err)
+		}
+		r.SetConfigPath(daemonFlags.config)
 
 		err = r.Init(repo.FullNode)
 		if err != nil && err != repo.ErrRepoExists {

--- a/storage/catalog.go
+++ b/storage/catalog.go
@@ -24,6 +24,7 @@ func NewCatalog(cfg config.StorageConf) (*Catalog, error) {
 		if _, exists := c.storages[name]; exists {
 			return nil, fmt.Errorf("duplicate storage name: %q", name)
 		}
+		log.Debugw("registering storage", "name", name, "type", "postgresql")
 
 		// Find the url of the database, which is either indirectly specified using URLEnv or explicit via URL
 		var dburl string
@@ -48,6 +49,8 @@ func NewCatalog(cfg config.StorageConf) (*Catalog, error) {
 
 		switch sc.Format {
 		case "CSV":
+			log.Debugw("registering storage", "name", name, "type", "csv")
+
 			db, err := NewCSVStorageLatest(sc.Path)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create postgresql storage %q: %w", name, err)


### PR DESCRIPTION
I thought visor wasn't detecting the storages in the config file but it turned out it just couldn't find the config. It's fine if you specify it with --config but I think it's also useful to default it to looking in the root of the repo.