### PR TITLE
feat: add basic templating of csv filenames

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,9 +37,10 @@ type PgStorageConf struct {
 }
 
 type FileStorageConf struct {
-	Format     string
-	Path       string
-	OmitHeader bool // when true, don't write column headers to new output files
+	Format      string
+	Path        string
+	OmitHeader  bool   // when true, don't write column headers to new output files
+	FilePattern string // pattern to use for filenames written in the path specified
 }
 
 func DefaultConf() *Conf {
@@ -99,9 +100,10 @@ func SampleConf() *Conf {
 
 		File: map[string]FileStorageConf{
 			"CSV": {
-				Format:     "CSV",
-				Path:       "/tmp",
-				OmitHeader: false,
+				Format:      "CSV",
+				Path:        "/tmp",
+				OmitHeader:  false,
+				FilePattern: "{table}.csv",
 			},
 		},
 	}

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -48,8 +48,12 @@ func (m *LilyNodeAPI) LilyWatch(_ context.Context, cfg *LilyWatchConfig) (schedu
 	// the context's passed to these methods live for the duration of the clients request, so make a new one.
 	ctx := context.Background()
 
+	md := storage.Metadata{
+		JobName: cfg.Name,
+	}
+
 	// create a database connection for this watch, ensure its pingable, and run migrations if needed/configured to.
-	strg, err := m.StorageCatalog.Connect(ctx, cfg.Storage)
+	strg, err := m.StorageCatalog.Connect(ctx, cfg.Storage, md)
 	if err != nil {
 		return schedule.InvalidJobID, err
 	}
@@ -97,8 +101,12 @@ func (m *LilyNodeAPI) LilyWalk(_ context.Context, cfg *LilyWalkConfig) (schedule
 	// the context's passed to these methods live for the duration of the clients request, so make a new one.
 	ctx := context.Background()
 
+	md := storage.Metadata{
+		JobName: cfg.Name,
+	}
+
 	// create a database connection for this watch, ensure its pingable, and run migrations if needed/configured to.
-	strg, err := m.StorageCatalog.Connect(ctx, cfg.Storage)
+	strg, err := m.StorageCatalog.Connect(ctx, cfg.Storage, md)
 	if err != nil {
 		return schedule.InvalidJobID, err
 	}

--- a/storage/catalog.go
+++ b/storage/catalog.go
@@ -75,7 +75,7 @@ type Catalog struct {
 }
 
 // Connect returns a storage that is ready for use. If name is empty, a null storage will be returned
-func (c *Catalog) Connect(ctx context.Context, name string) (model.Storage, error) {
+func (c *Catalog) Connect(ctx context.Context, name string, md Metadata) (model.Storage, error) {
 	if name == "" {
 		return &NullStorage{}, nil
 	}
@@ -83,6 +83,12 @@ func (c *Catalog) Connect(ctx context.Context, name string) (model.Storage, erro
 	s, exists := c.storages[name]
 	if !exists {
 		return nil, fmt.Errorf("unknown storage: %q", name)
+	}
+
+	// Does this storage support metadata?
+	ms, ok := s.(StorageWithMetadata)
+	if ok {
+		s = ms.WithMetadata(md)
 	}
 
 	// Does this storage need to be connected?
@@ -97,4 +103,14 @@ func (c *Catalog) Connect(ctx context.Context, name string) (model.Storage, erro
 	}
 
 	return s, nil
+}
+
+type StorageWithMetadata interface {
+	// WithMetadata returns a storage based configured with the supplied metadata
+	WithMetadata(Metadata) model.Storage
+}
+
+// Metadata is additional information that a storage may use to annotate the data it writes
+type Metadata struct {
+	JobName string // name of the job using the storage
 }

--- a/storage/catalog.go
+++ b/storage/catalog.go
@@ -53,6 +53,7 @@ func NewCatalog(cfg config.StorageConf) (*Catalog, error) {
 
 			opts := DefaultCSVStorageOptions()
 			opts.OmitHeader = sc.OmitHeader
+			opts.FilePattern = sc.FilePattern
 
 			db, err := NewCSVStorageLatest(sc.Path, opts)
 			if err != nil {

--- a/storage/csv.go
+++ b/storage/csv.go
@@ -85,6 +85,8 @@ type CSVStorage struct {
 	metadata Metadata
 }
 
+var _ StorageWithMetadata = (*CSVStorage)(nil)
+
 type CSVStorageOptions struct {
 	OmitHeader  bool
 	FilePattern string
@@ -129,7 +131,7 @@ func NewCSVStorageLatest(path string, opts CSVStorageOptions) (*CSVStorage, erro
 	return NewCSVStorage(path, LatestSchemaVersion(), opts)
 }
 
-func (c *CSVStorage) WithMetadata(md Metadata) *CSVStorage {
+func (c *CSVStorage) WithMetadata(md Metadata) model.Storage {
 	c2 := *c
 	c2.metadata = md
 	return &c2

--- a/storage/csv.go
+++ b/storage/csv.go
@@ -78,18 +78,21 @@ func getCSVModelTableByName(name string, version model.Version) (table, bool) {
 }
 
 type CSVStorage struct {
-	path    string
-	version model.Version // schema version
-	opts    CSVStorageOptions
+	path     string
+	version  model.Version // schema version
+	opts     CSVStorageOptions
+	metadata Metadata
 }
 
 type CSVStorageOptions struct {
-	OmitHeader bool
+	OmitHeader  bool
+	FilePattern string
 }
 
 func DefaultCSVStorageOptions() CSVStorageOptions {
 	return CSVStorageOptions{
-		OmitHeader: false,
+		OmitHeader:  false,
+		FilePattern: "{table}.csv",
 	}
 }
 
@@ -111,6 +114,12 @@ func NewCSVStorage(path string, version model.Version, opts CSVStorageOptions) (
 
 func NewCSVStorageLatest(path string, opts CSVStorageOptions) (*CSVStorage, error) {
 	return NewCSVStorage(path, LatestSchemaVersion(), opts)
+}
+
+func (c *CSVStorage) WithMetadata(md Metadata) *CSVStorage {
+	c2 := *c
+	c2.metadata = md
+	return &c2
 }
 
 // PersistBatch persists a batch of models to CSV, creating new files if they don't already exist otherwise appending

--- a/storage/csv_test.go
+++ b/storage/csv_test.go
@@ -557,3 +557,36 @@ func TestCSVOptionOmitHeader(t *testing.T) {
 		runTest(t, true, "42,blocka,msg1\n")
 	})
 }
+
+func TestCSVOptionFilePattern(t *testing.T) {
+	tm := &TestModel{
+		Height:  42,
+		Block:   "blocka",
+		Message: "msg1",
+	}
+
+	baseName := t.Name()
+
+	runTest := func(t *testing.T, pattern string, expected string) {
+		dir, err := ioutil.TempDir("", baseName)
+		t.Logf("dir %s", dir)
+		require.NoError(t, err)
+
+		defer os.RemoveAll(dir) // nolint: errcheck
+
+		opts := DefaultCSVStorageOptions()
+
+		st, err := NewCSVStorage(dir, model.Version{Major: 1}, opts)
+		require.NoError(t, err)
+
+		err = st.PersistBatch(context.Background(), tm)
+		require.NoError(t, err)
+
+		_, err = os.Stat(filepath.Join(dir, expected))
+		require.NoError(t, err)
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		runTest(t, "{table}.csv", "test_models.csv")
+	})
+}

--- a/storage/csv_test.go
+++ b/storage/csv_test.go
@@ -580,9 +580,9 @@ func TestCSVOptionFilePattern(t *testing.T) {
 		st, err := NewCSVStorage(dir, model.Version{Major: 1}, opts)
 		require.NoError(t, err)
 
-		st = st.WithMetadata(md)
+		mst := st.WithMetadata(md)
 
-		err = st.PersistBatch(context.Background(), tm)
+		err = mst.PersistBatch(context.Background(), tm)
 		require.NoError(t, err)
 
 		_, err = os.Stat(filepath.Join(dir, expected))


### PR DESCRIPTION
Add ability to embed name of job in csv filenames. This allows us to run multiple jobs without their files being overwritten by one another. We can also start jobs with meaningful names like `walk-975000-978000` and have output files named in the same way.