### PR TITLE
fix: give head notifier a buffer

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -502,7 +502,7 @@ func (t *TipSetIndexer) stateChangedActors(ctx context.Context, old, new cid.Cid
 			return out, nil
 		}
 	}
-	log.Debugf("using slow state diff")
+	log.Debug("using slow state diff")
 	return t.node.StateChangedActors(ctx, old, new)
 }
 

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -456,6 +456,7 @@ func (t *TipSetIndexer) stateChangedActors(ctx context.Context, old, new cid.Cid
 		if span.IsRecording() {
 			span.SetAttribute("diff", "fast")
 		}
+		// TODO: replace hamt.UseTreeBitWidth and hamt.UseHashFunction with values based on network version
 		changes, err := hamt.Diff(ctx, t.node.Store(), t.node.Store(), oldRoot, newRoot, hamt.UseTreeBitWidth(5), hamt.UseHashFunction(func(input []byte) []byte {
 			res := sha256.Sum256(input)
 			return res[:]
@@ -500,6 +501,7 @@ func (t *TipSetIndexer) stateChangedActors(ctx context.Context, old, new cid.Cid
 			return out, nil
 		}
 	}
+	log.Debugf("using slow state diff")
 	return t.node.StateChangedActors(ctx, old, new)
 }
 

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -357,6 +357,7 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 		for task, p := range taskOutputs {
 			go func(task string, p model.Persistable) {
 				defer wg.Done()
+				start := time.Now()
 				ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, task))
 
 				if err := t.storage.PersistBatch(ctx, p); err != nil {

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -232,6 +232,7 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 
 			// If we have actor processors then find actors that have changed state
 			if len(t.actorProcessors) > 0 {
+				changesStart := time.Now()
 				var err error
 				var changes map[string]types.Actor
 				// special case, we want to extract all actor states from the genesis block.
@@ -241,6 +242,7 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 					changes, err = t.stateChangedActors(tctx, parent.ParentState(), child.ParentState())
 				}
 				if err == nil {
+					ll.Debugw("found actor state changes", "count", len(changes), "time", time.Since(changesStart))
 					if t.addressFilter != nil {
 						for addr := range changes {
 							if !t.addressFilter.Allow(addr) {
@@ -418,7 +420,6 @@ func (t *TipSetIndexer) getGenesisActors(ctx context.Context) (map[string]types.
 	if err := tree.ForEach(func(addr address.Address, act *types.Actor) error {
 		out[addr.String()] = *act
 		return nil
-
 	}); err != nil {
 		return nil, err
 	}

--- a/commands/setup.go
+++ b/commands/setup.go
@@ -140,7 +140,7 @@ func jaegerConfigFromCliContext(cctx *cli.Context) (*jaegerConfig, error) {
 
 func setupLogging(cctx *cli.Context) error {
 	ll := cctx.String("log-level")
-	if err := logging.SetLogLevelRegex(".*", ll); err != nil {
+	if err := logging.SetLogLevel("*", ll); err != nil {
 		return xerrors.Errorf("set log level: %w", err)
 	}
 


### PR DESCRIPTION
Converting head notifier channel into a buffered channel decouples the event subsystem from the indexer. Since this change I haven't seen the node fall out of sync.