### PR TITLE
fix: make from and to options required for walk command

### DIFF
--- a/commands/walk.go
+++ b/commands/walk.go
@@ -53,13 +53,13 @@ var WalkCmd = &cli.Command{
 			Name:        "from",
 			Usage:       "Limit actor and message processing to tipsets at or above `HEIGHT`",
 			Destination: &walkFlags.from,
+			Required:    true,
 		},
 		&cli.Int64Flag{
 			Name:        "to",
 			Usage:       "Limit actor and message processing to tipsets at or below `HEIGHT`",
-			Value:       estimateCurrentEpoch(),
-			DefaultText: "MaxInt64",
 			Destination: &walkFlags.to,
+			Required:    true,
 		},
 		&cli.StringFlag{
 			Name:        "storage",


### PR DESCRIPTION
Currently running `visor walk` starts a walk down the entire chain which is probably not what someone wants when trying out the command.