### PR TITLE
feat: add metrics for tipset cache used by watches

### DIFF
--- a/chain/tipset.go
+++ b/chain/tipset.go
@@ -19,6 +19,7 @@ var (
 	ErrCacheEmpty       = errors.New("cache empty")
 	ErrAddOutOfOrder    = errors.New("added tipset height lower than current head")
 	ErrRevertOutOfOrder = errors.New("reverted tipset does not match current head")
+	ErrEmptyRevert      = errors.New("reverted received on empty cache")
 )
 
 // TipSetCache is a cache of recent tipsets that can keep track of reversions.
@@ -85,7 +86,7 @@ func (c *TipSetCache) Add(ts *types.TipSet) (*types.TipSet, error) {
 // Revert removes the head tipset
 func (c *TipSetCache) Revert(ts *types.TipSet) error {
 	if c.len == 0 {
-		return nil
+		return ErrEmptyRevert
 	}
 
 	// Can only revert the most recent tipset
@@ -120,6 +121,11 @@ func (c *TipSetCache) SetCurrent(ts *types.TipSet) error {
 // Len returns the number of tipsets in the cache. This will never exceed the size of the cache.
 func (c *TipSetCache) Len() int {
 	return c.len
+}
+
+// Size returns the maximum number of tipsets that may be present in the cache.
+func (c *TipSetCache) Size() int {
+	return len(c.buffer)
 }
 
 // Height returns the height of the current head or zero if the cache is empty.

--- a/chain/tipset_test.go
+++ b/chain/tipset_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var dummyCid cid.Cid
-var dummyTs *types.TipSet
+var (
+	dummyCid cid.Cid
+	dummyTs  *types.TipSet
+)
 
 func init() {
 	dummyCid, _ = cid.Parse("bafkqaaa")
@@ -21,7 +23,6 @@ func init() {
 }
 
 func TestTipSetCacheInvariants(t *testing.T) {
-
 	t.Run("empty cache", func(t *testing.T) {
 		c := NewTipSetCache(3)
 		ts, err := c.Head()
@@ -33,14 +34,13 @@ func TestTipSetCacheInvariants(t *testing.T) {
 		assert.Nil(t, ts)
 
 		err = c.Revert(dummyTs)
-		assert.NoError(t, err)
+		assert.Error(t, err, ErrEmptyRevert)
 
 		oldTail, err := c.Add(dummyTs)
 		assert.NoError(t, err)
 		assert.Nil(t, oldTail)
 
 		assert.Equal(t, 1, c.Len())
-
 	})
 
 	t.Run("reset empties cache", func(t *testing.T) {
@@ -62,11 +62,10 @@ func TestTipSetCacheInvariants(t *testing.T) {
 		assert.Nil(t, ts)
 
 		err = c.Revert(dummyTs)
-		assert.NoError(t, err)
+		assert.Error(t, err, ErrEmptyRevert)
 
 		_, err = c.Add(dummyTs)
 		assert.NoError(t, err)
-
 	})
 
 	t.Run("head returns last added", func(t *testing.T) {
@@ -214,7 +213,6 @@ func TestTipSetCacheInvariants(t *testing.T) {
 		head, err = c.Head()
 		require.NoError(t, err)
 		assert.Same(t, ts1, head)
-
 	})
 
 	t.Run("revert ring", func(t *testing.T) {
@@ -241,7 +239,6 @@ func TestTipSetCacheInvariants(t *testing.T) {
 		head, err := c.Head()
 		require.NoError(t, err)
 		assert.Same(t, ts3, head)
-
 	})
 
 	t.Run("zero sized cache", func(t *testing.T) {
@@ -262,10 +259,8 @@ func TestTipSetCacheInvariants(t *testing.T) {
 		assert.Nil(t, ts)
 
 		err = c.Revert(dummyTs)
-		assert.NoError(t, err)
-
+		assert.Error(t, err, ErrEmptyRevert)
 	})
-
 }
 
 func TestTipSetCacheAddOutOfOrder(t *testing.T) {
@@ -309,7 +304,6 @@ func TestTipSetCacheSetCurrent(t *testing.T) {
 		head, err := c.Head()
 		require.NoError(t, err)
 		assert.Same(t, ts1, head)
-
 	})
 
 	t.Run("same height", func(t *testing.T) {
@@ -328,7 +322,6 @@ func TestTipSetCacheSetCurrent(t *testing.T) {
 		head, err := c.Head()
 		require.NoError(t, err)
 		assert.Same(t, ts14alt, head)
-
 	})
 
 	t.Run("same tipset", func(t *testing.T) {
@@ -346,7 +339,6 @@ func TestTipSetCacheSetCurrent(t *testing.T) {
 		head, err := c.Head()
 		require.NoError(t, err)
 		assert.Same(t, ts14, head)
-
 	})
 
 	t.Run("higher height", func(t *testing.T) {
@@ -422,7 +414,6 @@ func TestTipSetCacheSetCurrent(t *testing.T) {
 		require.NoError(t, err)
 		assert.Same(t, ts12, head)
 	})
-
 }
 
 func TestTipSetCacheAddOnlyReturnsOldTailWhenFull(t *testing.T) {
@@ -455,7 +446,6 @@ func TestTipSetCacheAddOnlyReturnsOldTailWhenFull(t *testing.T) {
 	oldTail, err = c.Add(ts17)
 	require.NoError(t, err)
 	assert.Same(t, oldTail, ts14) // cache is now full so oldest is evicted
-
 }
 
 func mustMakeTs(parents []cid.Cid, h abi.ChainEpoch, msgcid cid.Cid) *types.TipSet {
@@ -493,7 +483,6 @@ func mustMakeTs(parents []cid.Cid, h abi.ChainEpoch, msgcid cid.Cid) *types.TipS
 			BLSAggregate: &crypto.Signature{Type: crypto.SigTypeBLS},
 		},
 	})
-
 	if err != nil {
 		panic("mustMakeTs: " + err.Error())
 	}

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -14,13 +14,11 @@ import (
 	"github.com/filecoin-project/sentinel-visor/schedule"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/urfave/cli/v2"
-	"go.opencensus.io/stats"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/sentinel-visor/chain"
 	"github.com/filecoin-project/sentinel-visor/lens"
 	"github.com/filecoin-project/sentinel-visor/lens/lily"
-	"github.com/filecoin-project/sentinel-visor/metrics"
 	"github.com/filecoin-project/sentinel-visor/model"
 	"github.com/filecoin-project/sentinel-visor/storage"
 )
@@ -292,7 +290,6 @@ func (c *LotusChainNotifier) Run(ctx context.Context) error {
 			}
 
 			for _, ch := range headEvents {
-				stats.Record(ctx, metrics.WatchHeight.M(int64(ch.Val.Height())))
 				he := &chain.HeadEvent{
 					TipSet: ch.Val,
 				}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,20 +23,23 @@ var (
 )
 
 var (
-	ProcessingDuration  = stats.Float64("processing_duration_ms", "Time taken to process a single item", stats.UnitMilliseconds)
-	PersistDuration     = stats.Float64("persist_duration_ms", "Duration of a models persist operation", stats.UnitMilliseconds)
-	PersistModel        = stats.Int64("persist_model", "Number of models persisted", stats.UnitDimensionless)
-	DBConns             = stats.Int64("db_conns", "Database connections held", stats.UnitDimensionless)
-	LensRequestDuration = stats.Float64("lens_request_duration_ms", "Duration of lotus api requets", stats.UnitMilliseconds)
-	TipsetHeight        = stats.Int64("tipset_height", "The height of the tipset being processed by a task", stats.UnitDimensionless)
-	ProcessingFailure   = stats.Int64("processing_failure", "Number of processing failures", stats.UnitDimensionless)
-	PersistFailure      = stats.Int64("persist_failure", "Number of persistence failures", stats.UnitDimensionless)
-	WatchHeight         = stats.Int64("watch_height", "The height of the tipset last seen by the watch command", stats.UnitDimensionless)
-	TipSetSkip          = stats.Int64("tipset_skip", "Number of tipsets that were not processed. This is is an indication that visor cannot keep up with chain.", stats.UnitDimensionless)
-	JobStart            = stats.Int64("job_start", "Number of jobs started", stats.UnitDimensionless)
-	JobComplete         = stats.Int64("job_complete", "Number of jobs completed without error", stats.UnitDimensionless)
-	JobError            = stats.Int64("job_error", "Number of jobs stopped due to a fatal error", stats.UnitDimensionless)
-	JobTimeout          = stats.Int64("job_timeout", "Number of jobs stopped due to taking longer than expected", stats.UnitDimensionless)
+	ProcessingDuration     = stats.Float64("processing_duration_ms", "Time taken to process a single item", stats.UnitMilliseconds)
+	PersistDuration        = stats.Float64("persist_duration_ms", "Duration of a models persist operation", stats.UnitMilliseconds)
+	PersistModel           = stats.Int64("persist_model", "Number of models persisted", stats.UnitDimensionless)
+	DBConns                = stats.Int64("db_conns", "Database connections held", stats.UnitDimensionless)
+	LensRequestDuration    = stats.Float64("lens_request_duration_ms", "Duration of lotus api requets", stats.UnitMilliseconds)
+	TipsetHeight           = stats.Int64("tipset_height", "The height of the tipset being processed by a task", stats.UnitDimensionless)
+	ProcessingFailure      = stats.Int64("processing_failure", "Number of processing failures", stats.UnitDimensionless)
+	PersistFailure         = stats.Int64("persist_failure", "Number of persistence failures", stats.UnitDimensionless)
+	WatchHeight            = stats.Int64("watch_height", "The height of the tipset last seen by the watch command", stats.UnitDimensionless)
+	TipSetSkip             = stats.Int64("tipset_skip", "Number of tipsets that were not processed. This is is an indication that visor cannot keep up with chain.", stats.UnitDimensionless)
+	JobStart               = stats.Int64("job_start", "Number of jobs started", stats.UnitDimensionless)
+	JobComplete            = stats.Int64("job_complete", "Number of jobs completed without error", stats.UnitDimensionless)
+	JobError               = stats.Int64("job_error", "Number of jobs stopped due to a fatal error", stats.UnitDimensionless)
+	JobTimeout             = stats.Int64("job_timeout", "Number of jobs stopped due to taking longer than expected", stats.UnitDimensionless)
+	TipSetCacheSize        = stats.Int64("tipset_cache_size", "Configured size of the tipset cache (aka confidence).", stats.UnitDimensionless)
+	TipSetCacheDepth       = stats.Int64("tipset_cache_depth", "Number of tipsets currently in the tipset cache.", stats.UnitDimensionless)
+	TipSetCacheEmptyRevert = stats.Int64("tipset_cache_empty_revert", "Number of revert operations performed on an empty tipset cache. This is an indication that a chain reorg is underway that is deeper than the cache size and includes tipsets that have already been read from the cache.", stats.UnitDimensionless)
 )
 
 var (
@@ -86,13 +89,13 @@ var (
 	WatchHeightView = &view.View{
 		Measure:     WatchHeight,
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{},
+		TagKeys:     []tag.Key{Job},
 	}
 	TipSetSkipTotalView = &view.View{
 		Name:        TipSetSkip.Name() + "_total",
 		Measure:     TipSetSkip,
 		Aggregation: view.Sum(),
-		TagKeys:     []tag.Key{},
+		TagKeys:     []tag.Key{Job},
 	}
 
 	JobStartTotalView = &view.View{
@@ -126,6 +129,23 @@ var (
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{TaskType, Table},
 	}
+
+	TipSetCacheSizeView = &view.View{
+		Measure:     TipSetCacheSize,
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{Job},
+	}
+	TipSetCacheDepthView = &view.View{
+		Measure:     TipSetCacheDepth,
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{Job},
+	}
+	TipSetCacheEmptyRevertTotalView = &view.View{
+		Name:        TipSetCacheEmptyRevert.Name() + "_total",
+		Measure:     TipSetCacheEmptyRevert,
+		Aggregation: view.Sum(),
+		TagKeys:     []tag.Key{Job},
+	}
 )
 
 var DefaultViews = []*view.View{
@@ -143,6 +163,9 @@ var DefaultViews = []*view.View{
 	JobErrorTotalView,
 	JobTimeoutTotalView,
 	PersistModelTotalView,
+	TipSetCacheSizeView,
+	TipSetCacheDepthView,
+	TipSetCacheEmptyRevertTotalView,
 }
 
 // SinceInMilliseconds returns the duration of time since the provide time as a float64.


### PR DESCRIPTION
Adds metrics that allows monitoring of the depth of the tipset cache and identification of reorgs that extend beyond the size of the cache. Also fixes the `watch_height` metric that was not being reported for lily. `watch_height` records the height of the most recent tipset event which may be an apply or a revert. Reorgs should be visible as a rapid reduction in this metric followed by a corresponding increase back to the expected epoch height.