### PR TITLE
fix: consistent processing report heights

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -203,7 +203,6 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 	// If no parent tipset available then we need to wait for another tipset. It's likely we received the last or first tipset
 	// in a batch.
 	if parent != nil {
-
 		// Run each tipset processing task concurrently
 		for name, p := range t.processors {
 			inFlight++

--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -173,8 +173,6 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 	}
 	defer cancel()
 
-	ll := log.With("height", int64(ts.Height()))
-
 	start := time.Now()
 
 	inFlight := 0
@@ -183,189 +181,195 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 	// A map to gather the persistable outputs from each task
 	taskOutputs := make(map[string]model.PersistableList, len(t.processors)+len(t.actorProcessors))
 
-	// The parent is the primary tipset that tasks act upon. The child adds additional context such as outcomes of
-	// message execution.
-	var parent, child *types.TipSet
+	// current is the primary tipset that tasks act upon.
+	// next adds additional context such as outcomes of message execution.
+	var current, next *types.TipSet
 	if t.lastTipSet != nil {
 		if t.lastTipSet.Height() > ts.Height() {
 			// last tipset seen was the child
-			child = t.lastTipSet
-			parent = ts
+			next = t.lastTipSet
+			current = ts
 		} else if t.lastTipSet.Height() < ts.Height() {
 			// last tipset seen was the parent
-			child = ts
-			parent = t.lastTipSet
+			next = ts
+			current = t.lastTipSet
 		} else {
 			log.Errorw("out of order tipsets", "height", ts.Height(), "last_height", t.lastTipSet.Height())
 		}
 	}
 
-	// If no parent tipset available then we need to wait for another tipset. It's likely we received the last or first tipset
-	// in a batch.
-	if parent != nil {
-		// Run each tipset processing task concurrently
-		for name, p := range t.processors {
-			inFlight++
-			go t.runProcessor(tctx, p, name, parent, results)
+	// remember the last tipset we observed
+	t.lastTipSet = ts
+
+	// current is nil when we have only seen the first tipset in our sequence. we should wait for the next one.
+	if current == nil {
+		return nil
+	}
+
+	ll := log.With("current", int64(current.Height()), "next", int64(next.Height()))
+
+	// Run each tipset processing task concurrently
+	for name, p := range t.processors {
+		inFlight++
+		go t.runProcessor(tctx, p, name, current, results)
+	}
+
+	if t.node == nil {
+		node, closer, err := t.opener.Open(ctx)
+		if err != nil {
+			return xerrors.Errorf("unable to open lens: %w", err)
 		}
+		t.node = node
+		t.closer = closer
+	}
 
-		if t.node == nil {
-			node, closer, err := t.opener.Open(ctx)
-			if err != nil {
-				return xerrors.Errorf("unable to open lens: %w", err)
+	if types.CidArrsEqual(next.Parents().Cids(), current.Cids()) {
+		if len(t.consensusProcessor) > 0 {
+			for name, p := range t.consensusProcessor {
+				inFlight++
+				go t.runConsensusProcessor(ctx, p, name, next, current, results)
 			}
-			t.node = node
-			t.closer = closer
 		}
+		// If we have message or actor processors then extract the messages and receipts
+		if len(t.messageProcessors) > 0 || len(t.actorProcessors) > 0 {
+			execMessagesStart := time.Now()
+			tsMsgs, err := t.node.GetExecutedAndBlockMessagesForTipset(ctx, next, current)
+			if err == nil {
+				ll.Debugw("found executed messages", "count", len(tsMsgs.Executed), "time", time.Since(execMessagesStart))
 
-		if types.CidArrsEqual(child.Parents().Cids(), parent.Cids()) {
-			if len(t.consensusProcessor) > 0 {
-				for name, p := range t.consensusProcessor {
-					inFlight++
-					go t.runConsensusProcessor(ctx, p, name, child, parent, results)
-				}
-			}
-			// If we have message or actor processors then extract the messages and receipts
-			if len(t.messageProcessors) > 0 || len(t.actorProcessors) > 0 {
-				execMessagesStart := time.Now()
-				tsMsgs, err := t.node.GetExecutedAndBlockMessagesForTipset(ctx, child, parent)
-				if err == nil {
-					ll.Debugw("found executed messages", "count", len(tsMsgs.Executed), "time", time.Since(execMessagesStart))
-
-					if len(t.messageProcessors) > 0 {
-						// Start all the message processors
-						for name, p := range t.messageProcessors {
-							inFlight++
-							go t.runMessageProcessor(tctx, p, name, child, parent, tsMsgs.Executed, tsMsgs.Block, results)
-						}
-					}
-
-					// If we have actor processors then find actors that have changed state
-					if len(t.actorProcessors) > 0 {
-						changesStart := time.Now()
-						var err error
-						var changes map[string]types.Actor
-						// special case, we want to extract all actor states from the genesis block.
-						if parent.Height() == 0 {
-							changes, err = t.getGenesisActors(ctx)
-						} else {
-							changes, err = t.stateChangedActors(tctx, parent.ParentState(), child.ParentState())
-						}
-						if err == nil {
-							ll.Debugw("found actor state changes", "count", len(changes), "time", time.Since(changesStart))
-							if t.addressFilter != nil {
-								for addr := range changes {
-									if !t.addressFilter.Allow(addr) {
-										delete(changes, addr)
-									}
-								}
-							}
-							for name, p := range t.actorProcessors {
-								inFlight++
-								go t.runActorProcessor(tctx, p, name, child, parent, changes, tsMsgs.Executed, results)
-							}
-						} else {
-							ll.Errorw("failed to extract actor changes", "error", err)
-							terr := xerrors.Errorf("failed to extract actor changes: %w", err)
-							// We need to report that all actor tasks failed
-							for name := range t.actorProcessors {
-								report := &visormodel.ProcessingReport{
-									Height:         int64(parent.Height()),
-									StateRoot:      parent.ParentState().String(),
-									Reporter:       t.name,
-									Task:           name,
-									StartedAt:      start,
-									CompletedAt:    time.Now(),
-									Status:         visormodel.ProcessingStatusError,
-									ErrorsDetected: terr,
-								}
-								taskOutputs[name] = model.PersistableList{report}
-							}
-						}
-					}
-
-				} else {
-					ll.Errorw("failed to extract messages", "error", err)
-					terr := xerrors.Errorf("failed to extract messages: %w", err)
-					// We need to report that all message tasks failed
-					for name := range t.messageProcessors {
-						report := &visormodel.ProcessingReport{
-							Height:         int64(parent.Height()),
-							StateRoot:      parent.ParentState().String(),
-							Reporter:       t.name,
-							Task:           name,
-							StartedAt:      start,
-							CompletedAt:    time.Now(),
-							Status:         visormodel.ProcessingStatusError,
-							ErrorsDetected: terr,
-						}
-						taskOutputs[name] = model.PersistableList{report}
-					}
-					// We also need to report that all actor tasks failed
-					for name := range t.actorProcessors {
-						report := &visormodel.ProcessingReport{
-							Height:         int64(parent.Height()),
-							StateRoot:      parent.ParentState().String(),
-							Reporter:       t.name,
-							Task:           name,
-							StartedAt:      start,
-							CompletedAt:    time.Now(),
-							Status:         visormodel.ProcessingStatusError,
-							ErrorsDetected: terr,
-						}
-						taskOutputs[name] = model.PersistableList{report}
-					}
-
-				}
-			}
-
-			// If we have messages execution processors then extract internal messages
-			if len(t.messageExecutionProcessors) > 0 {
-				execMessagesStart := time.Now()
-				iMsgs, err := t.node.GetMessageExecutionsForTipSet(ctx, child, parent)
-				if err == nil {
-					ll.Debugw("found message execution results", "count", len(iMsgs), "time", time.Since(execMessagesStart))
+				if len(t.messageProcessors) > 0 {
 					// Start all the message processors
-					for name, p := range t.messageExecutionProcessors {
+					for name, p := range t.messageProcessors {
 						inFlight++
-						go t.runMessageExecutionProcessor(tctx, p, name, child, parent, iMsgs, results)
-					}
-				} else {
-					ll.Errorw("failed to extract messages", "error", err)
-					terr := xerrors.Errorf("failed to extract messages: %w", err)
-					// We need to report that all message tasks failed
-					for name := range t.messageExecutionProcessors {
-						report := &visormodel.ProcessingReport{
-							Height:         int64(parent.Height()),
-							StateRoot:      parent.ParentState().String(),
-							Reporter:       t.name,
-							Task:           name,
-							StartedAt:      start,
-							CompletedAt:    time.Now(),
-							Status:         visormodel.ProcessingStatusError,
-							ErrorsDetected: terr,
-						}
-						taskOutputs[name] = model.PersistableList{report}
+						go t.runMessageProcessor(tctx, p, name, next, current, tsMsgs.Executed, tsMsgs.Block, results)
 					}
 				}
-			}
 
-		} else {
-			// TODO: we could fetch the parent stateroot and proceed to index this tipset. However this will be
-			// slower and increases the likelihood that we exceed the processing window and cause the next
-			// tipset to be skipped completely.
-			log.Errorw("mismatching child and parent tipsets", "height", ts.Height(), "child", child.Key(), "parent", parent.Key())
+				// If we have actor processors then find actors that have changed state
+				if len(t.actorProcessors) > 0 {
+					changesStart := time.Now()
+					var err error
+					var changes map[string]types.Actor
+					// special case, we want to extract all actor states from the genesis block.
+					if current.Height() == 0 {
+						changes, err = t.getGenesisActors(ctx)
+					} else {
+						changes, err = t.stateChangedActors(tctx, current.ParentState(), next.ParentState())
+					}
+					if err == nil {
+						ll.Debugw("found actor state changes", "count", len(changes), "time", time.Since(changesStart))
+						if t.addressFilter != nil {
+							for addr := range changes {
+								if !t.addressFilter.Allow(addr) {
+									delete(changes, addr)
+								}
+							}
+						}
+						for name, p := range t.actorProcessors {
+							inFlight++
+							go t.runActorProcessor(tctx, p, name, next, current, changes, tsMsgs.Executed, results)
+						}
+					} else {
+						ll.Errorw("failed to extract actor changes", "error", err)
+						terr := xerrors.Errorf("failed to extract actor changes: %w", err)
+						// We need to report that all actor tasks failed
+						for name := range t.actorProcessors {
+							report := &visormodel.ProcessingReport{
+								Height:         int64(current.Height()),
+								StateRoot:      current.ParentState().String(),
+								Reporter:       t.name,
+								Task:           name,
+								StartedAt:      start,
+								CompletedAt:    time.Now(),
+								Status:         visormodel.ProcessingStatusError,
+								ErrorsDetected: terr,
+							}
+							taskOutputs[name] = model.PersistableList{report}
+						}
+					}
+				}
 
-			// We need to report that all message and actor tasks were skipped
-			reason := "tipset did not have expected parent or child"
-			for name := range t.messageProcessors {
-				taskOutputs[name] = model.PersistableList{t.buildSkippedTipsetReport(ts, name, start, reason)}
-				ll.Infow("task skipped", "task", name, "reason", reason)
+			} else {
+				ll.Errorw("failed to extract messages", "error", err)
+				terr := xerrors.Errorf("failed to extract messages: %w", err)
+				// We need to report that all message tasks failed
+				for name := range t.messageProcessors {
+					report := &visormodel.ProcessingReport{
+						Height:         int64(current.Height()),
+						StateRoot:      current.ParentState().String(),
+						Reporter:       t.name,
+						Task:           name,
+						StartedAt:      start,
+						CompletedAt:    time.Now(),
+						Status:         visormodel.ProcessingStatusError,
+						ErrorsDetected: terr,
+					}
+					taskOutputs[name] = model.PersistableList{report}
+				}
+				// We also need to report that all actor tasks failed
+				for name := range t.actorProcessors {
+					report := &visormodel.ProcessingReport{
+						Height:         int64(current.Height()),
+						StateRoot:      current.ParentState().String(),
+						Reporter:       t.name,
+						Task:           name,
+						StartedAt:      start,
+						CompletedAt:    time.Now(),
+						Status:         visormodel.ProcessingStatusError,
+						ErrorsDetected: terr,
+					}
+					taskOutputs[name] = model.PersistableList{report}
+				}
+
 			}
-			for name := range t.actorProcessors {
-				taskOutputs[name] = model.PersistableList{t.buildSkippedTipsetReport(ts, name, start, reason)}
-				ll.Infow("task skipped", "task", name, "reason", reason)
+		}
+
+		// If we have messages execution processors then extract internal messages
+		if len(t.messageExecutionProcessors) > 0 {
+			execMessagesStart := time.Now()
+			iMsgs, err := t.node.GetMessageExecutionsForTipSet(ctx, next, current)
+			if err == nil {
+				ll.Debugw("found message execution results", "count", len(iMsgs), "time", time.Since(execMessagesStart))
+				// Start all the message processors
+				for name, p := range t.messageExecutionProcessors {
+					inFlight++
+					go t.runMessageExecutionProcessor(tctx, p, name, next, current, iMsgs, results)
+				}
+			} else {
+				ll.Errorw("failed to extract messages", "error", err)
+				terr := xerrors.Errorf("failed to extract messages: %w", err)
+				// We need to report that all message tasks failed
+				for name := range t.messageExecutionProcessors {
+					report := &visormodel.ProcessingReport{
+						Height:         int64(current.Height()),
+						StateRoot:      current.ParentState().String(),
+						Reporter:       t.name,
+						Task:           name,
+						StartedAt:      start,
+						CompletedAt:    time.Now(),
+						Status:         visormodel.ProcessingStatusError,
+						ErrorsDetected: terr,
+					}
+					taskOutputs[name] = model.PersistableList{report}
+				}
 			}
+		}
+
+	} else {
+		// TODO: we could fetch the parent stateroot and proceed to index this tipset. However this will be
+		// slower and increases the likelihood that we exceed the processing window and cause the next
+		// tipset to be skipped completely.
+		ll.Errorw("mismatching current and next tipsets", "current_tipset", current.Key(), "next_tipset", next.Key())
+
+		// We need to report that all message and actor tasks were skipped
+		reason := "tipset did not have expected parent or child"
+		for name := range t.messageProcessors {
+			taskOutputs[name] = model.PersistableList{t.buildSkippedTipsetReport(ts, name, start, reason)}
+			ll.Infow("task skipped", "task", name, "reason", reason)
+		}
+		for name := range t.actorProcessors {
+			taskOutputs[name] = model.PersistableList{t.buildSkippedTipsetReport(ts, name, start, reason)}
+			ll.Infow("task skipped", "task", name, "reason", reason)
 		}
 	}
 
@@ -412,24 +416,21 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 				res.Report[idx].Status = visormodel.ProcessingStatusOK
 			}
 
-			llt.Infow("task report", "report_height", res.Report[idx].Height, "status", res.Report[idx].Status, "time", res.Report[idx].CompletedAt.Sub(res.Report[idx].StartedAt))
+			llt.Debugw("task report", "status", res.Report[idx].Status, "time", res.Report[idx].CompletedAt.Sub(res.Report[idx].StartedAt))
 		}
 
 		// Persist the processing report and the data in a single transaction
 		taskOutputs[res.Task] = model.PersistableList{res.Report, res.Data}
 	}
-
-	// remember the last tipset we observed
-	t.lastTipSet = ts
+	ll.Debugw("data extracted", "time", time.Since(start))
 
 	if len(taskOutputs) == 0 {
 		// Nothing to persist
-		ll.Debugw("tipset complete, nothing to persist", "total_time", time.Since(start))
+		ll.Infow("tipset complete, nothing to persist", "total_time", time.Since(start))
 		return nil
 	}
 
 	// wait until there is an empty slot before persisting
-	ll.Debugw("waiting to persist data", "time", time.Since(start))
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -464,7 +465,7 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 			}(task, p)
 		}
 		wg.Wait()
-		ll.Debugw("tipset complete", "total_time", time.Since(start))
+		ll.Infow("tipset complete", "total_time", time.Since(start))
 	}()
 
 	return nil

--- a/chain/walker.go
+++ b/chain/walker.go
@@ -54,6 +54,7 @@ func (c *Walker) Run(ctx context.Context) error {
 		return xerrors.Errorf("cannot walk history, chain head (%d) is earlier than minimum height (%d)", int64(ts.Height()), c.minHeight)
 	}
 
+	// TODO: use ChainGetTipSetAfterHeight to handle null rounds properly (deferring until we have removed/simplified lenses)
 	// Start at maxHeight+1 so that the tipset at maxHeight becomes the parent for any tasks that need to make a diff between two tipsets.
 	// A walk where min==max must still process two tipsets to be sure of extracting data.
 	if int64(ts.Height()) > c.maxHeight+1 {

--- a/chain/watcher_test.go
+++ b/chain/watcher_test.go
@@ -91,6 +91,7 @@ func TestWatcher(t *testing.T) {
 		require.NoError(t, err, "index")
 	}
 
+	bm.MineUntilBlock(ctx, full, nil)
 	child := <-newHeads
 	for _, hc := range child {
 		he := &HeadEvent{Type: hc.Type, TipSet: hc.Val}

--- a/chain/watcher_test.go
+++ b/chain/watcher_test.go
@@ -75,17 +75,24 @@ func TestWatcher(t *testing.T) {
 	require.NoError(t, err, "chain notify")
 
 	t.Logf("indexing chain")
-	nh := <-newHeads
+	parent := <-newHeads
 
 	var bhs blockHeaderList
-	for _, head := range nh {
+	for _, head := range parent {
 		bhs = append(bhs, head.Val.Blocks()...)
 	}
 
 	cids := bhs.Cids()
 	rounds := bhs.Rounds()
 
-	for _, hc := range nh {
+	for _, hc := range parent {
+		he := &HeadEvent{Type: hc.Type, TipSet: hc.Val}
+		err = idx.index(ctx, he)
+		require.NoError(t, err, "index")
+	}
+
+	child := <-newHeads
+	for _, hc := range child {
 		he := &HeadEvent{Type: hc.Type, TipSet: hc.Val}
 		err = idx.index(ctx, he)
 		require.NoError(t, err, "index")

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -456,7 +456,6 @@ func MethodAndParamsForMessage(m *types.Message, destCode cid.Cid) (string, stri
 	encoded := string(bytes.ReplaceAll(bytes.ToValidUTF8(buf.Bytes(), []byte{}), []byte{0x00}, []byte{}))
 
 	return method, encoded, nil
-
 }
 
 func ActorNameAndFamilyFromCode(c cid.Cid) (name string, family string, err error) {
@@ -519,5 +518,4 @@ func MakeGetActorCodeFunc(ctx context.Context, store adt.Store, ts, pts *types.T
 
 		return cid.Undef, false
 	}, nil
-
 }

--- a/tasks/actorstate/task.go
+++ b/tasks/actorstate/task.go
@@ -61,8 +61,8 @@ func (t *Task) ProcessActors(ctx context.Context, ts *types.TipSet, pts *types.T
 	log.Debugw("processing actor state changes", "height", ts.Height(), "parent_height", pts.Height())
 
 	report := &visormodel.ProcessingReport{
-		Height:    int64(ts.Height()),
-		StateRoot: ts.ParentState().String(),
+		Height:    int64(pts.Height()),
+		StateRoot: pts.ParentState().String(),
 		Status:    visormodel.ProcessingStatusOK,
 	}
 

--- a/tasks/consensus/task.go
+++ b/tasks/consensus/task.go
@@ -11,8 +11,7 @@ import (
 	"go.opentelemetry.io/otel/label"
 )
 
-type Task struct {
-}
+type Task struct{}
 
 func NewTask() *Task {
 	return &Task{}
@@ -26,20 +25,20 @@ func (t *Task) ProcessTipSets(ctx context.Context, child, parent *types.TipSet) 
 	}
 	defer span.End()
 
-	var pl = make(chain.ChainConsensusList, child.Height()-parent.Height())
-	var rp = make(visormodel.ProcessingReportList, child.Height()-parent.Height())
+	pl := make(chain.ChainConsensusList, child.Height()-parent.Height())
+	rp := make(visormodel.ProcessingReportList, child.Height()-parent.Height())
 	idx := 0
-	for epoch := child.Height(); epoch > parent.Height(); epoch-- {
-		if child.Height() == epoch {
+	for epoch := parent.Height(); epoch < child.Height(); epoch++ {
+		if parent.Height() == epoch {
 			pl[idx] = &chain.ChainConsensus{
 				Height:          int64(epoch),
-				ParentStateRoot: child.ParentState().String(),
-				ParentTipSet:    child.Parents().String(),
-				TipSet:          child.Key().String(),
+				ParentStateRoot: parent.ParentState().String(),
+				ParentTipSet:    parent.Parents().String(),
+				TipSet:          parent.Key().String(),
 			}
 			rp[idx] = &visormodel.ProcessingReport{
 				Height:    int64(epoch),
-				StateRoot: child.ParentState().String(),
+				StateRoot: parent.ParentState().String(),
 			}
 		} else {
 			// null round no tipset


### PR DESCRIPTION
Four changes:

 1. actor tasks use parent height for processing report
 2. reverse direction of consensus task processing so that processing report includes one for parent height
 3. move single tipset processors into the indexer's parent/child loop and ensure they use the parent tipset only
 4. start a walk at the tipset after upper bound height specified by `--to` so that the upper bound has a child tipset for context

Fixes https://github.com/filecoin-project/sentinel-visor/issues/652