### PR TITLE
fix(reports): visor processing reports correspond to tipset passed to indexer

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -267,7 +267,7 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 					var changes map[string]types.Actor
 					// special case, we want to extract all actor states from the genesis block.
 					if parent.Height() == 0 {
-						changes, err = t.getGenesisActors(ctx)
+						changes, err = t.getGenesisActors(tctx)
 					} else {
 						changes, err = t.stateChangedActors(tctx, parent.ParentState(), child.ParentState())
 					}

--- a/chain/walker.go
+++ b/chain/walker.go
@@ -90,6 +90,10 @@ func (c *Walker) WalkChain(ctx context.Context, node lens.API, ts *types.TipSet)
 			return xerrors.Errorf("get tipset: %w", err)
 		}
 
+		if int64(ts.Height()) < c.minHeight {
+			break
+		}
+
 		log.Debugw("found tipset", "height", ts.Height())
 		if err := c.obs.TipSet(ctx, ts); err != nil {
 			return xerrors.Errorf("notify tipset: %w", err)

--- a/tasks/messageexecutions/message.go
+++ b/tasks/messageexecutions/message.go
@@ -35,8 +35,8 @@ func (p *Task) ProcessMessageExecutions(ctx context.Context, store adt.Store, ts
 	defer span.End()
 
 	report := &visormodel.ProcessingReport{
-		Height:    int64(pts.Height()),
-		StateRoot: pts.ParentState().String(),
+		Height:    int64(ts.Height()),
+		StateRoot: ts.ParentState().String(),
 	}
 
 	var (

--- a/tasks/messages/message.go
+++ b/tasks/messages/message.go
@@ -42,8 +42,8 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 	defer span.End()
 
 	report := &visormodel.ProcessingReport{
-		Height:    int64(pts.Height()),
-		StateRoot: pts.ParentState().String(),
+		Height:    int64(ts.Height()),
+		StateRoot: ts.ParentState().String(),
 	}
 
 	var (

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -64,8 +64,8 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 	}
 
 	report := &visormodel.ProcessingReport{
-		Height:    int64(pts.Height()),
-		StateRoot: pts.ParentState().String(),
+		Height:    int64(ts.Height()),
+		StateRoot: ts.ParentState().String(),
 	}
 
 	errorsDetected := make([]*MultisigError, 0, len(emsgs))


### PR DESCRIPTION
This change ensures visor processing report entries correspond to the tipset and state root passed to the indexer. Without this change there exists an annoying edge case in gap filling (#598): e.g. If we find a gap for message task at height 9 and instruct the indexer to index the tipset at height 9 the message processors will end up processing the tipset at height 8.