### PR TITLE
fix: increase API cache size

### DIFF
--- a/commands/setup.go
+++ b/commands/setup.go
@@ -74,7 +74,7 @@ func setupDatabase(cctx *cli.Context) (*storage.Database, error) {
 func setupLens(cctx *cli.Context) (lens.APIOpener, lens.APICloser, error) {
 	switch cctx.String("lens") {
 	case "lotus":
-		return vapi.NewAPIOpener(cctx, 50_000)
+		return vapi.NewAPIOpener(cctx, 100_000)
 	case "lotusrepo":
 		return repoapi.NewAPIOpener(cctx)
 	case "carrepo":


### PR DESCRIPTION
Increase API cache size and remove restart delay if indexing takes too long. This reduces choppiness in the first few epochs when starting up visor against mainnet.