### PR TITLE
polish: use lowercase for id option for consistency

### DIFF
--- a/commands/job.go
+++ b/commands/job.go
@@ -32,8 +32,8 @@ var JobStartCmd = &cli.Command{
 		clientAPIFlagSet,
 		[]cli.Flag{
 			&cli.IntFlag{
-				Name:        "ID",
-				Usage:       "ID of job to start",
+				Name:        "id",
+				Usage:       "Identifier of job to start",
 				Required:    true,
 				Destination: &jobControlFlags.ID,
 			},
@@ -58,8 +58,8 @@ var JobStopCmd = &cli.Command{
 		clientAPIFlagSet,
 		[]cli.Flag{
 			&cli.IntFlag{
-				Name:        "ID",
-				Usage:       "ID of job to stop",
+				Name:        "id",
+				Usage:       "Identifier of job to stop",
 				Required:    true,
 				Destination: &jobControlFlags.ID,
 			},


### PR DESCRIPTION
None of our other options use uppercase and the job listing output uses lowercase for the id field. 