### PR TITLE
polish: include window and storage in job params output

### DIFF
--- a/chain/walker.go
+++ b/chain/walker.go
@@ -32,14 +32,6 @@ type Walker struct {
 	maxHeight int64 // limit persisting to tipsets equal to or below this height}
 }
 
-func (c *Walker) Params() map[string]interface{} {
-	out := make(map[string]interface{})
-	out["finality"] = c.finality
-	out["minHeight"] = c.minHeight
-	out["maxHeight"] = c.maxHeight
-	return out
-}
-
 // Run starts walking the chain history and continues until the context is done or
 // the start of the chain is reached.
 func (c *Walker) Run(ctx context.Context) error {

--- a/chain/watcher.go
+++ b/chain/watcher.go
@@ -33,12 +33,6 @@ type Watcher struct {
 	indexSlot  chan struct{} // filled with a token when a goroutine is indexing a tipset
 }
 
-func (c *Watcher) Params() map[string]interface{} {
-	out := make(map[string]interface{})
-	out["confidence"] = c.confidence
-	return out
-}
-
 // Run starts following the chain head and blocks until the context is done or
 // an error occurs.
 func (c *Watcher) Run(ctx context.Context) error {

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -86,7 +86,13 @@ func (m *LilyNodeAPI) LilyWatch(_ context.Context, cfg *LilyWatchConfig) (schedu
 	}
 
 	id := m.Scheduler.Submit(&schedule.JobConfig{
-		Name:                cfg.Name,
+		Name: cfg.Name,
+		Type: "watch",
+		Params: map[string]string{
+			"window":     fmt.Sprintf("%s", cfg.Window),
+			"confidence": fmt.Sprintf("%d", cfg.Confidence),
+			"storage":    cfg.Storage,
+		},
 		Tasks:               cfg.Tasks,
 		Job:                 chain.NewWatcher(indexer, obs, cfg.Confidence),
 		RestartOnFailure:    cfg.RestartOnFailure,
@@ -118,7 +124,14 @@ func (m *LilyNodeAPI) LilyWalk(_ context.Context, cfg *LilyWalkConfig) (schedule
 	}
 
 	id := m.Scheduler.Submit(&schedule.JobConfig{
-		Name:                cfg.Name,
+		Name: cfg.Name,
+		Type: "walk",
+		Params: map[string]string{
+			"window":    fmt.Sprintf("%s", cfg.Window),
+			"minHeight": fmt.Sprintf("%d", cfg.From),
+			"maxHeight": fmt.Sprintf("%d", cfg.To),
+			"storage":   cfg.Storage,
+		},
 		Tasks:               cfg.Tasks,
 		Job:                 chain.NewWalker(indexer, m, cfg.From, cfg.To),
 		RestartOnFailure:    cfg.RestartOnFailure,

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -89,7 +89,7 @@ func (m *LilyNodeAPI) LilyWatch(_ context.Context, cfg *LilyWatchConfig) (schedu
 		Name: cfg.Name,
 		Type: "watch",
 		Params: map[string]string{
-			"window":     fmt.Sprintf("%s", cfg.Window),
+			"window":     cfg.Window.String(),
 			"confidence": fmt.Sprintf("%d", cfg.Confidence),
 			"storage":    cfg.Storage,
 		},
@@ -127,7 +127,7 @@ func (m *LilyNodeAPI) LilyWalk(_ context.Context, cfg *LilyWalkConfig) (schedule
 		Name: cfg.Name,
 		Type: "walk",
 		Params: map[string]string{
-			"window":    fmt.Sprintf("%s", cfg.Window),
+			"window":    cfg.Window.String(),
 			"minHeight": fmt.Sprintf("%d", cfg.From),
 			"maxHeight": fmt.Sprintf("%d", cfg.To),
 			"storage":   cfg.Storage,


### PR DESCRIPTION
Also refactor how the params are surfaced to avoid hardcoding known jobs types in a type switch. Changed params map to have string values to make it simpler for clients to format result as a list or similar.