### PR TITLE
manifest the vector failure: WIP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,12 +66,8 @@ build: deps visor
 deps: $(BUILD_DEPS)
 
 .PHONY: vector-setup
-vector-setup: ./vector/data/.complete
-
-./vector/data/.complete:
+vector-setup:
 	cd ./vector; ./fetch_vectors.sh
-	touch $@
-CLEAN+=./vector/data/.complete
 CLEAN+=./vector/data/*.json
 
 # test starts dependencies and runs all tests

--- a/commands/vector.go
+++ b/commands/vector.go
@@ -27,6 +27,12 @@ var BuildVectorCmd = &cli.Command{
 	Name:  "build",
 	Usage: "Create a vector.",
 	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "lens-repo",
+			EnvVars: []string{"VISOR_LENS_REPO"},
+			Value:   "~/.lotus", // TODO: Consider XDG_DATA_HOME
+			Usage:   "The path of a repo to be opened by the lens",
+		},
 		&cli.Int64Flag{
 			Name:    "from",
 			Usage:   "Limit actor and message processing to tipsets at or above `HEIGHT`",

--- a/vector/runner.go
+++ b/vector/runner.go
@@ -123,6 +123,7 @@ func (r *Runner) Validate(ctx context.Context) error {
 	actual := r.storage.Data
 	expected := r.schema.Exp.Models
 
+	var errStr []string
 	for expTable, expData := range expected {
 		if expTable == "visor_processing_reports" {
 			continue
@@ -141,9 +142,13 @@ func (r *Runner) Validate(ctx context.Context) error {
 		if diff != "" {
 			log.Errorf("Validate Model %s: Failed\n", expTable)
 			fmt.Println(diff)
+			errStr = append(errStr, "failed to validate model: %s", expTable)
 		} else {
 			log.Infof("Validate Model %s: Passed\n", expTable)
 		}
+	}
+	if len(errStr) > 0 {
+		return xerrors.Errorf("validation failed: %s", errStr)
 	}
 	return nil
 }

--- a/vector/runner.go
+++ b/vector/runner.go
@@ -142,7 +142,7 @@ func (r *Runner) Validate(ctx context.Context) error {
 		if diff != "" {
 			log.Errorf("Validate Model %s: Failed\n", expTable)
 			fmt.Println(diff)
-			errStr = append(errStr, "failed to validate model: %s", expTable)
+			errStr = append(errStr, fmt.Sprintf("failed to validate model: %s\n", expTable))
 		} else {
 			log.Infof("Validate Model %s: Passed\n", expTable)
 		}


### PR DESCRIPTION
Unfortunately, a lot broke here:
- The process for fetching vectors was broken in the Makefile as it won't detect new vectors being added to the manifest
- The Validate method needs to return an error to indicate failures
- The messages, init_actor, and chain economics vectors broke due to minor changes in their models scheme (the addition of heights and a new field added to the chain economics vector)

Im regenerating the new vectors and fixing the Makefile to detect them.