### PR TITLE
fix: avoid indexer blocking head events

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -63,7 +63,8 @@ type TipSetIndexer struct {
 	messageProcessors map[string]MessageProcessor
 	actorProcessors   map[string]ActorProcessor
 	name              string
-	persistSlot       chan struct{} // filled with a token when a gorroutine is persisting data
+	processSlot       chan struct{} // filled with a token when a goroutine is processing a tipset
+	persistSlot       chan struct{} // filled with a token when a goroutine is persisting data
 	lastTipSet        *types.TipSet
 	node              lens.API
 	opener            lens.APIOpener
@@ -88,6 +89,7 @@ func NewTipSetIndexer(o lens.APIOpener, d model.Storage, window time.Duration, n
 		storage:           d,
 		window:            window,
 		name:              name,
+		processSlot:       make(chan struct{}, 1), // allow one concurrent processing job
 		persistSlot:       make(chan struct{}, 1), // allow one concurrent persistence job
 		processors:        map[string]TipSetProcessor{},
 		messageProcessors: map[string]MessageProcessor{},
@@ -133,7 +135,33 @@ func NewTipSetIndexer(o lens.APIOpener, d model.Storage, window time.Duration, n
 
 // TipSet is called when a new tipset has been discovered
 func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
-	ctx, span := global.Tracer("").Start(ctx, "Indexer.TipSet")
+	// Process the tipset if we can, otherwise skip it so we don't block if indexing is too slow
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case t.processSlot <- struct{}{}:
+		// Processing slot was available which means we can continue.
+		go func() {
+			// Clear the slot when we have completed processing
+			defer func() {
+				<-t.processSlot
+			}()
+
+			err := t.processTipSet(ctx, ts)
+			if err != nil {
+				log.Errorw("failed to process tipset", "error", err, "height", ts.Height())
+			}
+		}()
+	default:
+		// TODO: write processing report to the database
+		log.Errorw("skipped tipset since processor not available", "height", ts.Height())
+	}
+
+	return nil // only fatal errors should be returned
+}
+
+func (t *TipSetIndexer) processTipSet(ctx context.Context, ts *types.TipSet) error {
+	ctx, span := global.Tracer("").Start(ctx, "Indexer.processTipSet")
 	if span.IsRecording() {
 		span.SetAttributes(label.String("tipset", ts.String()), label.Int64("height", int64(ts.Height())))
 	}

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -133,7 +133,7 @@ func NewTipSetIndexer(o lens.APIOpener, d model.Storage, window time.Duration, n
 
 // TipSet is called when a new tipset has been discovered
 func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
-	ctx, span := global.Tracer("").Start(ctx, "Indexer.processTipSet")
+	ctx, span := global.Tracer("").Start(ctx, "Indexer.TipSet")
 	if span.IsRecording() {
 		span.SetAttributes(label.String("tipset", ts.String()), label.Int64("height", int64(ts.Height())))
 	}

--- a/chain/tipset.go
+++ b/chain/tipset.go
@@ -11,12 +11,15 @@ import (
 // A TipSetObserver waits for notifications of new tipsets.
 type TipSetObserver interface {
 	TipSet(ctx context.Context, ts *types.TipSet) error
+	SkipTipSet(ctx context.Context, ts *types.TipSet, reason string) error
 	Close() error
 }
 
-var ErrCacheEmpty = errors.New("cache empty")
-var ErrAddOutOfOrder = errors.New("added tipset height lower than current head")
-var ErrRevertOutOfOrder = errors.New("reverted tipset does not match current head")
+var (
+	ErrCacheEmpty       = errors.New("cache empty")
+	ErrAddOutOfOrder    = errors.New("added tipset height lower than current head")
+	ErrRevertOutOfOrder = errors.New("reverted tipset does not match current head")
+)
 
 // TipSetCache is a cache of recent tipsets that can keep track of reversions.
 // Inspired by tipSetCache in Lotus chain/events package.

--- a/chain/watcher.go
+++ b/chain/watcher.go
@@ -78,7 +78,7 @@ func (c *Watcher) index(ctx context.Context, he *HeadEvent) error {
 
 		// Send the tipset that fell out of the confidence window to the observer
 		if tail != nil {
-			if err := c.obs.TipSet(ctx, tail); err != nil {
+			if err := c.maybeIndexTipSet(ctx, tail); err != nil {
 				return xerrors.Errorf("notify tipset: %w", err)
 			}
 		}

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -53,7 +53,7 @@ func (m *LilyNodeAPI) LilyWatch(_ context.Context, cfg *LilyWatchConfig) (schedu
 
 	// HeadNotifier bridges between the event system and the watcher
 	obs := &HeadNotifier{
-		bufferSize: 40,
+		bufferSize: 5,
 	}
 
 	// get the current head and set it on the tipset cache (mimic chain.watcher behaviour)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -30,6 +30,7 @@ var (
 	ProcessingFailure   = stats.Int64("processing_failure", "Number of processing failures", stats.UnitDimensionless)
 	PersistFailure      = stats.Int64("persist_failure", "Number of persistence failures", stats.UnitDimensionless)
 	WatchHeight         = stats.Int64("watch_height", "The height of the tipset last seen by the watch command", stats.UnitDimensionless)
+	TipSetSkip          = stats.Int64("tipset_skip", "Number of tipsets that were not processed. This is is an indication that visor cannot keep up with chain.", stats.UnitDimensionless)
 )
 
 var (
@@ -79,6 +80,12 @@ var (
 	WatchHeightView = &view.View{
 		Measure:     WatchHeight,
 		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{},
+	}
+	TipSetSkipTotalView = &view.View{
+		Name:        TipSetSkip.Name() + "_total",
+		Measure:     TipSetSkip,
+		Aggregation: view.Sum(),
 		TagKeys:     []tag.Key{},
 	}
 )

--- a/model/visor/report.go
+++ b/model/visor/report.go
@@ -17,6 +17,7 @@ const (
 	ProcessingStatusOK    = "OK"
 	ProcessingStatusInfo  = "INFO"  // Processing was successful but the task reported information in the StatusInformation column
 	ProcessingStatusError = "ERROR" // one or more errors were encountered, data may be incomplete
+	ProcessingStatusSkip  = "SKIP"  // no processing was attempted, a reason may be given in the StatusInformation column
 )
 
 type ProcessingReport struct {


### PR DESCRIPTION
During a watch, skip tipset processing if the indexer is taking longer than one epoch to process. We need to avoid blocking the stream of incoming tipsets otherwise we will cause the node to fall behind the chain while it waits for us to catch up (which may never happen if we consistently take too long)