### PR TITLE
feat: add observe command with peer agents task

### DIFF
--- a/chain/walker.go
+++ b/chain/walker.go
@@ -23,7 +23,7 @@ func NewWalker(obs TipSetObserver, opener lens.APIOpener, minHeight, maxHeight i
 	}
 }
 
-// Walker is a task that indexes blocks by walking the chain history.
+// Walker is a job that indexes blocks by walking the chain history.
 type Walker struct {
 	opener    lens.APIOpener
 	obs       TipSetObserver

--- a/commands/observe.go
+++ b/commands/observe.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	lotuscli "github.com/filecoin-project/lotus/cli"
+	"github.com/urfave/cli/v2"
+
+	"github.com/filecoin-project/sentinel-visor/lens/lily"
+	"github.com/filecoin-project/sentinel-visor/network"
+)
+
+var observeFlags struct {
+	tasks    string
+	storage  string
+	name     string
+	interval time.Duration
+}
+
+var ObserveCmd = &cli.Command{
+	Name:  "observe",
+	Usage: "Start a daemon job to observe the node and its environment.",
+	Flags: flagSet(
+		clientAPIFlagSet,
+		[]cli.Flag{
+			&cli.StringFlag{
+				Name:        "tasks",
+				Usage:       "Comma separated list of observe tasks to run. Each task is reported separately in the database.",
+				Value:       strings.Join([]string{network.PeerAgentsTask}, ","),
+				Destination: &observeFlags.tasks,
+			},
+			&cli.DurationFlag{
+				Name:        "interval",
+				Usage:       "Duration after which any indexing work not completed will be marked incomplete",
+				Value:       600 * time.Second,
+				Destination: &observeFlags.interval,
+			},
+			&cli.StringFlag{
+				Name:        "storage",
+				Usage:       "Name of storage that results will be written to.",
+				Value:       "",
+				Destination: &observeFlags.storage,
+			},
+			&cli.StringFlag{
+				Name:        "name",
+				Usage:       "Name of job for easy identification later.",
+				Value:       "",
+				Destination: &observeFlags.name,
+			},
+		},
+	),
+	Action: func(cctx *cli.Context) error {
+		ctx := lotuscli.ReqContext(cctx)
+
+		obsName := fmt.Sprintf("observe_%d", time.Now().Unix())
+		if observeFlags.name != "" {
+			obsName = observeFlags.name
+		}
+
+		cfg := &lily.LilyObserveConfig{
+			Name:                obsName,
+			Tasks:               strings.Split(observeFlags.tasks, ","),
+			Interval:            observeFlags.interval,
+			RestartDelay:        0,
+			RestartOnCompletion: false,
+			RestartOnFailure:    true,
+			Storage:             observeFlags.storage,
+		}
+
+		api, closer, err := GetAPI(ctx, clientAPIFlags.apiAddr, clientAPIFlags.apiToken)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		obsID, err := api.LilyObserve(ctx, cfg)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(os.Stdout, "Created observe job %s (%d)\n", obsName, obsID); err != nil {
+			return err
+		}
+		return nil
+	},
+}

--- a/commands/walk.go
+++ b/commands/walk.go
@@ -118,7 +118,7 @@ var WalkCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(os.Stdout, "Created Watch Job: %d", watchID); err != nil {
+		if _, err := fmt.Fprintf(os.Stdout, "Created Watch Job: %d\n", watchID); err != nil {
 			return err
 		}
 		return nil

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -115,7 +115,7 @@ var WatchCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(os.Stdout, "Created Watch Job: %d", watchID); err != nil {
+		if _, err := fmt.Fprintf(os.Stdout, "Created Watch Job: %d\n", watchID); err != nil {
 			return err
 		}
 		return nil

--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -19,6 +19,7 @@ type LilyAPI interface {
 
 	LilyWatch(ctx context.Context, cfg *LilyWatchConfig) (schedule.JobID, error)
 	LilyWalk(ctx context.Context, cfg *LilyWalkConfig) (schedule.JobID, error)
+	LilyObserve(ctx context.Context, cfg *LilyObserveConfig) (schedule.JobID, error)
 
 	LilyJobStart(ctx context.Context, ID schedule.JobID) error
 	LilyJobStop(ctx context.Context, ID schedule.JobID) error
@@ -63,6 +64,16 @@ type LilyWalkConfig struct {
 	Name                string
 	Tasks               []string
 	Window              time.Duration
+	RestartOnFailure    bool
+	RestartOnCompletion bool
+	RestartDelay        time.Duration
+	Storage             string // name of storage system to use, may be empty
+}
+
+type LilyObserveConfig struct {
+	Name                string
+	Tasks               []string
+	Interval            time.Duration
 	RestartOnFailure    bool
 	RestartOnCompletion bool
 	RestartDelay        time.Duration

--- a/lens/lily/struct.go
+++ b/lens/lily/struct.go
@@ -27,8 +27,9 @@ type LilyAPIStruct struct {
 		Store                                func() adt.Store                                                                  `perm:"read"`
 		GetExecutedAndBlockMessagesForTipset func(context.Context, *types.TipSet, *types.TipSet) (*lens.TipSetMessages, error) `perm:"read"`
 
-		LilyWatch func(context.Context, *LilyWatchConfig) (schedule.JobID, error) `perm:"read"`
-		LilyWalk  func(context.Context, *LilyWalkConfig) (schedule.JobID, error)  `perm:"read"`
+		LilyWatch   func(context.Context, *LilyWatchConfig) (schedule.JobID, error)   `perm:"read"`
+		LilyWalk    func(context.Context, *LilyWalkConfig) (schedule.JobID, error)    `perm:"read"`
+		LilyObserve func(context.Context, *LilyObserveConfig) (schedule.JobID, error) `perm:"read"`
 
 		LilyJobStart func(ctx context.Context, ID schedule.JobID) error      `perm:"read"`
 		LilyJobStop  func(ctx context.Context, ID schedule.JobID) error      `perm:"read"`
@@ -62,6 +63,10 @@ func (s *LilyAPIStruct) LilyWatch(ctx context.Context, cfg *LilyWatchConfig) (sc
 
 func (s *LilyAPIStruct) LilyWalk(ctx context.Context, cfg *LilyWalkConfig) (schedule.JobID, error) {
 	return s.Internal.LilyWalk(ctx, cfg)
+}
+
+func (s *LilyAPIStruct) LilyObserve(ctx context.Context, cfg *LilyObserveConfig) (schedule.JobID, error) {
+	return s.Internal.LilyObserve(ctx, cfg)
 }
 
 func (s *LilyAPIStruct) LilyJobStart(ctx context.Context, ID schedule.JobID) error {

--- a/main.go
+++ b/main.go
@@ -138,6 +138,7 @@ func main() {
 			commands.LogCmd,
 			commands.MigrateCmd,
 			commands.NetCmd,
+			commands.ObserveCmd,
 			commands.RunCmd,
 			commands.StopCmd,
 			commands.SyncCmd,

--- a/model/observed/peeragent.go
+++ b/model/observed/peeragent.go
@@ -1,0 +1,55 @@
+package observed
+
+import (
+	"context"
+	"time"
+
+	"go.opencensus.io/tag"
+	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/label"
+
+	"github.com/filecoin-project/sentinel-visor/metrics"
+	"github.com/filecoin-project/sentinel-visor/model"
+)
+
+type PeerAgent struct {
+	//lint:ignore U1000 tableName is a convention used by go-pg
+	tableName struct{} `pg:"observed_peer_agents"`
+
+	// ObservedAt is the time the observation was made
+	ObservedAt time.Time `pg:",notnull"`
+
+	// RawAgent is the raw peer agent string
+	RawAgent string `pg:",notnull"`
+
+	// NormalizedAgent is a parsed version of peer agent string, stripping out patch versions
+	NormalizedAgent string `pg:",notnull"`
+
+	// Count is the number of peers with the associated agent
+	Count int64 `pg:",use_zero,notnull"`
+}
+
+func (p *PeerAgent) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "observed_peer_agents"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
+	return s.PersistModel(ctx, p)
+}
+
+type PeerAgentList []*PeerAgent
+
+func (l PeerAgentList) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
+	if len(l) == 0 {
+		return nil
+	}
+	ctx, span := global.Tracer("").Start(ctx, "PeerAgentList.Persist", trace.WithAttributes(label.Int("count", len(l))))
+	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "observed_peer_agents"))
+	stop := metrics.Timer(ctx, metrics.PersistDuration)
+	defer stop()
+
+	return s.PersistModel(ctx, l)
+}

--- a/network/observer.go
+++ b/network/observer.go
@@ -1,0 +1,178 @@
+package network
+
+import (
+	"context"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opentelemetry.io/otel/api/global"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/metrics"
+	"github.com/filecoin-project/sentinel-visor/model"
+	"github.com/filecoin-project/sentinel-visor/tasks/observe/peeragents"
+	logging "github.com/ipfs/go-log/v2"
+)
+
+const (
+	PeerAgentsTask = "peeragents" // task that observes connected peer agents
+)
+
+var log = logging.Logger("visor/network")
+
+type API interface {
+	peeragents.API
+}
+
+type ObserverOpt func(t *Observer)
+
+func NewObserver(api API, storage model.Storage, interval time.Duration, name string, tasks []string, options ...ObserverOpt) (*Observer, error) {
+	if interval <= 0 {
+		return nil, xerrors.Errorf("observer interval must be greater than zero: %d", interval)
+	}
+
+	obs := &Observer{
+		interval: interval,
+		storage:  storage,
+		name:     name,
+		tasks:    map[string]Task{},
+	}
+
+	for _, task := range tasks {
+		switch task {
+		case PeerAgentsTask:
+			obs.tasks[PeerAgentsTask] = peeragents.NewTask(api)
+		default:
+			return nil, xerrors.Errorf("unknown task: %s", task)
+		}
+	}
+
+	for _, opt := range options {
+		opt(obs)
+	}
+
+	return obs, nil
+}
+
+// An Observer observes features of the filecoin network
+type Observer struct {
+	interval time.Duration
+	storage  model.Storage
+	name     string
+	tasks    map[string]Task
+}
+
+// Run starts observing the filecoin netwoirk and continues until the context is done or
+// a fatal error occurs.
+func (o *Observer) Run(ctx context.Context) error {
+	ticker := time.NewTicker(o.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			o.Tick(ctx)
+		}
+	}
+}
+
+func (o *Observer) Details() (string, map[string]interface{}) {
+	return "observer", map[string]interface{}{
+		"name":     o.name,
+		"interval": o.interval,
+	}
+}
+
+// Tick is called on each tick of the observer's interval
+func (o *Observer) Tick(ctx context.Context) error {
+	ctx, span := global.Tracer("").Start(ctx, "Observer.Tick")
+	defer span.End()
+
+	// Do as much indexing as possible in the specified time interval
+	tctx, cancel := context.WithTimeout(ctx, o.interval)
+	defer cancel()
+
+	inFlight := 0
+	results := make(chan *TaskResult, len(o.tasks))
+
+	// Run each tipset processing task concurrently
+	for name, task := range o.tasks {
+		inFlight++
+		go o.runTask(tctx, task, name, results)
+	}
+
+	// Wait for all tasks to complete
+	for inFlight > 0 {
+		var res *TaskResult
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case res = <-results:
+		}
+		inFlight--
+
+		llt := log.With("task", res.Task)
+
+		// Was there a fatal error?
+		if res.Error != nil {
+			llt.Errorw("task returned with error", "error", res.Error.Error())
+			return res.Error
+		}
+
+		llt.Debugw("task report", "time", res.CompletedAt.Sub(res.StartedAt))
+
+		startPersist := time.Now()
+		if err := o.storage.PersistBatch(ctx, res.Data); err != nil {
+			stats.Record(ctx, metrics.PersistFailure.M(1))
+			llt.Errorw("persistence failed", "error", err)
+		} else {
+			llt.Debugw("task data persisted", "time", time.Since(startPersist))
+		}
+
+	}
+
+	return nil
+}
+
+func (o *Observer) runTask(ctx context.Context, task Task, name string, results chan *TaskResult) {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, name))
+	stop := metrics.Timer(ctx, metrics.ProcessingDuration)
+	defer stop()
+	start := time.Now()
+
+	data, err := task.Process(ctx)
+	if err != nil {
+		stats.Record(ctx, metrics.ProcessingFailure.M(1))
+		results <- &TaskResult{
+			Task:        name,
+			Error:       err,
+			StartedAt:   start,
+			CompletedAt: time.Now(),
+		}
+		return
+	}
+	results <- &TaskResult{
+		Task:        name,
+		Data:        data,
+		StartedAt:   start,
+		CompletedAt: time.Now(),
+	}
+}
+
+// A TaskResult is either some data to persist or an error which indicates that the task did not complete. Partial
+// completions are possible provided the Data contains a persistable log of the results.
+type TaskResult struct {
+	Task        string
+	Error       error
+	Data        model.Persistable
+	StartedAt   time.Time
+	CompletedAt time.Time
+}
+
+type Task interface {
+	Process(ctx context.Context) (model.Persistable, error)
+	Close() error
+}

--- a/tasks/observe/peeragents/peeragents.go
+++ b/tasks/observe/peeragents/peeragents.go
@@ -1,0 +1,82 @@
+package peeragents
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sentinel-visor/model"
+	"github.com/filecoin-project/sentinel-visor/model/observed"
+)
+
+var log = logging.Logger("visor/task/peeragents")
+
+type API interface {
+	NetPeers(context.Context) ([]peer.AddrInfo, error)
+	NetAgentVersion(context.Context, peer.ID) (string, error)
+}
+
+func NewTask(api API) *Task {
+	return &Task{
+		api: api,
+	}
+}
+
+type Task struct {
+	api API
+}
+
+func (t *Task) Process(ctx context.Context) (model.Persistable, error) {
+	peers, err := t.api.NetPeers(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("get peers: %w", err)
+	}
+
+	start := time.Now()
+	agents := map[string]int64{}
+
+	for _, peer := range peers {
+		agent, err := t.api.NetAgentVersion(ctx, peer.ID)
+		if err != nil {
+			log.Debugw("failed to get agent version", "error", err)
+			continue
+		}
+		agents[agent]++
+	}
+
+	var l observed.PeerAgentList
+
+	for agent, count := range agents {
+		pa := &observed.PeerAgent{
+			ObservedAt:      start,
+			RawAgent:        agent,
+			NormalizedAgent: NormalizeAgent(agent),
+			Count:           count,
+		}
+
+		log.Debugw("observed", "raw_agent", pa.RawAgent, "norm_agent", pa.NormalizedAgent, "count", pa.Count)
+		l = append(l, pa)
+	}
+
+	return l, nil
+}
+
+var nameAndVersion = regexp.MustCompile(`^(.+?)\+`)
+
+// NormalizeAgent attempts to normalize an agent string to a software name and major/minor version
+func NormalizeAgent(agent string) string {
+	m := nameAndVersion.FindStringSubmatch(agent)
+	if len(m) > 1 {
+		return m[1]
+	}
+
+	return agent
+}
+
+func (t *Task) Close() error {
+	return nil
+}


### PR DESCRIPTION
This is an initial approach to adding tasks that observe the state of the network rather than the chain. We can iterate on naming.

Adds:
 - a new command `observe` that runs a set of network observing tasks at specified intervals
 - an example task `peeragents` that counts number of each reported agent string among the node's peers
 - a new model and table `observed_peer_agents`

Usage:

The command only works with a visor daemon. Start the daemon then run:

```
visor observe --tasks=peeragents --interval=300s
```

Every 300s the task will write rows to the `observed_peer_agents` table

Notes:

We could add support for using a remote Lotus API lens. Car and SQL lenses would need to be no-ops or fail support somehow.

TODO:

 - [ ] add a migration for the new table. Probably should extract from https://github.com/filecoin-project/sentinel-visor/pull/539 first
